### PR TITLE
strife: Fix the name of MAP29, should be "Entity's Lair"

### DIFF
--- a/src/strife/d_englsh.h
+++ b/src/strife/d_englsh.h
@@ -173,7 +173,7 @@
 #define HUSTR_26        "AREA 26: proving grounds"
 #define HUSTR_27        "AREA 27: The Lab"
 #define HUSTR_28        "AREA 28: Alien Ship"
-#define HUSTR_29        "AREA 29: Entity"
+#define HUSTR_29        "AREA 29: Entity's Lair"
 
 #define HUSTR_30        "AREA 30: Abandoned Front Base"
 #define HUSTR_31        "AREA 31: Training Facility"


### PR DESCRIPTION
Double-checked with strife1.exe
