### PR TITLE
Suggestion for fix on issue #659 

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1624,7 +1624,7 @@ void G_DoSaveGame (void)
 
     if (save_stream == NULL)
     {
-        return;
+        I_Error ("Error writing Savegame");
     }
 
     savegame_error = false;


### PR DESCRIPTION
Adjusted save code to exit if we detect a write error. Current process is to return, however this will cause an infinite loop.