### PR TITLE
introduce a "gamevariant" variable to tell different IWADs apart

### DIFF
--- a/src/d_mode.h
+++ b/src/d_mode.h
@@ -74,6 +74,16 @@ typedef enum
     exe_strife_1_31  // Strife v1.31
 } GameVersion_t;
 
+// What IWAD variant are we using?
+
+typedef enum
+{
+    vanilla    = 0, // Vanilla Doom
+    freedoom   = 1, // FreeDoom: Phase 1 + 2
+    freedm     = 2, // FreeDM
+    bfgedition = 4, // Doom Classic (Doom 3: BFG Edition)
+} GameVariant_t;
+
 // Skill level.
 
 typedef enum

--- a/src/d_mode.h
+++ b/src/d_mode.h
@@ -78,10 +78,10 @@ typedef enum
 
 typedef enum
 {
-    vanilla    = 0, // Vanilla Doom
-    freedoom   = 1, // FreeDoom: Phase 1 + 2
-    freedm     = 2, // FreeDM
-    bfgedition = 4, // Doom Classic (Doom 3: BFG Edition)
+    vanilla,    // Vanilla Doom
+    freedoom,   // FreeDoom: Phase 1 + 2
+    freedm,     // FreeDM
+    bfgedition, // Doom Classic (Doom 3: BFG Edition)
 } GameVariant_t;
 
 // Skill level.

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -118,9 +118,6 @@ boolean		advancedemo;
 // Store demo, do not accept any inputs
 boolean         storedemo;
 
-// "BFG Edition" version of doom2.wad does not include TITLEPIC.
-boolean         bfgedition;
-
 // If true, the main game loop has started.
 boolean         main_loop_started = false;
 
@@ -411,7 +408,7 @@ boolean D_GrabMouseCallback(void)
 //
 void D_DoomLoop (void)
 {
-    if (bfgedition &&
+    if (gamevariant & bfgedition &&
         (demorecording || (gameaction == ga_playdemo) || netgame))
     {
         printf(" WARNING: You are playing using one of the Doom Classic\n"
@@ -579,7 +576,7 @@ void D_DoAdvanceDemo (void)
 
     // The Doom 3: BFG Edition version of doom2.wad does not have a
     // TITLETPIC lump. Use INTERPIC instead as a workaround.
-    if (bfgedition && !strcasecmp(pagename, "TITLEPIC")
+    if (gamevariant & bfgedition && !strcasecmp(pagename, "TITLEPIC")
         && W_CheckNumForName("titlepic") < 0)
     {
         pagename = DEH_String("INTERPIC");
@@ -812,8 +809,9 @@ void D_IdentifyVersion(void)
 
 void D_SetGameDescription(void)
 {
-    boolean is_freedoom = W_CheckNumForName("FREEDOOM") >= 0,
-            is_freedm = W_CheckNumForName("FREEDM") >= 0;
+    gamevariant = W_CheckNumForName("FREEDOOM") >= 0 ?
+                  W_CheckNumForName("FREEDM") >= 0 ?
+                  freedoom & freedm : freedoom : vanilla;
 
     gamedescription = "Unknown";
 
@@ -821,7 +819,7 @@ void D_SetGameDescription(void)
     {
         // Doom 1.  But which version?
 
-        if (is_freedoom)
+        if (gamevariant & freedoom)
         {
             gamedescription = GetGameName("Freedoom: Phase 1");
         }
@@ -844,9 +842,9 @@ void D_SetGameDescription(void)
     {
         // Doom 2 of some kind.  But which mission?
 
-        if (is_freedoom)
+        if (gamevariant & freedoom)
         {
-            if (is_freedm)
+            if (gamevariant & freedm)
             {
                 gamedescription = GetGameName("FreeDM");
             }
@@ -1126,7 +1124,7 @@ static void D_Endoom(void)
 static void LoadIwadDeh(void)
 {
     // The Freedoom IWADs have DEHACKED lumps that must be loaded.
-    if (W_CheckNumForName("FREEDOOM") >= 0)
+    if (gamevariant & freedoom)
     {
         // Old versions of Freedoom (before 2014-09) did not have technically
         // valid DEHACKED lumps, so ignore errors and just continue if this
@@ -1448,7 +1446,7 @@ void D_DoomMain (void)
     if (W_CheckNumForName("dmenupic") >= 0)
     {
         printf("BFG Edition: Using workarounds as needed.\n");
-        bfgedition = true;
+        gamevariant = bfgedition;
 
         // BFG Edition changes the names of the secret levels to
         // censor the Wolfenstein references. It also has an extra
@@ -1635,7 +1633,7 @@ void D_DoomMain (void)
     // Freedoom's IWADs are Boom-compatible, which means they usually
     // don't work in Vanilla (though FreeDM is okay). Show a warning
     // message and give a link to the website.
-    if (W_CheckNumForName("FREEDOOM") >= 0 && W_CheckNumForName("FREEDM") < 0)
+    if (gamevariant & freedoom && !(gamevariant & freedm))
     {
         printf(" WARNING: You are playing using one of the Freedoom IWAD\n"
                " files, which might not work in this port. See this page\n"

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -408,7 +408,7 @@ boolean D_GrabMouseCallback(void)
 //
 void D_DoomLoop (void)
 {
-    if (gamevariant & bfgedition &&
+    if (gamevariant == bfgedition &&
         (demorecording || (gameaction == ga_playdemo) || netgame))
     {
         printf(" WARNING: You are playing using one of the Doom Classic\n"
@@ -576,7 +576,7 @@ void D_DoAdvanceDemo (void)
 
     // The Doom 3: BFG Edition version of doom2.wad does not have a
     // TITLETPIC lump. Use INTERPIC instead as a workaround.
-    if (gamevariant & bfgedition && !strcasecmp(pagename, "TITLEPIC")
+    if (gamevariant == bfgedition && !strcasecmp(pagename, "TITLEPIC")
         && W_CheckNumForName("titlepic") < 0)
     {
         pagename = DEH_String("INTERPIC");
@@ -809,17 +809,13 @@ void D_IdentifyVersion(void)
 
 void D_SetGameDescription(void)
 {
-    gamevariant = W_CheckNumForName("FREEDOOM") >= 0 ?
-                  W_CheckNumForName("FREEDM") >= 0 ?
-                  freedoom & freedm : freedoom : vanilla;
-
     gamedescription = "Unknown";
 
     if (logical_gamemission == doom)
     {
         // Doom 1.  But which version?
 
-        if (gamevariant & freedoom)
+        if (gamevariant == freedoom)
         {
             gamedescription = GetGameName("Freedoom: Phase 1");
         }
@@ -842,16 +838,13 @@ void D_SetGameDescription(void)
     {
         // Doom 2 of some kind.  But which mission?
 
-        if (gamevariant & freedoom)
+        if (gamevariant == freedm)
         {
-            if (gamevariant & freedm)
-            {
-                gamedescription = GetGameName("FreeDM");
-            }
-            else
-            {
-                gamedescription = GetGameName("Freedoom: Phase 2");
-            }
+            gamedescription = GetGameName("FreeDM");
+        }
+        else if (gamevariant == freedoom)
+        {
+            gamedescription = GetGameName("Freedoom: Phase 2");
         }
         else if (logical_gamemission == doom2)
         {
@@ -1124,7 +1117,7 @@ static void D_Endoom(void)
 static void LoadIwadDeh(void)
 {
     // The Freedoom IWADs have DEHACKED lumps that must be loaded.
-    if (gamevariant & freedoom)
+    if (gamevariant == freedoom || gamevariant == freedm)
     {
         // Old versions of Freedoom (before 2014-09) did not have technically
         // valid DEHACKED lumps, so ignore errors and just continue if this
@@ -1435,6 +1428,24 @@ void D_DoomMain (void)
         LoadIwadDeh();
     }
 
+    // Check which IWAD variant we are using.
+
+    if (W_CheckNumForName("FREEDOOM") >= 0)
+    {
+        if (W_CheckNumForName("FREEDM") >= 0)
+        {
+            gamevariant = freedm;
+        }
+        else
+        {
+            gamevariant = freedoom;
+        }
+    }
+    else if (W_CheckNumForName("DMENUPIC") >= 0)
+    {
+        gamevariant = bfgedition;
+    }
+
     // Doom 3: BFG Edition includes modified versions of the classic
     // IWADs which can be identified by an additional DMENUPIC lump.
     // Furthermore, the M_GDHIGH lumps have been modified in a way that
@@ -1443,10 +1454,9 @@ void D_DoomMain (void)
     // We specifically check for DMENUPIC here, before PWADs have been
     // loaded which could probably include a lump of that name.
 
-    if (W_CheckNumForName("dmenupic") >= 0)
+    if (gamevariant == bfgedition)
     {
         printf("BFG Edition: Using workarounds as needed.\n");
-        gamevariant = bfgedition;
 
         // BFG Edition changes the names of the secret levels to
         // censor the Wolfenstein references. It also has an extra
@@ -1633,7 +1643,7 @@ void D_DoomMain (void)
     // Freedoom's IWADs are Boom-compatible, which means they usually
     // don't work in Vanilla (though FreeDM is okay). Show a warning
     // message and give a link to the website.
-    if (gamevariant & freedoom && !(gamevariant & freedm))
+    if (gamevariant == freedoom)
     {
         printf(" WARNING: You are playing using one of the Freedoom IWAD\n"
                " files, which might not work in this port. See this page\n"

--- a/src/doom/doomstat.c
+++ b/src/doom/doomstat.c
@@ -25,6 +25,7 @@
 GameMode_t gamemode = indetermined;
 GameMission_t	gamemission = doom;
 GameVersion_t   gameversion = exe_final2;
+GameVariant_t   gamevariant = vanilla;
 char *gamedescription;
 
 // Set if homebrew PWAD stuff has been added.

--- a/src/doom/doomstat.h
+++ b/src/doom/doomstat.h
@@ -56,10 +56,8 @@ extern  boolean	devparm;	// DEBUG: launched with -devparm
 extern GameMode_t	gamemode;
 extern GameMission_t	gamemission;
 extern GameVersion_t    gameversion;
+extern GameVariant_t    gamevariant;
 extern char            *gamedescription;
-
-// If true, we're using one of the mangled BFG edition IWADs.
-extern boolean bfgedition;
 
 // Convenience macro.
 // 'gamemission' can be equal to pack_chex or pack_hacx, but these are


### PR DESCRIPTION
Chocolate Doom supports different variants that are available of the
IWADs, e.g. for Doom 2 it supports the Vanilla IWAD, the one shipped
with the Doom 3: BFG Edition as well as Freedoom: Phase 2 and FreeDM.

Each of these IWAD variants requires some specific special-casing and
the newly introduced global "gamevariant" variable can be used to keep
track of all of this.