### PR TITLE
Add Steam IWAD path for Strife: Veteran Edition

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -183,6 +183,10 @@ static char *steam_install_subdirs[] =
     // From Doom 3: BFG Edition:
 
     "steamapps\\common\\DOOM 3 BFG Edition\\base\\wads",
+
+    // From Strife: Veteran Edition:
+
+    "steamapps\\common\\Strife",
 };
 
 #define STEAM_BFG_GUS_PATCHES \


### PR DESCRIPTION
The release of Strife on Steam now adds a new official location to find it on Windows.
