### PR TITLE
Clear mouse event(s) created by SDL_WarpMouse.

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -935,7 +935,15 @@ static void UpdateGrab(void)
         // example.
 
         SDL_WarpMouse(screen->w - 16, screen->h - 16);
+
+        // Clear any relative movement caused by warping
+
+        SDL_PumpEvents();
+    #if SDL_VERSION_ATLEAST(1, 3, 0)
+        SDL_GetRelativeMouseState(0, NULL, NULL);
+    #else
         SDL_GetRelativeMouseState(NULL, NULL);
+    #endif
     }
 
     currently_grabbed = grab;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -829,11 +829,7 @@ static void CenterMouse(void)
     // Clear any relative movement caused by warping
 
     SDL_PumpEvents();
-#if SDL_VERSION_ATLEAST(1, 3, 0)
-    SDL_GetRelativeMouseState(0, NULL, NULL);
-#else
     SDL_GetRelativeMouseState(NULL, NULL);
-#endif
 }
 
 //
@@ -847,11 +843,7 @@ static void I_ReadMouse(void)
     int x, y;
     event_t ev;
 
-#if SDL_VERSION_ATLEAST(1, 3, 0)
-    SDL_GetRelativeMouseState(0, &x, &y);
-#else
     SDL_GetRelativeMouseState(&x, &y);
-#endif
 
     if (x != 0 || y != 0) 
     {
@@ -939,11 +931,7 @@ static void UpdateGrab(void)
         // Clear any relative movement caused by warping
 
         SDL_PumpEvents();
-    #if SDL_VERSION_ATLEAST(1, 3, 0)
-        SDL_GetRelativeMouseState(0, NULL, NULL);
-    #else
         SDL_GetRelativeMouseState(NULL, NULL);
-    #endif
     }
 
     currently_grabbed = grab;


### PR DESCRIPTION
Fixes #471 
SDL_WarpMouse was creating mouse events that were later interpreted as user mouse input. Use code from CenterMouse to avoid this.