### PR TITLE
bash-completion: Detect the appropriate directory for installation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,13 @@ AC_SDL_MAIN_WORKAROUND([
     AC_CHECK_LIB(amd64, amd64_iopl)
 ])
 
+AC_ARG_WITH([bashcompletiondir],
+    AS_HELP_STRING([--with-bashcompletiondir=DIR], [Bash completion directory]),
+    [],
+    [AS_IF([$($PKG_CONFIG --exists bash-completion)],
+        [bashcompletiondir=$($PKG_CONFIG --variable=completionsdir bash-completion)],
+	[bashcompletiondir=${datadir}/bash-completion/completions])])
+
 case $host in
   *cygwin* | *mingw* )
     AC_CHECK_TOOL(WINDRES, windres, )
@@ -166,6 +173,8 @@ AC_SUBST(PACKAGE_LICENSE)
 AC_SUBST(PACKAGE_MAINTAINER)
 AC_SUBST(PACKAGE_URL)
 AC_SUBST(PACKAGE_ISSUES)
+
+AC_SUBST(bashcompletiondir)
 
 dnl Shut up the datarootdir warnings.
 AC_DEFUN([AC_DATAROOTDIR_CHECKED])

--- a/man/bash-completion/.gitignore
+++ b/man/bash-completion/.gitignore
@@ -1,0 +1,4 @@
+*doom
+*heretic
+*hexen
+*strife

--- a/man/bash-completion/Makefile.am
+++ b/man/bash-completion/Makefile.am
@@ -1,3 +1,5 @@
+bashcompletiondir=@bashcompletiondir@
+
 BASH_COMPLETION_TEMPLATES = \
     doom.template \
     heretic.template \
@@ -12,7 +14,7 @@ BASH_COMPLETION_SCRIPTLETS = \
     @PROGRAM_PREFIX@hexen \
     @PROGRAM_PREFIX@strife
 
-noinst_DATA = $(BASH_COMPLETION_SCRIPTLETS)
+bashcompletion_DATA = $(BASH_COMPLETION_SCRIPTLETS)
 CLEANFILES = $(BASH_COMPLETION_SCRIPTLETS)
 
 MANDIR = $(top_srcdir)/man


### PR DESCRIPTION
It was originally assumed in #626 that the installation directory was distribution-specific (which can still be true), and thus the proper location can't be discovered. Turns out that you can query pkg-config for this very piece of information. The day is saved! :-)