### PR TITLE
Refer to the correct sound effect in A_FireCGun

### DIFF
--- a/src/doom/p_pspr.c
+++ b/src/doom/p_pspr.c
@@ -743,7 +743,7 @@ A_FireCGun
 ( player_t*	player,
   pspdef_t*	psp ) 
 {
-    S_StartSound (player->mo, sfx_pistol);
+    S_StartSound (player->mo, sfx_chgun);
 
     if (!player->ammo[weaponinfo[player->readyweapon].ammo])
 	return;


### PR DESCRIPTION
A_FireCGun called S_StartSound with sfx_pistol as an argument.
Therefore the sfx_chgun sound effect is never selected, and the
various code paths that check for whether a sound effect is a
link or not are never executed (sfx_chgun is the only such sound
effect).

I hypothesise that this was changed at some point post Doom 1.2.,
possibly post 1.9 and prior to the linuxdoom source release.

If pitch shifting is turned on, this alters the base pitch for
the chaingun to be shifted upwards. This is consistent with
Doom 1.2's behaviour, although we might need/want to recalibrate
the shifting a little bit further.

Closes: #671.