### PR TITLE
Add "-geom" argument

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1573,6 +1573,10 @@ void I_GraphicsCheckCommandLine(void)
     // windowed or fullscreen mode.
 
     i = M_CheckParmWithArgs("-geometry", 1);
+    if !(i > 0)
+    {
+    	i = M_CheckParmWithArgs("-geom", 1);
+    }
 
     if (i > 0)
     {


### PR DESCRIPTION
PrBoom allows "-geom" as well as "-geometry" and I just tried to use it in Choco to no avail. Might as well just add it in for the sake of completeness.