### PR TITLE
Add support for .lmp file formats to Mac Launcher

### DIFF
--- a/pkg/osx/AppController.m
+++ b/pkg/osx/AppController.m
@@ -101,6 +101,11 @@
         [self->launcherManager addFileToCommandLine: fileName
                                forArgument: @"-merge"];
     }
+    else if (![extension caseInsensitiveCompare: @"lmp"])
+    {
+        [self->launcherManager addFileToCommandLine: fileName
+                               forArgument: @"-playdemo"];
+    }
     else if (![extension caseInsensitiveCompare: @"deh"])
     {
         [self->launcherManager addFileToCommandLine: fileName

--- a/pkg/osx/Info.plist.in
+++ b/pkg/osx/Info.plist.in
@@ -51,6 +51,18 @@ Licensed under the GNU GPL v2.</string>
                 </dict>
                 <dict>
                         <key>CFBundleTypeName</key>
+                        <string>Doom demo recording</string>
+                        <key>CFBundleTypeIconFile</key>
+                        <string>wadfile.icns</string>
+                        <key>CFBundleTypeRole</key>
+                        <string>Viewer</string>
+                        <key>CFBundleTypeExtensions</key>
+                        <array>
+                                <string>lmp</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>CFBundleTypeName</key>
                         <string>Doom Dehacked patch</string>
                         <key>CFBundleTypeIconFile</key>
                         <string>wadfile.icns</string>


### PR DESCRIPTION
Once the app has been launched at least once, double-clicking upon
an .lmp file should start the Chocolate Doom launcher and add
appropriate "-playdemo" command-line arguments.

Closes: #677.