### PR TITLE
remove 256x200 resolution option

### DIFF
--- a/src/setup/display.c
+++ b/src/setup/display.c
@@ -53,7 +53,6 @@ static screen_mode_t screen_modes_unscaled[] =
 
 static screen_mode_t screen_modes_scaled[] = 
 {
-    { 256,  200 },
     { 320,  240 },
     { 512,  400 },
     { 640,  480 },
@@ -62,6 +61,7 @@ static screen_mode_t screen_modes_scaled[] =
     { 1024, 800 },
     { 1280, 960 },
     { 1600, 1200 },
+    { 1920, 1440 },
     { 0, 0},
 };
 


### PR DESCRIPTION
I cannot recall why 256x200 was included in the list, I guess there was a good
reason for it, perhaps there still is. But, I imagine it's a niche use-case, and at
present it's presented in the default list of resolutions, and also as the first one
in the list.

This resolution is a scale-down from Doom's native resolution (=lossy/lower quality).
The vast majority of chocolate-doom players will not want to use it. Balance out
the resolution table by adding 1920x1440 at the end, instead. (so the columns are
equal lengths)

Note it will still be possible for people to use 256x200 if they really
want to: you can supply any width or height in chocolate-doom.cfg, or drag to resize
the window yourself at run-time.