### PR TITLE
[sdl2-branch] toggle fullscreen with cmd+enter

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -318,6 +318,12 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
     }
 }
 
+static void I_ToggleFullScreen(void)
+{
+    Uint32 flags = SDL_GetWindowFlags(screen) & SDL_WINDOW_FULLSCREEN_DESKTOP;
+    SDL_SetWindowFullscreen(screen, flags ^ SDL_WINDOW_FULLSCREEN_DESKTOP);
+}
+
 void I_GetEvent(void)
 {
     extern void I_HandleKeyboardEvent(SDL_Event *sdlevent);
@@ -331,6 +337,14 @@ void I_GetEvent(void)
         switch (sdlevent.type)
         {
             case SDL_KEYDOWN:
+                if (sdlevent.key.keysym.scancode == SDL_SCANCODE_RETURN &&
+                    sdlevent.key.keysym.mod & (KMOD_LGUI | KMOD_RGUI))
+                {
+                    I_ToggleFullScreen();
+                    break;
+                }
+                // deliberate fall-though
+
             case SDL_KEYUP:
 		I_HandleKeyboardEvent(&sdlevent);
                 break;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -318,6 +318,15 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
     }
 }
 
+static boolean ToggleFullScreenKeyShortcut(SDL_Keysym *sym)
+{
+    Uint16 flags = (KMOD_LALT | KMOD_RALT);
+#if defined(__MACOSX__)
+    flags |= (KMOD_LGUI | KMOD_RGUI);
+#endif
+    return (sym->scancode == SDL_SCANCODE_RETURN && sym->mod & flags);
+}
+
 static void I_ToggleFullScreen(void)
 {
     Uint32 flags = SDL_GetWindowFlags(screen) & SDL_WINDOW_FULLSCREEN_DESKTOP;
@@ -337,8 +346,7 @@ void I_GetEvent(void)
         switch (sdlevent.type)
         {
             case SDL_KEYDOWN:
-                if (sdlevent.key.keysym.scancode == SDL_SCANCODE_RETURN &&
-                    sdlevent.key.keysym.mod & (KMOD_LGUI | KMOD_RGUI))
+                if (ToggleFullScreenKeyShortcut(&sdlevent.key.keysym))
                 {
                     I_ToggleFullScreen();
                     break;


### PR DESCRIPTION
This morning's breakfast coding... Only tested on Mac so far

Special-case listen for LGUI/RGUI + enter (which is Command on Mac;
Windows key on Windows; Meta or whatever on Linux) and toggle
fullscreen.

We might want to handle Mac slightly differently: I think the OS itself
basically does the equivalent of SDL's FULLSCREEN_WINDOWED whenever something
tries to become fullscreen. As things currently stand, this works on Mac, and
you can additionally fullscreen by clicking the green fullscreen (formerly
maximize) icon in the window titlebar. Switching from/to fullscreen between
fullscreen-via-shortcut or fullscreen-via-maximize button works as expected.

However, when you are fullscreen-via-maximize-button, if you push the mouse
pointer to the top edge, the titlebar scrolls down and you could click to
de-maximize. This does not happen if you are fullscreen-via-shortcut. Further
investigation required.