### PR TITLE
setup: add support for the Xbox One controller on Linux

### DIFF
--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -331,6 +331,13 @@ static const known_joystick_t known_joysticks[] =
         xbox360_controller_linux,
     },
 
+    // Xbox One controller as it appears on Linux.
+    {
+        "Microsoft X-Box One pad",
+        6, 11, 1,
+        xbox360_controller_linux,
+    },
+
     {
         "Logitech Dual Action",
         4, 12, 1,


### PR DESCRIPTION
Effectively it's a slightly re-arranged Xbox 360 controller, no major
changes, so we can just use the same config as that one.

(This is actually a duplicate of #499 but I accidentally overwrote the commit with a newer push. Now it's on a separate branch.)