### PR TITLE
Ensure the buffer is zero-terminated.

### DIFF
--- a/src/gusconf.c
+++ b/src/gusconf.c
@@ -192,6 +192,7 @@ static char *ReadDMXConfig(void)
     data = Z_Malloc(len + 1, PU_STATIC, NULL);
     W_ReadLump(lumpnum, data);
 
+    data[len] = '\0';
     return data;
 }
 


### PR DESCRIPTION
Garbage at the end caused crashes.
