### PR TITLE
VS2015 compilation fix

### DIFF
--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -66,7 +66,7 @@
 
 #include <inttypes.h>
 
-#ifdef __cplusplus
+#if defined(__cplusplus) || defined(__bool_true_false_are_defined)
 
 // Use builtin bool type with C++.
 


### PR DESCRIPTION
Visual C++ 2015 defines C99 bool/true/false, which can be tested with __bool_true_false_are_defined macro.
