### PR TITLE
Input-related fixups for textscreen/setup in SDL2

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1168,16 +1168,6 @@ void I_InitGraphics(void)
 
     memset(I_VideoBuffer, 0, SCREENWIDTH * SCREENHEIGHT);
 
-    // We need SDL to give us translated versions of keys as well
-
-    // SDL2-TODO SDL_EnableUNICODE(1);
-
-    // Repeat key presses - this is what Vanilla Doom does
-    // Not sure about repeat rate - probably dependent on which DOS
-    // driver is used.  This is good enough though.
-
-    // SDL2-TODO SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
-
     // clear out any events waiting at the start and center the mouse
   
     while (SDL_PollEvent(&dummy));

--- a/src/setup/display.c
+++ b/src/setup/display.c
@@ -208,13 +208,6 @@ static void GenerateModesTable(TXT_UNCAST_ARG(widget),
     }
 }
 
-static void UpdateModeSeparator(TXT_UNCAST_ARG(widget),
-                                TXT_UNCAST_ARG(separator))
-{
-    TXT_CAST_ARG(txt_separator_t, separator);
-    TXT_SetSeparatorLabel(separator, "Window size");
-}
-
 static void AdvancedDisplayConfig(TXT_UNCAST_ARG(widget),
                                   TXT_UNCAST_ARG(modes_table))
 {
@@ -266,7 +259,6 @@ void ConfigDisplay(void)
 {
     txt_window_t *window;
     txt_table_t *modes_table;
-    txt_separator_t *modes_separator;
     txt_window_action_t *advanced_button;
     txt_checkbox_t *fs_checkbox;
     int num_columns;
@@ -296,18 +288,15 @@ void ConfigDisplay(void)
 
     // Build window:
 
-    TXT_AddWidget(window,
-                  fs_checkbox = TXT_NewCheckBox("Full screen", &fullscreen));
-
     TXT_AddWidgets(window,
-                   modes_separator = TXT_NewSeparator(""),
+                   TXT_NewSeparator("Window size"),
                    modes_table,
+                   TXT_NewSeparator("Options"),
+                   fs_checkbox = TXT_NewCheckBox("Full screen", &fullscreen),
                    NULL);
 
     TXT_SignalConnect(fs_checkbox, "changed",
                       GenerateModesTable, modes_table);
-    TXT_SignalConnect(fs_checkbox, "changed",
-                      UpdateModeSeparator, modes_separator);
 
     // How many rows high will the configuration window be?
     // Need to take into account number of fullscreen modes, and also
@@ -340,7 +329,6 @@ void ConfigDisplay(void)
                                   TXT_SCREEN_W / 2, window_y);
 
     GenerateModesTable(NULL, modes_table);
-    UpdateModeSeparator(NULL, modes_separator);
 
     // Button to open "advanced" window.
     // Need to pass a pointer to the modes table, as some of the options

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -304,7 +304,6 @@ int TXT_Init(void)
     SDL_LockSurface(screenbuffer);
     SDL_SetPaletteColors(screenbuffer->format->palette, ega_colors, 0, 16);
     SDL_UnlockSurface(screenbuffer);
-    // SDL2-TODO SDL_EnableUNICODE(1);
 
     screendata = malloc(TXT_SCREEN_W * TXT_SCREEN_H * 2);
     memset(screendata, 0, TXT_SCREEN_W * TXT_SCREEN_H * 2);
@@ -314,8 +313,6 @@ int TXT_Init(void)
 
     // Repeat key presses so we can hold down arrows to scroll down the
     // menu, for example. This is what setup.exe does.
-
-    // SDL2-TODO SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
 
     return 1;
 }

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -67,6 +67,8 @@ static const txt_font_t *font;
 // normal_font otherwise.
 static const txt_font_t highdpi_font = { "normal-highdpi", NULL, 8, 16 };
 
+static const int scancode_translate_table[] = SCANCODE_TO_KEYS_ARRAY;
+
 //#define TANGO
 
 #ifndef TANGO
@@ -475,123 +477,38 @@ void TXT_GetMousePosition(int *x, int *y)
 // Translates the SDL key
 //
 
+// XXX: duplicate from doomtype.h
+#define arrlen(array) (sizeof(array) / sizeof(*array))
+
 static int TranslateKey(SDL_Keysym *sym)
 {
-    switch(sym->sym)
+    int scancode = sym->scancode;
+
+    switch (scancode)
     {
-        case SDLK_LEFT:        return KEY_LEFTARROW;
-        case SDLK_RIGHT:       return KEY_RIGHTARROW;
-        case SDLK_DOWN:        return KEY_DOWNARROW;
-        case SDLK_UP:          return KEY_UPARROW;
-        case SDLK_ESCAPE:      return KEY_ESCAPE;
-        case SDLK_RETURN:      return KEY_ENTER;
-        case SDLK_TAB:         return KEY_TAB;
-        case SDLK_F1:          return KEY_F1;
-        case SDLK_F2:          return KEY_F2;
-        case SDLK_F3:          return KEY_F3;
-        case SDLK_F4:          return KEY_F4;
-        case SDLK_F5:          return KEY_F5;
-        case SDLK_F6:          return KEY_F6;
-        case SDLK_F7:          return KEY_F7;
-        case SDLK_F8:          return KEY_F8;
-        case SDLK_F9:          return KEY_F9;
-        case SDLK_F10:         return KEY_F10;
-        case SDLK_F11:         return KEY_F11;
-        case SDLK_F12:         return KEY_F12;
-        case SDLK_PRINTSCREEN:       return KEY_PRTSCR;
+        case SDL_SCANCODE_LCTRL:
+        case SDL_SCANCODE_RCTRL:
+            return KEY_RCTRL;
 
-        case SDLK_BACKSPACE:   return KEY_BACKSPACE;
-        case SDLK_DELETE:      return KEY_DEL;
+        case SDL_SCANCODE_LSHIFT:
+        case SDL_SCANCODE_RSHIFT:
+            return KEY_RSHIFT;
 
-        case SDLK_PAUSE:       return KEY_PAUSE;
+        case SDL_SCANCODE_LALT:
+            return KEY_LALT;
 
-        case SDLK_LSHIFT:
-        case SDLK_RSHIFT:
-                               return KEY_RSHIFT;
+        case SDL_SCANCODE_RALT:
+            return KEY_RALT;
 
-        case SDLK_LCTRL:
-        case SDLK_RCTRL:
-                               return KEY_RCTRL;
-
-        case SDLK_LALT:
-        case SDLK_RALT:
-                               return KEY_RALT;
-
-        case SDLK_CAPSLOCK:    return KEY_CAPSLOCK;
-        case SDLK_SCROLLLOCK:   return KEY_SCRLCK;
-
-        case SDLK_HOME:        return KEY_HOME;
-        case SDLK_INSERT:      return KEY_INS;
-        case SDLK_END:         return KEY_END;
-        case SDLK_PAGEUP:      return KEY_PGUP;
-        case SDLK_PAGEDOWN:    return KEY_PGDN;
-
-#ifdef SDL_HAVE_APP_KEYS
-        case SDLK_APP1:        return KEY_F1;
-        case SDLK_APP2:        return KEY_F2;
-        case SDLK_APP3:        return KEY_F3;
-        case SDLK_APP4:        return KEY_F4;
-        case SDLK_APP5:        return KEY_F5;
-        case SDLK_APP6:        return KEY_F6;
-#endif
-
-        default:               break;
-    }
-
-    // Returned value is different, depending on whether key mapping is
-    // enabled.  Key mapping is preferable most of the time, for typing
-    // in text, etc.  However, when we want to read raw keyboard codes
-    // for the setup keyboard configuration dialog, we want the raw
-    // key code.
-
-    if (key_mapping)
-    {
-        // Unicode characters beyond the ASCII range need to be
-        // mapped up into textscreen's Unicode range.
-
-#if 0
-    // SDL2-TODO
-        if (sym->unicode < 128)
-        {
-            return sym->unicode;
-        }
-        else
-        {
-            return sym->unicode - 128 + TXT_UNICODE_BASE;
-        }
-#endif
-        return 0;
-    }
-    else
-    {
-        // Keypad mapping is only done when we want a raw value:
-        // most of the time, the keypad should behave as it normally
-        // does.
-
-        switch (sym->sym)
-        {
-            case SDLK_KP_0:         return KEYP_0;
-            case SDLK_KP_1:         return KEYP_1;
-            case SDLK_KP_2:         return KEYP_2;
-            case SDLK_KP_3:         return KEYP_3;
-            case SDLK_KP_4:         return KEYP_4;
-            case SDLK_KP_5:         return KEYP_5;
-            case SDLK_KP_6:         return KEYP_6;
-            case SDLK_KP_7:         return KEYP_7;
-            case SDLK_KP_8:         return KEYP_8;
-            case SDLK_KP_9:         return KEYP_9;
-
-            case SDLK_KP_PERIOD:   return KEYP_PERIOD;
-            case SDLK_KP_MULTIPLY: return KEYP_MULTIPLY;
-            case SDLK_KP_PLUS:     return KEYP_PLUS;
-            case SDLK_KP_MINUS:    return KEYP_MINUS;
-            case SDLK_KP_DIVIDE:   return KEYP_DIVIDE;
-            case SDLK_KP_EQUALS:   return KEYP_EQUALS;
-            case SDLK_KP_ENTER:    return KEYP_ENTER;
-
-            default:
-                return tolower(sym->sym);
-        }
+        default:
+            if (scancode >= 0 && scancode < arrlen(scancode_translate_table))
+            {
+                return scancode_translate_table[scancode];
+            }
+            else
+            {
+                return 0;
+            }
     }
 }
 


### PR DESCRIPTION
Remove some "SDL2-TODO" comments where no further work is needed.

Simplify the resolution selection in setup by removing the windowed/fullscreen toggle and all the heuristic support code for finding a fullscreen resolution that is not relevant to the sdl2 approach.

Copy some of the input changes from i_input to textscreen to fix accessing menus etc. in setup.

Further work is needed on setup relating to text input, but nothing that is a regression from sdl1 so far as I can see!

(oddly this is a net code reduction of 220 lines)