### PR TITLE
Fix "`gcc_struct' attribute directive ignored" warnings

### DIFF
--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -52,10 +52,10 @@
 
 #ifdef __GNUC__
 
-#ifdef __clang__
-#define PACKEDATTR __attribute__((packed))
-#else
+#if defined(_WIN32) && !defined(__clang__)
 #define PACKEDATTR __attribute__((packed,gcc_struct))
+#else
+#define PACKEDATTR __attribute__((packed))
 #endif
 
 #else


### PR DESCRIPTION
Compilation for target architectures other than i386, x86_64 or PowerPC
(e.g. ARM) caused multiple warnings like the following to appear:

  doomdata.h:75:1: warning: ‘gcc_struct’ attribute directive ignored
   } PACKEDATTR mapsidedef_t;
   ^

This was due to 'gcc_struct' being undefined for these architectures.
Since that attribute was actually introduced by commit 87db726b9a9ae61ca
to address the fact that -mms-bitfields became the default for GCC on
Windows, limit it to that case.