### PR TITLE
fix mousewheel for sdl2 by synthesising button events

### DIFF
--- a/src/i_input.c
+++ b/src/i_input.c
@@ -360,40 +360,31 @@ static void MapMouseWheelToButtons(SDL_MouseWheelEvent *wheel)
     // SDL2 distinguishes button events from mouse wheel events.
     // We want to treat the mouse wheel as two buttons, as per
     // SDL1
-    event_t event1, event2;
-    int y = wheel->y;
+    event_t up, down;
     int button;
 
-#if !(SDL_MAJOR_VERSION == 2 && SDL_MINOR_VERSION == 0 && SDL_PATCHLEVEL < 4)
-    // Ignore OS axis inversion (so up is always up)
-    if (wheel->direction == SDL_MOUSEWHEEL_FLIPPED)
-    {
-        y *= -1;
-    }
-#endif
-
-    if (y <= 0)
+    if (wheel->y <= 0)
     {   // scroll down
-        button = 3;
+        button = 4;
     }
     else
     {   // scroll up
-        button = 4;
+        button = 3;
     }
 
     // post a button down event
     mouse_button_state |= (1 << button);
-    event1.type = ev_mouse;
-    event1.data1 = mouse_button_state;
-    event1.data2 = event1.data3 = 0;
-    D_PostEvent(&event1);
+    down.type = ev_mouse;
+    down.data1 = mouse_button_state;
+    down.data2 = down.data3 = 0;
+    D_PostEvent(&down);
 
     // post a button up event
     mouse_button_state &= ~(1 << button);
-    event2.type = ev_mouse;
-    event2.data1 = mouse_button_state;
-    event2.data2 = event2.data3 = 0;
-    D_PostEvent(&event2);
+    up.type = ev_mouse;
+    up.data1 = mouse_button_state;
+    up.data2 = up.data3 = 0;
+    D_PostEvent(&up);
 }
 
 void I_HandleMouseEvent(SDL_Event *sdlevent)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -418,6 +418,7 @@ void I_GetEvent(void)
 
             case SDL_MOUSEBUTTONDOWN:
             case SDL_MOUSEBUTTONUP:
+            case SDL_MOUSEWHEEL:
                 if (usemouse && !nomouse && window_focused)
                 {
                     I_HandleMouseEvent(&sdlevent);

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -531,6 +531,30 @@ static int SDLButtonToTXTButton(int button)
     }
 }
 
+// Convert an SDL wheel motion to a textscreen button index.
+
+static int SDLWheelToTXTButton(SDL_MouseWheelEvent *wheel)
+{
+    int y = wheel->y;
+
+#if !(SDL_MAJOR_VERSION == 2 && SDL_MINOR_VERSION == 0 && SDL_PATCHLEVEL < 4)
+    // Ignore OS axis inversion (so up is always up)
+    if (wheel->direction == SDL_MOUSEWHEEL_FLIPPED)
+    {
+        y *= -1;
+    }
+#endif
+
+    if (y <= 0)
+    {
+        return TXT_MOUSE_SCROLLDOWN;
+    }
+    else
+    {
+        return TXT_MOUSE_SCROLLUP;
+    }
+}
+
 static int MouseHasMoved(void)
 {
     static int last_x = 0, last_y = 0;
@@ -614,6 +638,9 @@ signed int TXT_GetChar(void)
                     return SDLButtonToTXTButton(ev.button.button);
                 }
                 break;
+
+            case SDL_MOUSEWHEEL:
+                return SDLWheelToTXTButton(&ev.wheel);
 
             case SDL_KEYDOWN:
                 UpdateModifierState(&ev.key.keysym, 1);

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -535,17 +535,7 @@ static int SDLButtonToTXTButton(int button)
 
 static int SDLWheelToTXTButton(SDL_MouseWheelEvent *wheel)
 {
-    int y = wheel->y;
-
-#if !(SDL_MAJOR_VERSION == 2 && SDL_MINOR_VERSION == 0 && SDL_PATCHLEVEL < 4)
-    // Ignore OS axis inversion (so up is always up)
-    if (wheel->direction == SDL_MOUSEWHEEL_FLIPPED)
-    {
-        y *= -1;
-    }
-#endif
-
-    if (y <= 0)
+    if (wheel->y <= 0)
     {
         return TXT_MOUSE_SCROLLDOWN;
     }


### PR DESCRIPTION
SDL2 treats mouse wheel events as different from buttons.

Assuming we want the wheel to emulate buttons as per SDL1,
map the mouse wheel events to buttons. Use the mappings in
textscreen (down = 3, up = 4).

Fixes #722.