### PR TITLE
setup: fix usejoystick/use_joystick typo in the previous commit

### DIFF
--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -505,7 +505,7 @@ static int CalibrationEventCallback(SDL_Event *event, void *user_data)
             // Finished?
             if (calibrate_stage == CALIBRATE_CENTER)
             {
-                use_joystick = 1;
+                usejoystick = 1;
                 TXT_CloseWindow(calibration_window);
             }
 


### PR DESCRIPTION
The previous commit used an undefined use_joystick variable which made the build of chocolate-setup fail. This appears, to me, have been a simple typo and should fix #392 

(Without a joystick, I can't actually verify the correctness myself.)
