### PR TITLE
Emulation of hidden par bug in Final Doom.

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1725,9 +1725,6 @@ G_InitNew
     // the -warp command line parameter to behave differently.
     // This is left here for posterity.
 
-    if (skill > sk_nightmare)
-	skill = sk_nightmare;
-
     // This was quite messy with SPECIAL and commented parts.
     // Supposedly hacks to make the latest edition work.
     // It might not work properly.
@@ -1750,6 +1747,33 @@ G_InitNew
 	episode = 3;
     }
     */
+
+    if (skill > sk_nightmare)
+	skill = sk_nightmare;
+
+    if (gameversion >= exe_ultimate)
+    {
+        if (episode == 0)
+        {
+            episode = 4;
+        }
+    }
+    else
+    {
+        if (episode < 1)
+        {
+            episode = 1;
+        }
+        if (episode > 3)
+        {
+            episode = 3;
+        }
+    }
+
+    if (episode > 1 && gamemode == shareware)
+    {
+        episode = 1;
+    }
 
     if (map < 1)
 	map = 1;

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -653,7 +653,7 @@ ST_Responder (event_t* ev)
       }
       else
       {
-          if (map < 0)
+          if (map < 1)
           {
               return false;
           }

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -611,7 +611,7 @@ ST_Responder (event_t* ev)
       
       if (gamemode == commercial)
       {
-	epsd = 1;
+	epsd = 0;
 	map = (buf[0] - '0')*10 + buf[1] - '0';
       }
       else
@@ -628,30 +628,40 @@ ST_Responder (event_t* ev)
       }
 
       // Catch invalid maps.
-      if (epsd < 1)
-	return false;
-
-      if (map < 1)
-	return false;
-
-      // Ohmygod - this is not going to work.
-      if ((gamemode == retail)
-	  && ((epsd > 4) || (map > 9)))
-	return false;
-
-      if ((gamemode == registered)
-	  && ((epsd > 3) || (map > 9)))
-	return false;
-
-      if ((gamemode == shareware)
-	  && ((epsd > 1) || (map > 9)))
-	return false;
-
-      // The source release has this check as map > 34. However, Vanilla
-      // Doom allows IDCLEV up to MAP40 even though it normally crashes.
-      if ((gamemode == commercial)
-	&& (( epsd > 1) || (map > 40)))
-	return false;
+      if (gamemode != commercial)
+      {
+          if (epsd < 1)
+          {
+              return false;
+          }
+          if (epsd > 4)
+          {
+              return false;
+          }
+          if (epsd == 4 && gamemode != retail)
+          {
+              return false;
+          }
+          if (map < 1)
+          {
+              return false;
+          }
+          if (map > 9)
+          {
+              return false;
+          }
+      }
+      else
+      {
+          if (map < 0)
+          {
+              return false;
+          }
+          if (map > 40)
+          {
+              return false;
+          }
+      }
 
       // So be it.
       plyr->message = DEH_String(STSTR_CLEV);

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -638,7 +638,7 @@ ST_Responder (event_t* ev)
           {
               return false;
           }
-          if (epsd == 4 && gamemode != retail)
+          if (epsd == 4 && gameversion < exe_ultimate)
           {
               return false;
           }

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -1810,7 +1810,7 @@ void WI_initVariables(wbstartstruct_t* wbstartstruct)
     if (!wbs->maxsecret)
 	wbs->maxsecret = 1;
 
-    if ( gamemode != retail )
+    if ( gameversion < exe_ultimate )
       if (wbs->epsd > 2)
 	wbs->epsd -= 3;
 }


### PR DESCRIPTION
Level warp cheat sets episode to 0. But G_InitNew changes episode value to 4, if it equals to 0. So, par is not displayed.

This bug also occurs in Ultimate Doom and Chex executables.