### PR TITLE
automake: install binaries to ${bindir} not ${exec_prefix}/games

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = doom heretic hexen strife setup
 
-execgamesdir = ${exec_prefix}/games
+execgamesdir = ${bindir}
 
 execgames_PROGRAMS = @PROGRAM_PREFIX@doom     \
                      @PROGRAM_PREFIX@heretic  \

--- a/src/setup/Makefile.am
+++ b/src/setup/Makefile.am
@@ -1,6 +1,4 @@
 
-gamesdir = $(prefix)/games
-
 AM_CFLAGS = @SDL_CFLAGS@                                           \
             @SDLMIXER_CFLAGS@                                      \
             -I$(top_srcdir)/textscreen -I$(top_srcdir)/src


### PR DESCRIPTION
This has been enforcing a Debian-ism that proves problematic on
distributions that don't include /usr/games or /usr/local/games on the
$PATH by default.  On the packagers' side, the Arch, Fedora, and
OpenBSD packages (at least) have been patching the Makefile.in files
in order to get it to install to the bin directory instead.  On the
users' side, this comes as a rather nasty surprise when neither the
terminal nor GUI will launch the games when they've been installed to
a location not in the $PATH.

Using the power of autotools, the Debian maintainers can workaround
this change, to their preferred location, by using `./configure
--bindir=/usr/games`