### PR TITLE
opl: limit use of ioperm/inb/outb to x86 architecture

### DIFF
--- a/opl/opl.c
+++ b/opl/opl.c
@@ -27,7 +27,7 @@
 
 //#define OPL_DEBUG_TRACE
 
-#ifdef HAVE_IOPERM
+#if (defined(__i386__) || defined(__x86_64__)) && defined(HAVE_IOPERM)
 extern opl_driver_t opl_linux_driver;
 #endif
 #if defined(HAVE_LIBI386) || defined(HAVE_LIBAMD64)
@@ -40,7 +40,7 @@ extern opl_driver_t opl_sdl_driver;
 
 static opl_driver_t *drivers[] =
 {
-#ifdef HAVE_IOPERM
+#if (defined(__i386__) || defined(__x86_64__)) && defined(HAVE_IOPERM)
     &opl_linux_driver,
 #endif
 #if defined(HAVE_LIBI386) || defined(HAVE_LIBAMD64)

--- a/opl/opl_linux.c
+++ b/opl/opl_linux.c
@@ -17,7 +17,7 @@
 
 #include "config.h"
 
-#ifdef HAVE_IOPERM
+#if (defined(__i386__) || defined(__x86_64__)) && defined(HAVE_IOPERM)
 
 #include <stdio.h>
 #include <string.h>
@@ -99,5 +99,5 @@ opl_driver_t opl_linux_driver =
     OPL_Timer_AdjustCallbacks,
 };
 
-#endif /* #ifdef HAVE_IOPERM */
+#endif /* #if (defined(__i386__) || defined(__x86_64__)) && defined(HAVE_IOPERM) */
 


### PR DESCRIPTION
The use of I/O ports in the Linux driver to directly control OPL chips
is x86 specific and only really makes sense for x86-based PC's with
compatible hardware.

For some architectures (e.g. ARM), ioperm, inb and outb do exist and are
detected by the configure script (via AC_CHECK_FUNCS(ioperm)), but their
use is inappropriate in these cases and should be avoided.

In some other scenarios, like when using a GNU toolchain + uClibc for
PowerPC, the build even fails with the following error:

  opl_linux.c:26:20: fatal error: sys/io.h: No such file or directory

That is so because ioperm() is exported by uClibc and gets detected by
configure, which enables the "Linux" driver via definition of
HAVE_IOPERM, but in practice 'sys/io.h' is missing for ppc (inb/outb is
not implemented, and the call to ioperm() would return EIO anyway).

So, besides testing for HAVE_IOPERM, also test if either \__i386__ or
\__x86_64__ are defined before enabling this OPL driver.