### PR TITLE
Added -pistolstart parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,1 @@
-Simon Howard <fraggle@gmail.com>
-James Haley <haleyjd@hotmail.com>
-Samuel Villarreal <svkaiser@gmail.com>
+Linguica <linguica@doomworld.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,3 @@
-Linguica <linguica@doomworld.com>
+Simon Howard <fraggle@gmail.com>
+James Haley <haleyjd@hotmail.com>
+Samuel Villarreal <svkaiser@gmail.com>

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -103,6 +103,10 @@ fixed_t         offsetms;
 
 static boolean  new_sync = true;
 
+// Enforce pistol start if -pistolstart is set
+
+extern int	pistolstart;
+
 // Callback functions for loop code.
 
 static loop_interface_t *loop_interface = NULL;
@@ -432,6 +436,7 @@ void D_StartNetGame(net_gamesettings_t *settings,
 
     ticdup = settings->ticdup;
     new_sync = settings->new_sync;
+	pistolstart = settings->pistolstart;
 
     // TODO: Message disabled until we fix new_sync.
     //if (!new_sync)

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -436,7 +436,7 @@ void D_StartNetGame(net_gamesettings_t *settings,
 
     ticdup = settings->ticdup;
     new_sync = settings->new_sync;
-	pistolstart = settings->pistolstart;
+    pistolstart = settings->pistolstart;
 
     // TODO: Message disabled until we fix new_sync.
     //if (!new_sync)

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -105,7 +105,7 @@ static boolean  new_sync = true;
 
 // Enforce pistol start if -pistolstart is set
 
-extern int	pistolstart;
+extern boolean  pistolstart;
 
 // Callback functions for loop code.
 

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -100,7 +100,7 @@ boolean         nomonsters;	// checkparm of -nomonsters
 boolean         respawnparm;	// checkparm of -respawn
 boolean         fastparm;	// checkparm of -fast
 
-boolean			pistolstart; // checkparm of -pistolstart
+boolean         pistolstart; // checkparm of -pistolstart
 
 //extern int soundVolume;
 //extern  int	sfxVolume;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -99,7 +99,6 @@ boolean		devparm;	// started game with -devparm
 boolean         nomonsters;	// checkparm of -nomonsters
 boolean         respawnparm;	// checkparm of -respawn
 boolean         fastparm;	// checkparm of -fast
-
 boolean         pistolstart; // checkparm of -pistolstart
 
 //extern int soundVolume;
@@ -1386,10 +1385,10 @@ void D_DoomMain (void)
 	sidemove[1] = sidemove[1]*scale/100;
     }
     
-	if (M_CheckParm("-pistolstart"))
-	{
-		pistolstart = true;
-	}
+    if (M_CheckParm("-pistolstart"))
+    {
+        pistolstart = true;
+    }
 
     // init subsystems
     DEH_printf("V_Init: allocate screens.\n");

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1385,6 +1385,12 @@ void D_DoomMain (void)
 	sidemove[1] = sidemove[1]*scale/100;
     }
     
+    //!
+    // Players will start every new level from scratch, with none of their 
+    // accumulated weapons and ammo carrying over. Disabled during demo
+    // recording and playback.
+    //
+
     if (M_CheckParm("-pistolstart"))
     {
         pistolstart = true;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -100,6 +100,8 @@ boolean         nomonsters;	// checkparm of -nomonsters
 boolean         respawnparm;	// checkparm of -respawn
 boolean         fastparm;	// checkparm of -fast
 
+boolean			pistolstart; // checkparm of -pistolstart
+
 //extern int soundVolume;
 //extern  int	sfxVolume;
 //extern  int	musicVolume;
@@ -1384,6 +1386,11 @@ void D_DoomMain (void)
 	sidemove[1] = sidemove[1]*scale/100;
     }
     
+	if (M_CheckParm("-pistolstart"))
+	{
+		pistolstart = true;
+	}
+
     // init subsystems
     DEH_printf("V_Init: allocate screens.\n");
     V_Init ();

--- a/src/doom/d_net.c
+++ b/src/doom/d_net.c
@@ -121,6 +121,8 @@ static void LoadGameSettings(net_gamesettings_t *settings)
     timelimit = settings->timelimit;
     consoleplayer = settings->consoleplayer;
 
+	pistolstart = settings->pistolstart;
+
     if (lowres_turn)
     {
         printf("NOTE: Turning resolution is reduced; this is probably "
@@ -151,6 +153,8 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->fast_monsters = fastparm;
     settings->respawn_monsters = respawnparm;
     settings->timelimit = timelimit;
+
+	settings->pistolstart = pistolstart;
 
     settings->lowres_turn = M_CheckParm("-record") > 0
                          && M_CheckParm("-longtics") == 0;

--- a/src/doom/d_net.c
+++ b/src/doom/d_net.c
@@ -120,8 +120,7 @@ static void LoadGameSettings(net_gamesettings_t *settings)
     respawnparm = settings->respawn_monsters;
     timelimit = settings->timelimit;
     consoleplayer = settings->consoleplayer;
-
-	pistolstart = settings->pistolstart;
+    pistolstart = settings->pistolstart;
 
     if (lowres_turn)
     {
@@ -153,8 +152,7 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->fast_monsters = fastparm;
     settings->respawn_monsters = respawnparm;
     settings->timelimit = timelimit;
-
-	settings->pistolstart = pistolstart;
+    settings->pistolstart = pistolstart;
 
     settings->lowres_turn = M_CheckParm("-record") > 0
                          && M_CheckParm("-longtics") == 0;

--- a/src/doom/doomstat.h
+++ b/src/doom/doomstat.h
@@ -47,6 +47,8 @@ extern  boolean	nomonsters;	// checkparm of -nomonsters
 extern  boolean	respawnparm;	// checkparm of -respawn
 extern  boolean	fastparm;	// checkparm of -fast
 
+extern  boolean	pistolstart;	// checkparm of -pistolstart
+
 extern  boolean	devparm;	// DEBUG: launched with -devparm
 
 

--- a/src/doom/doomstat.h
+++ b/src/doom/doomstat.h
@@ -46,9 +46,7 @@
 extern  boolean	nomonsters;	// checkparm of -nomonsters
 extern  boolean	respawnparm;	// checkparm of -respawn
 extern  boolean	fastparm;	// checkparm of -fast
-
 extern  boolean	pistolstart;	// checkparm of -pistolstart
-
 extern  boolean	devparm;	// DEBUG: launched with -devparm
 
 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -603,6 +603,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 void G_DoLoadLevel (void) 
 { 
     int             i; 
+	extern int pistolstart;
 
     // Set the sky map.
     // First thing, we have a dummy sky texture name,
@@ -651,6 +652,20 @@ void G_DoLoadLevel (void)
 	memset (players[i].frags,0,sizeof(players[i].frags)); 
     } 
 		 
+	// Undocumented:
+	// Reset to pistol start condition if -pistolstart was invoked
+	// and no demo involved
+	
+	if (pistolstart && !demorecording && !demoplayback)
+	{
+		for (i = 0; i < MAXPLAYERS; i++)
+		{
+			//players[i].playerstate = PST_REBORN;
+			G_PlayerReborn(i);
+
+		}
+	}
+
     P_SetupLevel (gameepisode, gamemap, 0, gameskill);    
     displayplayer = consoleplayer;		// view the guy you are playing    
     gameaction = ga_nothing; 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -603,7 +603,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 void G_DoLoadLevel (void) 
 { 
     int             i; 
-	extern int      pistolstart;
+    extern int      pistolstart;
 
     // Set the sky map.
     // First thing, we have a dummy sky texture name,

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -603,7 +603,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 void G_DoLoadLevel (void) 
 { 
     int             i; 
-	extern int pistolstart;
+	extern int      pistolstart;
 
     // Set the sky map.
     // First thing, we have a dummy sky texture name,

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -651,21 +651,6 @@ void G_DoLoadLevel (void)
 	memset (players[i].frags,0,sizeof(players[i].frags)); 
     } 
 		 
-	// Undocumented:
-	// Reset to pistol start condition if -pistolstart was invoked
-	// and no demo involved
-	
-	if (M_CheckParm("-pistolstart")
-		&& !M_CheckParmWithArgs("-playdemo", 1)
-		&& !M_CheckParmWithArgs("-timedemo", 1)
-		&& !M_CheckParmWithArgs("-record", 1))
-	{
-		for (i = 0; i < MAXPLAYERS; i++)
-		{
-			G_PlayerReborn(i);
-		}
-	}
-
     P_SetupLevel (gameepisode, gamemap, 0, gameskill);    
     displayplayer = consoleplayer;		// view the guy you are playing    
     gameaction = ga_nothing; 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -651,6 +651,21 @@ void G_DoLoadLevel (void)
 	memset (players[i].frags,0,sizeof(players[i].frags)); 
     } 
 		 
+	// Undocumented:
+	// Reset to pistol start condition if -pistolstart was invoked
+	// and no demo involved
+	
+	if (M_CheckParm("-pistolstart")
+		&& !M_CheckParmWithArgs("-playdemo", 1)
+		&& !M_CheckParmWithArgs("-timedemo", 1)
+		&& !M_CheckParmWithArgs("-record", 1))
+	{
+		for (i = 0; i < MAXPLAYERS; i++)
+		{
+			G_PlayerReborn(i);
+		}
+	}
+
     P_SetupLevel (gameepisode, gamemap, 0, gameskill);    
     displayplayer = consoleplayer;		// view the guy you are playing    
     gameaction = ga_nothing; 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -652,19 +652,17 @@ void G_DoLoadLevel (void)
 	memset (players[i].frags,0,sizeof(players[i].frags)); 
     } 
 		 
-	// Undocumented:
-	// Reset to pistol start condition if -pistolstart was invoked
-	// and no demo involved
+    // Undocumented:
+    // Reset to pistol start condition if -pistolstart was invoked
+    // and no demo involved
 	
-	if (pistolstart && !demorecording && !demoplayback)
-	{
-		for (i = 0; i < MAXPLAYERS; i++)
-		{
-			//players[i].playerstate = PST_REBORN;
-			G_PlayerReborn(i);
-
-		}
-	}
+    if (pistolstart && !demorecording && !demoplayback)
+    {
+        for (i = 0; i < MAXPLAYERS; i++)
+        {
+            G_PlayerReborn(i);
+        }
+    }
 
     P_SetupLevel (gameepisode, gamemap, 0, gameskill);    
     displayplayer = consoleplayer;		// view the guy you are playing    

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -651,10 +651,6 @@ void G_DoLoadLevel (void)
 	    players[i].playerstate = PST_REBORN; 
 	memset (players[i].frags,0,sizeof(players[i].frags)); 
     } 
-		 
-    // Undocumented:
-    // Reset to pistol start condition if -pistolstart was invoked
-    // and no demo involved
 	
     if (pistolstart && !demorecording && !demoplayback)
     {

--- a/src/net_dedicated.c
+++ b/src/net_dedicated.c
@@ -41,7 +41,7 @@ static char *not_dedicated_options[] =
     "-deh", "-iwad", "-cdrom", "-gameversion", "-nomonsters", "-respawn",
     "-fast", "-altdeath", "-deathmatch", "-turbo", "-merge", "-af", "-as",
     "-aa", "-file", "-wart", "-skill", "-episode", "-timer", "-avg", "-warp",
-    "-loadgame", "-longtics", "-extratics", "-dup", NULL,
+    "-loadgame", "-longtics", "-extratics", "-dup", "-pistolstart", NULL,
 };
 
 static void CheckForClientOptions(void)

--- a/src/net_defs.h
+++ b/src/net_defs.h
@@ -177,7 +177,7 @@ typedef struct
     int timelimit;
     int loadgame;
     int random;  // [Strife only]
-	int pistolstart;
+    int pistolstart;
 
     // These fields are only used by the server when sending a game
     // start message:

--- a/src/net_defs.h
+++ b/src/net_defs.h
@@ -177,6 +177,7 @@ typedef struct
     int timelimit;
     int loadgame;
     int random;  // [Strife only]
+	int pistolstart;
 
     // These fields are only used by the server when sending a game
     // start message:

--- a/src/net_structrw.c
+++ b/src/net_structrw.c
@@ -69,6 +69,7 @@ void NET_WriteSettings(net_packet_t *packet, net_gamesettings_t *settings)
     NET_WriteInt32(packet, settings->timelimit);
     NET_WriteInt8(packet, settings->loadgame);
     NET_WriteInt8(packet, settings->random);
+	NET_WriteInt8(packet, settings->pistolstart);
     NET_WriteInt8(packet, settings->num_players);
     NET_WriteInt8(packet, settings->consoleplayer);
 
@@ -98,6 +99,7 @@ boolean NET_ReadSettings(net_packet_t *packet, net_gamesettings_t *settings)
            && NET_ReadInt32(packet, (unsigned int *) &settings->timelimit)
            && NET_ReadSInt8(packet, (signed int *) &settings->loadgame)
            && NET_ReadInt8(packet, (unsigned int *) &settings->random)
+		   && NET_ReadInt8(packet, (unsigned int *) &settings->pistolstart)
            && NET_ReadInt8(packet, (unsigned int *) &settings->num_players)
            && NET_ReadSInt8(packet, (signed int *) &settings->consoleplayer);
 

--- a/src/net_structrw.c
+++ b/src/net_structrw.c
@@ -69,7 +69,7 @@ void NET_WriteSettings(net_packet_t *packet, net_gamesettings_t *settings)
     NET_WriteInt32(packet, settings->timelimit);
     NET_WriteInt8(packet, settings->loadgame);
     NET_WriteInt8(packet, settings->random);
-	NET_WriteInt8(packet, settings->pistolstart);
+    NET_WriteInt8(packet, settings->pistolstart);
     NET_WriteInt8(packet, settings->num_players);
     NET_WriteInt8(packet, settings->consoleplayer);
 
@@ -99,7 +99,7 @@ boolean NET_ReadSettings(net_packet_t *packet, net_gamesettings_t *settings)
            && NET_ReadInt32(packet, (unsigned int *) &settings->timelimit)
            && NET_ReadSInt8(packet, (signed int *) &settings->loadgame)
            && NET_ReadInt8(packet, (unsigned int *) &settings->random)
-		   && NET_ReadInt8(packet, (unsigned int *) &settings->pistolstart)
+           && NET_ReadInt8(packet, (unsigned int *) &settings->pistolstart)
            && NET_ReadInt8(packet, (unsigned int *) &settings->num_players)
            && NET_ReadSInt8(packet, (signed int *) &settings->consoleplayer);
 


### PR DESCRIPTION
Many megawads are anthology projects where every level was designed independently and balanced for a pistol start. A -pistolstart parameter will make them play "correctly" without any additional effort by the player. I think it's sufficiently chocolately since it's equivalent to just IDCLEVing or suiciding on each new level, but handled automatically. It's also disabled when demos are involved in any way to maintain compatibility.