### PR TITLE
heretic: fix automap panning left

### DIFF
--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -634,7 +634,7 @@ boolean AM_Responder(event_t * ev)
             if (!followplayer)
                 m_paninc.x = 0;
         }
-        else if (key == key_map_east)
+        else if (key == key_map_west)
         {
             if (!followplayer)
                 m_paninc.x = 0;


### PR DESCRIPTION
When follow mode is off, hitting left would cause it to scroll all the way to the west of the map without stopping.
