### PR TITLE
Adjust PACKEDATTR for Clang

### DIFF
--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -51,7 +51,13 @@
 //
 
 #ifdef __GNUC__
+
+#ifdef __clang__
+#define PACKEDATTR __attribute__((packed))
+#else
 #define PACKEDATTR __attribute__((packed,gcc_struct))
+#endif
+
 #else
 #define PACKEDATTR
 #endif


### PR DESCRIPTION
Clang defines __GNUC__ but does not support the gnustruct packing
attribute, so add some extra #ifdef checks to catch Clang.