### PR TITLE
Bring back the classic Doom "hit enter" behaviour

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -884,8 +884,7 @@ static boolean D_AddFile(char *filename)
 }
 
 // Copyright message banners
-// Some dehacked mods replace these.  These are only displayed if they are 
-// replaced by dehacked.
+// Some dehacked mods replace these.
 
 static char *copyright_banners[] =
 {
@@ -911,19 +910,30 @@ static char *copyright_banners[] =
 void PrintDehackedBanners(void)
 {
     size_t i;
+    char *deh_s;
 
-    for (i=0; i<arrlen(copyright_banners); ++i)
+    deh_s = DEH_String(copyright_banners[0]);
+
+    if (modifiedgame || deh_s != copyright_banners[0])
     {
-        char *deh_s;
+        printf("%s", deh_s);
 
+        // Make sure the modified banner always ends in a newline character.
+        // If it doesn't, add a newline.  This fixes av.wad.
+        if (deh_s[strlen(deh_s) - 1] != '\n')
+        {
+            printf("\n");
+        }
+        getchar();
+    }
+
+    for (i=1; i<arrlen(copyright_banners); ++i)
+    {
         deh_s = DEH_String(copyright_banners[i]);
 
         if (deh_s != copyright_banners[i])
         {
             printf("%s", deh_s);
-
-            // Make sure the modified banner always ends in a newline character.
-            // If it doesn't, add a newline.  This fixes av.wad.
 
             if (deh_s[strlen(deh_s) - 1] != '\n')
             {


### PR DESCRIPTION
When playing PWADs with classic Doom, you always got the "this game
has been modified" banner and had to hit enter to continue.  If you
played a lot of PWADs, you got used to hitting enter regularly.  It
became a core part of the Doom-playing experience. Even if you used
one of those lovely launchers that came on the shovelware CDs which
streamlined the PWAD choosing experience, you always had to hit the
enter key.

This commit restores this classic behaviour and allows those who
still have the muscle-memory "hit enter" behaviour permanently
burned into their nervous systems to finally be at peace.

TODO for a future commit: the coloured top-line of text (red for
1.666, blue for 1.9 iirc)