### PR TITLE
Change opl sample rate to OPL2/3 sample rate

### DIFF
--- a/opl/opl.c
+++ b/opl/opl.c
@@ -56,7 +56,7 @@ static opl_driver_t *drivers[] =
 static opl_driver_t *driver = NULL;
 static int init_stage_reg_writes = 1;
 
-unsigned int opl_sample_rate = 22050;
+unsigned int opl_sample_rate = 49716;
 
 //
 // Init/shutdown code.


### PR DESCRIPTION
Set the OPL sample rate to 49716, rounded up from the formula
(14318180/288) = 49715.90277 Hz, to match the rate output from 
the OPL2/3 chip before being passed to the YM3014B DAC.

Tested and confirmed to work on my Raspberry Pi 2.