### PR TITLE
allow -geometry to specify fullscreen or windowed modes, like PrBoom

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1714,7 +1714,7 @@ void I_GraphicsCheckCommandLine(void)
             {
                 fullscreen = true;
             }
-            else if (f == 'w')
+            else if (s == 3 && f == 'w')
             {
                 fullscreen = false;
             }


### PR DESCRIPTION
This allows strings like "640x480w" to cause the engine to run in a
window, while strings like "1280x800f" cause the engine to run in
fullscreen mode.  This is inspired by the behavior of the PrBoom
-geometry parameter.
