### PR TITLE
Add error message to 1-sided DR special crash

### DIFF
--- a/src/doom/p_doors.c
+++ b/src/doom/p_doors.c
@@ -392,6 +392,12 @@ EV_VerticalDoor
     }
 	
     // if the sector has an active thinker, use it
+
+    if (line->sidenum[side^1] == -1)
+    {
+        I_Error("EV_VerticalDoor: DR special type on 1-sided linedef");
+    }
+
     sec = sides[ line->sidenum[side^1]] .sector;
 
     if (sec->specialdata)


### PR DESCRIPTION
I don't see any downside in at least giving players a hint as to why their game just spontaneously quit.