### PR TITLE
Heretic: Add map names for Episode 6

### DIFF
--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -83,7 +83,11 @@ char *LevelNames[] = {
     "E5M6:  COLONNADE",
     "E5M7:  FOETID MANSE",
     "E5M8:  FIELD OF JUDGEMENT",
-    "E5M9:  SKEIN OF D'SPARIL"
+    "E5M9:  SKEIN OF D'SPARIL",
+    // EPISODE 6: unnamed
+    "E6M1:  ",
+    "E6M2:  ",
+    "E6M3:  ",
 };
 
 static int cheating = 0;


### PR DESCRIPTION
Add blank map names for Episode 6.

This fixes a crash that can occur at the intermission screen after
completing a map in Episode 6.