### PR TITLE
doom: the sky changes in final2 map11->12 and map20->21 transitions.

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -612,6 +612,30 @@ void G_DoLoadLevel (void)
 
     skyflatnum = R_FlatNumForName(DEH_String(SKYFLATNAME));
 
+    // The "Sky never changes in Doom II" bug was fixed in
+    // the id Anthology version of doom2.exe for Final Doom.
+    if ((gamemode == commercial) && (gameversion == exe_final2))
+    {
+        char *skytexturename;
+
+        if (gamemap < 12)
+        {
+            skytexturename = "SKY1";
+        }
+        else if (gamemap < 21)
+        {
+            skytexturename = "SKY2";
+        }
+        else
+        {
+            skytexturename = "SKY3";
+        }
+
+        skytexturename = DEH_String(skytexturename);
+
+        skytexture = R_TextureNumForName(skytexturename);
+    }
+
     levelstarttic = gametic;        // for time calculation
     
     if (wipegamestate == GS_LEVEL) 


### PR DESCRIPTION
The id Anthology version of doom2.exe with Final Doom fixed the "Sky
never changes in Doom II" bug. The original Doom source release
included the repaired code, but it was re-bugged in an early Chocolate
Doom version to emulate the behavior of the better-known versions of
vanilla.

Thanks to @fabiangreffrath for demonstrating how he (more-generically)
fixed the bug in Crispy Doom.

Closes #533