### PR TITLE
More robust checks for BFG Edition.

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -576,7 +576,8 @@ void D_DoAdvanceDemo (void)
 
     // The Doom 3: BFG Edition version of doom2.wad does not have a
     // TITLETPIC lump. Use INTERPIC instead as a workaround.
-    if (!strcasecmp(pagename, "TITLEPIC") && W_CheckNumForName("titlepic") < 0)
+    if (bfgedition && !strcasecmp(pagename, "TITLEPIC")
+        && W_CheckNumForName("titlepic") < 0)
     {
         pagename = DEH_String("INTERPIC");
     }


### PR DESCRIPTION
1) Move the check for (bfgedition) right behind loading the IWAD, i.e.
   before any PWADs are loaded that could probably provide a DMENUPIC lump.
2) Instead of checking for a missing TITLEPIC lump (which is only true
   for the doom2.wad shipped with the BFG Edition) check for the presence
   of DMENUPIC (which is exclusive to both classic IWADs shipped with the
   BFG Edition). The M_GDHIGH lumps, however, are incompatibly modified
   in _both_ IWADs.
3) Move the check for the missing TITLEPIC lump to the place where it
   becomes actually crucial, i.e. D_DoAdvanceDemo() and make it independent
   of the (bfgedition) check. So, PWADs still have a chance to provide their
   own TITLEPIC lump.
