### PR TITLE
Fix zenity messages not being correctly formatted

### DIFF
--- a/src/i_system.c
+++ b/src/i_system.c
@@ -452,7 +452,14 @@ void I_Error (char *error, ...)
 #else
     if (exit_gui_popup && !I_ConsoleStdout())
     {
-        ZenityErrorBox(error);
+        char msgbuf[512];
+
+        va_start(argptr, error);
+        memset(msgbuf, 0, sizeof(msgbuf));
+        M_vsnprintf(msgbuf, sizeof(msgbuf), error, argptr);
+        va_end(argptr);
+
+        ZenityErrorBox(msgbuf);
     }
 #endif
 


### PR DESCRIPTION
This fixes messages like "IWAD file '%s' not found!"
to being shown to users.
We were not handling variable arguments of the I_Error function.
