### PR TITLE
Revert "Seed the M_Random random number generator from the system tim…

### DIFF
--- a/src/doom/m_random.c
+++ b/src/doom/m_random.c
@@ -16,11 +16,6 @@
 //	Random number LUT.
 //
 
-
-#include <time.h>
-
-#include "m_random.h"
-
 //
 // M_Random
 // Returns a 0-255 number
@@ -66,13 +61,5 @@ int M_Random (void)
 
 void M_ClearRandom (void)
 {
-    prndindex = 0;
-
-    // Seed the M_Random counter from the system time
-
-    rndindex = time(NULL) & 0xff;
+    rndindex = prndindex = 0;
 }
-
-
-
-


### PR DESCRIPTION
…e to give"

This reverts commit 59aad53bbde97e75e06717ea1b49bd3c92941b83.

Closes #665.

The original commit enhanced the behaviour of Doom to make some of the
pseudo-random behaviour less predictable. Whilst this is a nice feature, it's a
feature that vanilla lacks: replaying a demo would result in those behaviours
(wipe, pitched sound effects) being identical each time. This is not the case
with the above feature.

It could actually be quite useful to ensure that such behaviours are
reproducible to fine-tune our emulation of e.g. Doom/Heretic/Hexen pitch
shifting. Perhaps in the future our testing will be enhanced to compare
multimedia output of Vanilla versus chocolate for demo playback, in which case
we would also need to have reproducibility here.