### PR TITLE
additionally fix hexen start-up window position for sdl2

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -100,7 +100,7 @@ char *video_driver = "";
 
 // Window position:
 
-static char *window_position = "center";
+char *window_position = "center";
 
 // SDL display number on which to run.
 
@@ -1103,7 +1103,7 @@ static void CenterWindow(int *x, int *y, int w, int h)
     *y = bounds.y + SDL_max((bounds.h - h) / 2, 0);
 }
 
-static void GetWindowPosition(int *x, int *y, int w, int h)
+void I_GetWindowPosition(int *x, int *y, int w, int h)
 {
     // in fullscreen mode, the window "position" still matters, because
     // we use it to control which display we run fullscreen on.
@@ -1131,7 +1131,7 @@ static void GetWindowPosition(int *x, int *y, int w, int h)
     else if (sscanf(window_position, "%i,%i", x, y) != 2)
     {
         // invalid format: revert to default
-        fprintf(stderr, "GetWindowPosition: invalid window_position setting\n");
+        fprintf(stderr, "I_GetWindowPosition: invalid window_position setting\n");
         *x = *y = SDL_WINDOWPOS_UNDEFINED;
     }
 }
@@ -1172,7 +1172,7 @@ static void SetVideoMode(void)
         }
     }
 
-    GetWindowPosition(&x, &y, w, h);
+    I_GetWindowPosition(&x, &y, w, h);
 
     // Create window and renderer contexts. We set the window title
     // later anyway and leave the window position "undefined". If

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -94,4 +94,7 @@ extern int integer_scaling;
 extern int vga_porch_flash;
 extern int force_software_renderer;
 
+extern char *window_position;
+void I_GetWindowPosition(int *x, int *y, int w, int h);
+
 #endif

--- a/src/i_videohr.c
+++ b/src/i_videohr.c
@@ -21,6 +21,7 @@
 
 #include "doomtype.h"
 #include "i_timer.h"
+#include "i_video.h"
 
 // Palette fade-in takes two seconds
 
@@ -35,15 +36,18 @@ static char *window_title = "";
 
 boolean I_SetVideoModeHR(void)
 {
+    int x, y;
+
     if (SDL_Init(SDL_INIT_VIDEO) < 0)
     {
         return false;
     }
 
+    I_GetWindowPosition(&x, &y, HR_SCREENWIDTH, HR_SCREENHEIGHT);
+
     // Create screen surface at the native desktop pixel depth (bpp=0),
     // as we cannot trust true 8-bit to reliably work nowadays.
-    hr_screen = SDL_CreateWindow(window_title,
-        SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+    hr_screen = SDL_CreateWindow(window_title, x, y,
         HR_SCREENWIDTH, HR_SCREENHEIGHT,
         0);
 


### PR DESCRIPTION
A superset of #738, also closing #724.

I'm not sure what you will think of this. It only addresses one more window than before, the libtextscreen windows are unaffected. I suspect that the business of creating the window and setting its properties should probably exist outside of all three existing window creation cases, and each phase should share the same window object, but that would involve a lot more reworking.
