### PR TITLE
Avoid use of '$<' and '$^' in Makefile rules

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -54,7 +54,7 @@ MANDIR = $(top_srcdir)/man
 DOCGEN = $(MANDIR)/docgen
 
 $(SETUP_MAN_PAGES): chocolate-setup.6
-	cp $< $@
+	cp chocolate-setup.6 $@
 
 @PROGRAM_PREFIX@doom.6: ../src $(MANPAGE_GEN_FILES)
 	$(DOCGEN) -g doom -m doom.template $(top_srcdir)/src $(top_srcdir)/src/doom > $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -186,7 +186,7 @@ endif
 @PROGRAM_PREFIX@strife_LDADD = strife/libstrife.a $(EXTRA_LIBS)
 
 $(SETUP_BINARIES): @PROGRAM_PREFIX@setup$(EXEEXT)
-	cp $< $@
+	cp @PROGRAM_PREFIX@setup$(EXEEXT) $@
 
 # Source files needed for chocolate-setup:
 
@@ -272,13 +272,14 @@ CLEANFILES = $(execgames_SCRIPTS) $(app_DATA) $(screensaver_DATA)
 if HAVE_PYTHON
 
 icon.c : $(top_builddir)/data/doom8.ico
-	$(top_builddir)/data/convert-icon $< $@
+	$(top_builddir)/data/convert-icon $(top_builddir)/data/doom8.ico $@
 
 endif
 
 midiread : midifile.c
-	$(CC) -DTEST $(CFLAGS) @LDFLAGS@ $< -o $@
+	$(CC) -DTEST $(CFLAGS) @LDFLAGS@ midifile.c -o $@
 
-mus2mid : mus2mid.c memio.c z_native.c i_system.c m_argv.c m_misc.c
-	$(CC) -DSTANDALONE -I$(top_builddir) $(CFLAGS) @LDFLAGS@ $^ -o $@
+MUS2MID_SOURCES = mus2mid.c memio.c z_native.c i_system.c m_argv.c m_misc.c
+mus2mid : $(MUS2MID_SOURCES)
+	$(CC) -DSTANDALONE -I$(top_builddir) $(CFLAGS) @LDFLAGS@ $(MUS2MID_SOURCES) -o $@
 

--- a/src/setup/Makefile.am
+++ b/src/setup/Makefile.am
@@ -39,7 +39,7 @@ CLEANFILES = $(app_DATA)
 if HAVE_PYTHON
 
 setup_icon.c : $(top_builddir)/data/setup8.ico
-	$(top_builddir)/data/convert-icon $^ $@
+	$(top_builddir)/data/convert-icon $(top_builddir)/data/setup8.ico $@
 
 endif
 


### PR DESCRIPTION
Versions of make other than GNU make don't support automatic variables
in explicit rules, only in suffix (implicit) ones.

This fixes the build on FreeBSD (and possibly other BSD variants), which
was failing with errors like:

cp  chocolate-doom-setup
usage: cp [-R [-H | -L | -P]] [-f | -i | -n] [-alpvx] source_file target_file
       cp [-R [-H | -L | -P]] [-f | -i | -n] [-alpvx] source_file ... target_directory
*** Error code 64

Stop.