### PR TITLE
Swap OPL3 stereo mix on SDL output

### DIFF
--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -173,8 +173,8 @@ static void FillBuffer(int16_t *buffer, unsigned int nsamples)
 
         for (i=0; i<nsamples; ++i)
         {
-            buffer[i * 2] = (int16_t) mix_buffer[i * 2];
-            buffer[i * 2 + 1] = (int16_t) mix_buffer[i * 2 + 1];
+            buffer[i * 2 + 1] = (int16_t) mix_buffer[i * 2];
+            buffer[i * 2] = (int16_t) mix_buffer[i * 2 + 1];
         }
     }
     else


### PR DESCRIPTION
The OPL3 output to SDL was reversed; All left pans were to the right, and vice versa. 
This is the equivalent of physically reversing the audio patch cables in a mixer.

I have not checked to see if the root cause of this is deeper in the OPL3 code, but at least on the emulated OPL3 core through SDL this now plays correctly. D_E1M1 and D_EVIL now play with correct stereo panning and position.