### PR TITLE
doom: Always allow loading PWADs for Freedoom: Phase 1

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1604,7 +1604,7 @@ void D_DoomMain (void)
     }
 
     // Check for -file in shareware
-    if (modifiedgame)
+    if (modifiedgame && !(gamevariant & freedoom))
     {
 	// These are the lumps that will be checked in IWAD,
 	// if any one is not present, execution will be aborted.


### PR DESCRIPTION
With the combination of freedoom1.wad and -gameversion 1.666 through
1.9, Chocolate Doom would fail to pass the checks against loading
PWADs on the shareware version of Doom.  Checking for the FREEDOOM
lump resolves this.