### PR TITLE
chocolate-hexen: Fix int/pointer union

### DIFF
--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -169,7 +169,7 @@ struct player_s;
 
 typedef union
 {
-    int i;
+    intptr_t i;
     struct mobj_s *m;
     struct player_s *p;
 } specialval_t;


### PR DESCRIPTION
Hexen uses a union of an int and a pointer in specialval_t. There are many places in Hexen where the int is set to 0, and it is assumed that the pointer is then NULL. If the int is smaller than the pointer (e.g. on 64-bit systems, where the int is 32 bits and the pointer is 64), then this can leave a non-NULL pointer to nowhere. This patch ensures that the int and pointer are the same size. This fixes a bug where killing an enemy with the Wraithverge causes a segfault.