### PR TITLE
Fix STDISK offset for strife

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -429,7 +429,7 @@ void D_DoomLoop (void)
     I_GraphicsCheckCommandLine();
     I_SetGrabMouseCallback(D_GrabMouseCallback);
     I_InitGraphics();
-    I_EnableLoadingDisk();
+    I_EnableLoadingDisk(SCREENWIDTH - LOADING_DISK_W, SCREENHEIGHT - LOADING_DISK_H);
 
     V_RestoreBuffer();
     R_ExecuteSetViewSize();

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -92,8 +92,8 @@ static const char shiftxform[] =
 };
 
 
-#define LOADING_DISK_W 16
-#define LOADING_DISK_H 16
+static int loading_disk_xoffs = 0;
+static int loading_disk_yoffs = 0;
 
 // Non aspect ratio-corrected modes (direct multiples of 320x200)
 
@@ -393,9 +393,12 @@ static void SetShowCursor(boolean show)
     }
 }
 
-void I_EnableLoadingDisk(void)
+void I_EnableLoadingDisk(int xoffs, int yoffs)
 {
     char *disk_name;
+
+    loading_disk_xoffs = xoffs;
+    loading_disk_yoffs = yoffs;
 
     if (M_CheckParm("-cdrom") > 0)
         disk_name = DEH_String("STCDROM");
@@ -937,8 +940,8 @@ static int readtic = 0;
 void I_PrepareRead(void)
 {
     byte *screenloc = I_VideoBuffer
-                    + (SCREENHEIGHT - LOADING_DISK_H) * SCREENWIDTH
-                    + (SCREENWIDTH - LOADING_DISK_W);
+                    + loading_disk_yoffs * SCREENWIDTH
+                    + loading_disk_xoffs;
     int y;
 
     if (!initialized || saved_background == NULL)
@@ -969,12 +972,7 @@ void I_BeginRead(void)
     }
 
     // Draw the disk to the screen
-
-    V_DrawPatch(
-        SCREENWIDTH - LOADING_DISK_W,
-        SCREENHEIGHT - LOADING_DISK_H,
-        disk
-    );
+    V_DrawPatch(loading_disk_xoffs, loading_disk_yoffs, disk);
 
     readtic = gametic;
 }
@@ -982,8 +980,8 @@ void I_BeginRead(void)
 void I_EndRead(void)
 {
     byte *screenloc = I_VideoBuffer
-                    + (SCREENHEIGHT - LOADING_DISK_H) * SCREENWIDTH
-                    + (SCREENWIDTH - LOADING_DISK_W);
+                    + loading_disk_yoffs * SCREENWIDTH
+                    + loading_disk_xoffs;
     int y;
 
     if (!initialized || saved_background == NULL)

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -35,6 +35,11 @@
 
 #define SCREENHEIGHT_4_3 240
 
+// Dimensions of the flashing "loading" disk icon
+
+#define LOADING_DISK_W 16
+#define LOADING_DISK_H 16
+
 #define MAX_MOUSE_BUTTONS 8
 
 typedef struct
@@ -136,7 +141,7 @@ void I_StartTic (void);
 
 // Enable the loading disk image displayed when reading from disk.
 
-void I_EnableLoadingDisk(void);
+void I_EnableLoadingDisk(int xoffs, int yoffs);
 
 extern char *video_driver;
 extern boolean screenvisible;

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -509,7 +509,7 @@ void D_DoomLoop (void)
         I_InitGraphics();
     }
 
-    I_EnableLoadingDisk();
+    I_EnableLoadingDisk(SCREENWIDTH - LOADING_DISK_W, 0);
     I_SetGrabMouseCallback(D_GrabMouseCallback);
 
     V_RestoreBuffer();


### PR DESCRIPTION
This morning's breakfast-coding!

For issue #603.

Introduce some static variables for the x and y offset for drawing
STDISK and initialise them with I_EnableLoadingDisk. Pass the right
arguments for Doom and Strife in the relevant calls.

The disk is now drawn in the top-right for Strife, matching the
behaviour of the DOS version.