### PR TITLE
setup: add support for the Xbox One controller on Linux

### DIFF
--- a/man/docgen
+++ b/man/docgen
@@ -425,6 +425,8 @@ def manpage_output(targets, template_file):
     for t in targets:
         content += t.manpage_output() + "\n"
 
+    content = content.replace("-", "\\-")
+
     print_template(template_file, content)
 
 def wiki_output(targets, template):


### PR DESCRIPTION
Effectively it's a slightly re-arranged Xbox 360 controller, no major
changes, so we can just use the same config as that one.