### PR TITLE
Convert README to Markdown

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ CODEBLOCKS_FILES=                              \
         codeblocks/setup-res.rc
 
 DOC_FILES=                              \
-        README                          \
+        README.md                       \
         README.Music                    \
         NEWS                            \
         PHILOSOPHY                      \

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# Chocolate Doom
 
 Chocolate Doom aims to accurately reproduce the original DOS version of
 Doom and other games based on the Doom engine in a form that can be
@@ -6,35 +7,35 @@ run on modern computers.
 Originally, Chocolate Doom was only a Doom source port. The project
 now includes ports of Heretic and Hexen, and Strife.
 
-Chocolate Doom's aims are:
+Chocolate Doom’s aims are:
 
  * To always be 100% Free and Open Source software.
  * Portability to as many different operating systems as possible.
  * Accurate reproduction of the original DOS versions of the games,
    including bugs.
  * Compatibility with the DOS demo, configuration and savegame files.
- * To provide an accurate retro "feel" (display and input should
+ * To provide an accurate retro “feel” (display and input should
    behave the same).
 
 More information about the philosophy and design behind Chocolate Doom
 can be found in the PHILOSOPHY file distributed with the source code.
 
-== Setting up gameplay ==
+## Setting up gameplay
 
 For instructions on how to set up Chocolate Doom for play, see the
 INSTALL file.
 
-== Configuration File ==
+## Configuration File
 
 Chocolate Doom is compatible with the DOS Doom configuration file
-(normally named 'default.cfg'). Existing configuration files for DOS
+(normally named `default.cfg`). Existing configuration files for DOS
 Doom should therefore simply work out of the box. However, Chocolate
 Doom also provides some extra settings. These are stored in a
-separate file named 'chocolate-doom.cfg'.
+separate file named `chocolate-doom.cfg`.
 
 The configuration can be edited using the chocolate-setup tool.
 
-== Command line options ==
+## Command line options
 
 Chocolate Doom supports a number of command line parameters, including
 some extras that were not originally suported by the DOS versions. For
@@ -42,30 +43,34 @@ binary distributions, see the CMDLINE file included with your
 download; more information is also available on the Chocolate Doom
 website.
 
-== Playing TCs ==
+## Playing TCs
 
 With Vanilla Doom there is no way to include sprites in PWAD files.
-Chocolate Doom's '-file' command line option behaves exactly the same
+Chocolate Doom’s ‘-file’ command line option behaves exactly the same
 as Vanilla Doom, and trying to play TCs by adding the WAD files using
-'-file' will not work.
+‘-file’ will not work.
 
 Many Total Conversions (TCs) are distributed as a PWAD file which must
 be merged into the main IWAD. Typically a copy of DEUSF.EXE is
 included which performs this merge. Chocolate Doom includes a new
-option, '-merge', which will simulate this merge. Essentially, the
+option, ‘-merge’, which will simulate this merge. Essentially, the
 WAD directory is merged in memory, removing the need to modify the
 IWAD on disk.
 
 To play TCs using Chocolate Doom, run like this:
 
-  chocolate-doom -merge thetc.wad
+```
+chocolate-doom -merge thetc.wad
+```
 
 Here are some examples:
 
-  chocolate-doom -merge batman.wad -deh batman.deh vbatman.deh  (Batman Doom)
-  chocolate-doom -merge aoddoom1.wad -deh aoddoom1.deh  (Army of Darkness Doom)
+```
+chocolate-doom -merge batman.wad -deh batman.deh vbatman.deh  (Batman Doom)
+chocolate-doom -merge aoddoom1.wad -deh aoddoom1.deh  (Army of Darkness Doom)
+```
 
-== Other information ==
+## Other information
 
  * Chocolate Doom includes a number of different options for music
    playback. See the README.Music file for more details.
@@ -97,6 +102,3 @@ Here are some examples:
 
  * Please send any feedback, questions or suggestions to
    fraggle@gmail.com. Thanks!
-
-# vim: tw=70
-

--- a/pkg/config.make.in
+++ b/pkg/config.make.in
@@ -19,7 +19,7 @@ PACKAGE_VERSION = @PACKAGE_VERSION@
 
 # Documentation files to distribute with packages.
 
-DOC_FILES = README        \
+DOC_FILES = README.md     \
             README.Music  \
             COPYING       \
             NEWS

--- a/pkg/win32/GNUmakefile
+++ b/pkg/win32/GNUmakefile
@@ -49,6 +49,9 @@ staging-%:
 		cp $(TOPLEVEL)/$$f $@/$$f.txt;       \
 	done
 	cp $(TOPLEVEL)/man/CMDLINE.$* $@/CMDLINE.txt
+
+	# Strip ".md" from the README name.
+	mv $@/README.md.txt $@/README.txt
 	
 	$(TOPLEVEL)/man/simplecpp -D_WIN32 -DPRECOMPILED  \
 	             -D$(shell echo $* | tr a-z A-Z)      \


### PR DESCRIPTION
Only minor changes needed for this. It gains pretty-printing on GitHub, which in my opinion, looks a lot more attractive than the monospace unformatted version.

Fancier features could even included, such as in-line images, but I believe keeping this sane for viewing in a terminal or text editor should take greater priority.