### PR TITLE
Refactor loading disk icon code.

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -408,6 +408,8 @@ boolean D_GrabMouseCallback(void)
 //
 void D_DoomLoop (void)
 {
+    char *disk_lump_name;
+
     if (gamevariant == bfgedition &&
         (demorecording || (gameaction == ga_playdemo) || netgame))
     {
@@ -428,7 +430,14 @@ void D_DoomLoop (void)
     I_GraphicsCheckCommandLine();
     I_SetGrabMouseCallback(D_GrabMouseCallback);
     I_InitGraphics();
-    V_EnableLoadingDisk(SCREENWIDTH - LOADING_DISK_W, SCREENHEIGHT - LOADING_DISK_H);
+
+    if (M_CheckParm("-cdrom") > 0)
+        disk_lump_name = DEH_String("STCDROM");
+    else
+        disk_lump_name = DEH_String("STDISK");
+    V_EnableLoadingDisk(disk_lump_name,
+                        SCREENWIDTH - LOADING_DISK_W,
+                        SCREENHEIGHT - LOADING_DISK_H);
 
     V_RestoreBuffer();
     R_ExecuteSetViewSize();

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -214,7 +214,7 @@ void D_Display (void)
 	    break;
 	if (automapactive)
 	    AM_Drawer ();
-	if (wipe || (viewheight != SCREENHEIGHT && fullscreen) || disk_indicator == disk_dirty)
+	if (wipe || (viewheight != SCREENHEIGHT && fullscreen))
 	    redrawsbar = true;
 	if (inhelpscreensstate && !inhelpscreens)
 	    redrawsbar = true;              // just put away the help screen

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -125,6 +125,7 @@ char		wadfile[1024];		// primary wad file
 char		mapdir[1024];           // directory of development maps
 
 int             show_endoom = 1;
+int             show_diskicon = 1;
 
 
 void D_ConnectNetGame(void);
@@ -328,6 +329,27 @@ void D_Display (void)
     } while (!done);
 }
 
+static void EnableLoadingDisk(void)
+{
+    char *disk_lump_name;
+
+    if (show_diskicon)
+    {
+        if (M_CheckParm("-cdrom") > 0)
+        {
+            disk_lump_name = DEH_String("STCDROM");
+        }
+        else
+        {
+            disk_lump_name = DEH_String("STDISK");
+        }
+
+        V_EnableLoadingDisk(disk_lump_name,
+                            SCREENWIDTH - LOADING_DISK_W,
+                            SCREENHEIGHT - LOADING_DISK_H);
+    }
+}
+
 //
 // Add configuration file variable bindings.
 //
@@ -408,8 +430,6 @@ boolean D_GrabMouseCallback(void)
 //
 void D_DoomLoop (void)
 {
-    char *disk_lump_name;
-
     if (gamevariant == bfgedition &&
         (demorecording || (gameaction == ga_playdemo) || netgame))
     {
@@ -430,14 +450,7 @@ void D_DoomLoop (void)
     I_GraphicsCheckCommandLine();
     I_SetGrabMouseCallback(D_GrabMouseCallback);
     I_InitGraphics();
-
-    if (M_CheckParm("-cdrom") > 0)
-        disk_lump_name = DEH_String("STCDROM");
-    else
-        disk_lump_name = DEH_String("STDISK");
-    V_EnableLoadingDisk(disk_lump_name,
-                        SCREENWIDTH - LOADING_DISK_W,
-                        SCREENHEIGHT - LOADING_DISK_H);
+    EnableLoadingDisk();
 
     V_RestoreBuffer();
     R_ExecuteSetViewSize();

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -175,12 +175,6 @@ int png_screenshots = 0;
 
 int show_diskicon = 1;
 
-// Only display the disk icon if more then this much bytes have been read
-// during the previous tic.
-
-static const int diskicon_threshold = 20*1024;
-int diskicon_readbytes = 0;
-
 // if true, I_VideoBuffer is screen->pixels
 
 static boolean native_surface;
@@ -965,18 +959,8 @@ void I_FinishUpdate (void)
 	    I_VideoBuffer[ (SCREENHEIGHT-1)*SCREENWIDTH + i] = 0x0;
     }
 
-    if (show_diskicon && disk_indicator == disk_on)
-    {
-	if (diskicon_readbytes >= diskicon_threshold)
-	{
-	    V_BeginRead();
-	}
-    }
-    else if (disk_indicator == disk_dirty)
-    {
-	disk_indicator = disk_off;
-    }
-    diskicon_readbytes = 0;
+    // Draw disk icon before blit, if necessary.
+    V_DrawDiskIcon();
 
     // draw to screen
 
@@ -1012,6 +996,9 @@ void I_FinishUpdate (void)
     }
 
     SDL_Flip(screen);
+
+    // Restore background and undo the disk indicator, if it was drawn.
+    V_RestoreDiskBackground();
 }
 
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -171,10 +171,6 @@ int novert = 0;
 
 int png_screenshots = 0;
 
-// Display disk activity indicator.
-
-int show_diskicon = 1;
-
 // if true, I_VideoBuffer is screen->pixels
 
 static boolean native_surface;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -152,7 +152,4 @@ extern int screen_bpp;
 extern int fullscreen;
 extern int aspect_ratio_correct;
 
-extern int show_diskicon;
-extern int diskicon_readbytes;
-
 #endif

--- a/src/setup/display.c
+++ b/src/setup/display.c
@@ -560,13 +560,6 @@ static void AdvancedDisplayConfig(TXT_UNCAST_ARG(widget),
                                       &show_endoom));
     }
 
-    if (gamemission == doom || gamemission == strife)
-    {
-        TXT_AddWidget(window,
-                      TXT_NewCheckBox("Show disk activity indicator",
-                                      &show_diskicon));
-    }
-
 #ifdef HAVE_LIBPNG
     TXT_AddWidget(window,
                   TXT_NewCheckBox("Save screenshots in PNG format",

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -511,7 +511,7 @@ void D_DoomLoop (void)
         I_InitGraphics();
     }
 
-    V_EnableLoadingDisk(SCREENWIDTH - LOADING_DISK_W, 0);
+    V_EnableLoadingDisk("STDISK", SCREENWIDTH - LOADING_DISK_W, 3);
     I_SetGrabMouseCallback(D_GrabMouseCallback);
 
     V_RestoreBuffer();

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -142,6 +142,7 @@ char		wadfile[1024];          // primary wad file
 char		mapdir[1024];           // directory of development maps
 
 int             show_endoom = 1;
+int             show_diskicon = 1;
 int             graphical_startup = 1;
 
 // If true, startup has completed and the main game loop has started.
@@ -511,7 +512,10 @@ void D_DoomLoop (void)
         I_InitGraphics();
     }
 
-    V_EnableLoadingDisk("STDISK", SCREENWIDTH - LOADING_DISK_W, 3);
+    if (show_diskicon)
+    {
+        V_EnableLoadingDisk("STDISK", SCREENWIDTH - LOADING_DISK_W, 3);
+    }
     I_SetGrabMouseCallback(D_GrabMouseCallback);
 
     V_RestoreBuffer();

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -301,7 +301,7 @@ void D_Display (void)
     // see if the border needs to be updated to the screen
     if (gamestate == GS_LEVEL && !automapactive && scaledviewwidth != 320)
     {
-        if (menuactive || menuactivestate || !viewactivestate || disk_indicator == disk_dirty)
+        if (menuactive || menuactivestate || !viewactivestate)
         {
             borderdrawcount = 3;
             popupactivestate = false;

--- a/src/v_diskicon.c
+++ b/src/v_diskicon.c
@@ -89,20 +89,13 @@ static void SaveDiskData(char *disk_lump, int xoffs, int yoffs)
     Z_Free(tmpscreen);
 }
 
-void V_EnableLoadingDisk(int xoffs, int yoffs)
+void V_EnableLoadingDisk(char *lump_name, int xoffs, int yoffs)
 {
-    char *disk_name;
-
     loading_disk_xoffs = xoffs;
     loading_disk_yoffs = yoffs;
 
-    if (M_CheckParm("-cdrom") > 0)
-        disk_name = DEH_String("STCDROM");
-    else
-        disk_name = DEH_String("STDISK");
-
     saved_background = Z_Malloc(DISK_ICON_W * DISK_ICON_H, PU_STATIC, NULL);
-    SaveDiskData(disk_name, xoffs, yoffs);
+    SaveDiskData(lump_name, xoffs, yoffs);
 }
 
 void V_BeginRead(size_t nbytes)

--- a/src/v_diskicon.c
+++ b/src/v_diskicon.c
@@ -27,14 +27,18 @@
 
 #include "v_diskicon.h"
 
+#define DISK_ICON_W 16
+#define DISK_ICON_H 16
+
 // Only display the disk icon if more then this much bytes have been read
 // during the previous tic.
 
 static const int diskicon_threshold = 20*1024;
 
-// disk image patch (either STDISK or STCDROM)
-
-static patch_t *disk;
+// Two buffers: disk_data contains the data representing the disk icon
+// (raw, not a patch_t) while saved_background is an equivalently-sized
+// buffer where we save the background data while the disk is on screen.
+static byte *disk_data;
 static byte *saved_background;
 
 static int loading_disk_xoffs = 0;
@@ -43,28 +47,6 @@ static int loading_disk_yoffs = 0;
 // Number of bytes read since the last call to V_DrawDiskIcon().
 static size_t recent_bytes_read = 0;
 static boolean disk_drawn;
-
-void V_EnableLoadingDisk(int xoffs, int yoffs)
-{
-    char *disk_name;
-
-    loading_disk_xoffs = xoffs;
-    loading_disk_yoffs = yoffs;
-
-    if (M_CheckParm("-cdrom") > 0)
-        disk_name = DEH_String("STCDROM");
-    else
-        disk_name = DEH_String("STDISK");
-
-    disk = W_CacheLumpName(disk_name, PU_STATIC);
-    saved_background = Z_Malloc(SHORT(disk->width) * SHORT(disk->height),
-                                PU_STATIC, NULL);
-}
-
-void V_BeginRead(size_t nbytes)
-{
-    recent_bytes_read += nbytes;
-}
 
 static void CopyRegion(byte *dest, int dest_pitch,
                        byte *src, int src_pitch,
@@ -82,26 +64,72 @@ static void CopyRegion(byte *dest, int dest_pitch,
     }
 }
 
+static void SaveDiskData(char *disk_lump, int xoffs, int yoffs)
+{
+    byte *tmpscreen;
+    patch_t *disk;
+
+    // Allocate a complete temporary screen where we'll draw the patch.
+    tmpscreen = Z_Malloc(SCREENWIDTH * SCREENHEIGHT, PU_STATIC, NULL);
+    memset(tmpscreen, 0, SCREENWIDTH * SCREENHEIGHT);
+    V_UseBuffer(tmpscreen);
+
+    // Buffer where we'll save the disk data.
+    disk_data = Z_Malloc(DISK_ICON_W * DISK_ICON_H, PU_STATIC, NULL);
+
+    // Draw the patch and save the result to disk_data.
+    disk = W_CacheLumpName(disk_lump, PU_STATIC);
+    V_DrawPatch(loading_disk_xoffs, loading_disk_yoffs, disk);
+    CopyRegion(disk_data, DISK_ICON_W,
+               tmpscreen + yoffs * SCREENWIDTH + xoffs, SCREENWIDTH,
+               DISK_ICON_W, DISK_ICON_H);
+    W_ReleaseLumpName(disk_lump);
+
+    V_RestoreBuffer();
+    Z_Free(tmpscreen);
+}
+
+void V_EnableLoadingDisk(int xoffs, int yoffs)
+{
+    char *disk_name;
+
+    loading_disk_xoffs = xoffs;
+    loading_disk_yoffs = yoffs;
+
+    if (M_CheckParm("-cdrom") > 0)
+        disk_name = DEH_String("STCDROM");
+    else
+        disk_name = DEH_String("STDISK");
+
+    saved_background = Z_Malloc(DISK_ICON_W * DISK_ICON_H, PU_STATIC, NULL);
+    SaveDiskData(disk_name, xoffs, yoffs);
+}
+
+void V_BeginRead(size_t nbytes)
+{
+    recent_bytes_read += nbytes;
+}
+
 static byte *DiskRegionPointer(void)
 {
-    int x, y;
-
-    x = loading_disk_xoffs - SHORT(disk->leftoffset);
-    y = loading_disk_yoffs - SHORT(disk->topoffset);
-    return I_VideoBuffer + y * SCREENWIDTH + x;
+    return I_VideoBuffer
+         + loading_disk_yoffs * SCREENWIDTH
+         + loading_disk_xoffs;
 }
 
 void V_DrawDiskIcon(void)
 {
-    if (disk != NULL && recent_bytes_read > diskicon_threshold)
+    if (disk_data != NULL && recent_bytes_read > diskicon_threshold)
     {
         // Save the background behind the disk before we draw it.
-        CopyRegion(saved_background, SHORT(disk->width),
+        CopyRegion(saved_background, DISK_ICON_W,
                    DiskRegionPointer(), SCREENWIDTH,
-                   SHORT(disk->width), SHORT(disk->height));
+                   DISK_ICON_W, DISK_ICON_H);
 
-        // Draw the disk to the screen
-        V_DrawPatch(loading_disk_xoffs, loading_disk_yoffs, disk);
+        // Write the disk to the screen buffer.
+        CopyRegion(DiskRegionPointer(), SCREENWIDTH,
+                   disk_data, DISK_ICON_W,
+                   DISK_ICON_W, DISK_ICON_H);
         disk_drawn = true;
     }
 
@@ -114,8 +142,8 @@ void V_RestoreDiskBackground(void)
     {
         // Restore the background.
         CopyRegion(DiskRegionPointer(), SCREENWIDTH,
-                   saved_background, SHORT(disk->width),
-                   SHORT(disk->width), SHORT(disk->height));
+                   saved_background, DISK_ICON_W,
+                   DISK_ICON_W, DISK_ICON_H);
 
         disk_drawn = false;
     }

--- a/src/v_diskicon.c
+++ b/src/v_diskicon.c
@@ -86,8 +86,8 @@ static byte *DiskRegionPointer(void)
 {
     int x, y;
 
-    x = loading_disk_xoffs + SHORT(disk->leftoffset);
-    y = loading_disk_yoffs + SHORT(disk->topoffset);
+    x = loading_disk_xoffs - SHORT(disk->leftoffset);
+    y = loading_disk_yoffs - SHORT(disk->topoffset);
     return I_VideoBuffer + y * SCREENWIDTH + x;
 }
 

--- a/src/v_diskicon.c
+++ b/src/v_diskicon.c
@@ -27,9 +27,6 @@
 
 #include "v_diskicon.h"
 
-#define DISK_ICON_W 16
-#define DISK_ICON_H 16
-
 // Only display the disk icon if more then this much bytes have been read
 // during the previous tic.
 
@@ -75,14 +72,14 @@ static void SaveDiskData(char *disk_lump, int xoffs, int yoffs)
     V_UseBuffer(tmpscreen);
 
     // Buffer where we'll save the disk data.
-    disk_data = Z_Malloc(DISK_ICON_W * DISK_ICON_H, PU_STATIC, NULL);
+    disk_data = Z_Malloc(LOADING_DISK_W * LOADING_DISK_H, PU_STATIC, NULL);
 
     // Draw the patch and save the result to disk_data.
     disk = W_CacheLumpName(disk_lump, PU_STATIC);
     V_DrawPatch(loading_disk_xoffs, loading_disk_yoffs, disk);
-    CopyRegion(disk_data, DISK_ICON_W,
+    CopyRegion(disk_data, LOADING_DISK_W,
                tmpscreen + yoffs * SCREENWIDTH + xoffs, SCREENWIDTH,
-               DISK_ICON_W, DISK_ICON_H);
+               LOADING_DISK_W, LOADING_DISK_H);
     W_ReleaseLumpName(disk_lump);
 
     V_RestoreBuffer();
@@ -94,7 +91,8 @@ void V_EnableLoadingDisk(char *lump_name, int xoffs, int yoffs)
     loading_disk_xoffs = xoffs;
     loading_disk_yoffs = yoffs;
 
-    saved_background = Z_Malloc(DISK_ICON_W * DISK_ICON_H, PU_STATIC, NULL);
+    saved_background = Z_Malloc(LOADING_DISK_W * LOADING_DISK_H, PU_STATIC,
+                                NULL);
     SaveDiskData(lump_name, xoffs, yoffs);
 }
 
@@ -115,14 +113,14 @@ void V_DrawDiskIcon(void)
     if (disk_data != NULL && recent_bytes_read > diskicon_threshold)
     {
         // Save the background behind the disk before we draw it.
-        CopyRegion(saved_background, DISK_ICON_W,
+        CopyRegion(saved_background, LOADING_DISK_W,
                    DiskRegionPointer(), SCREENWIDTH,
-                   DISK_ICON_W, DISK_ICON_H);
+                   LOADING_DISK_W, LOADING_DISK_H);
 
         // Write the disk to the screen buffer.
         CopyRegion(DiskRegionPointer(), SCREENWIDTH,
-                   disk_data, DISK_ICON_W,
-                   DISK_ICON_W, DISK_ICON_H);
+                   disk_data, LOADING_DISK_W,
+                   LOADING_DISK_W, LOADING_DISK_H);
         disk_drawn = true;
     }
 
@@ -135,8 +133,8 @@ void V_RestoreDiskBackground(void)
     {
         // Restore the background.
         CopyRegion(DiskRegionPointer(), SCREENWIDTH,
-                   saved_background, DISK_ICON_W,
-                   DISK_ICON_W, DISK_ICON_H);
+                   saved_background, LOADING_DISK_W,
+                   LOADING_DISK_W, LOADING_DISK_H);
 
         disk_drawn = false;
     }

--- a/src/v_diskicon.h
+++ b/src/v_diskicon.h
@@ -24,16 +24,9 @@
 #define LOADING_DISK_W 16
 #define LOADING_DISK_H 16
 
-typedef enum
-{
-    disk_off,
-    disk_on,
-    disk_dirty
-} disk_indicator_e;
-
-extern disk_indicator_e disk_indicator;
-
-extern void V_EnableLoadingDisk (int xoffs, int yoffs);
-extern void V_BeginRead (void);
+extern void V_EnableLoadingDisk(int xoffs, int yoffs);
+extern void V_BeginRead(size_t nbytes);
+extern void V_DrawDiskIcon(void);
+extern void V_RestoreDiskBackground(void);
 
 #endif

--- a/src/v_diskicon.h
+++ b/src/v_diskicon.h
@@ -24,7 +24,7 @@
 #define LOADING_DISK_W 16
 #define LOADING_DISK_H 16
 
-extern void V_EnableLoadingDisk(int xoffs, int yoffs);
+extern void V_EnableLoadingDisk(char *lump_name, int xoffs, int yoffs);
 extern void V_BeginRead(size_t nbytes);
 extern void V_DrawDiskIcon(void);
 extern void V_RestoreDiskBackground(void);

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -348,9 +348,7 @@ void W_ReadLump(lumpindex_t lump, void *dest)
 
     l = lumpinfo[lump];
 
-    diskicon_readbytes += l->size;
-
-    disk_indicator = disk_on;
+    V_BeginRead(l->size);
 
     c = W_Read(l->wad_file, l->position, dest, l->size);
 


### PR DESCRIPTION
Only draw the disk icon just before doing the SDL blit to the screen,
and restore the background to I_VideoBuffer immediately after doing
so. This avoids the possibility of the disk remaining in the video
buffer and fixes #668.

Also centralize most loading disk code inside v_diskicon.c.