### PR TITLE
Use SDL_GetPrefPath for the configuration directory.

### DIFF
--- a/man/default.cfg.template
+++ b/man/default.cfg.template
@@ -11,7 +11,9 @@ Extra Chocolate Doom-specific options are stored in a separate
 configuration file, \fBchocolate-doom.cfg\fR.
 .PP
 \fIdefault.cfg\fR is normally stored in the user's home directory,
-in \fI~/.chocolate-doom/default.cfg\fR.
+as \fI~/.local/share/chocolate-doom/default.cfg\fR.  The path can be
+overridden using the \fBXDG_DATA_HOME\fR environment variable (see the XDG
+Base Directory Specification).
 .PP
 The \fBchocolate-setup\fR(6) tool provides a simple to use front-end
 for editing \fIdefault.cfg\fR.

--- a/man/doom.template
+++ b/man/doom.template
@@ -18,10 +18,10 @@ behavior.
 @include environ.man
 .SH FILES
 .TP
-\fB$HOME/.chocolate-doom/default.cfg\fR
+\fB$HOME/.local/share/chocolate-doom/default.cfg\fR
 The main configuration file for Chocolate Doom.  See \fBdefault.cfg\fR(5).
 .TP
-\fB$HOME/.chocolate-doom/chocolate-doom.cfg\fR
+\fB$HOME/.local/share/chocolate-doom/chocolate-doom.cfg\fR
 Extra configuration values that are specific to Chocolate Doom and not
 present in Vanilla Doom.  See \fBchocolate-doom.cfg\fR(5).
 .SH SEE ALSO

--- a/man/extra.cfg.template
+++ b/man/extra.cfg.template
@@ -12,7 +12,9 @@ contains configuration options that are specific to Chocolate Doom
 only.
 .PP
 \fIchocolate-doom.cfg\fR is normally stored in the user's home directory,
-as \fI~/.chocolate-doom/chocolate-doom.cfg\fR.
+as \fI~/.local/share/chocolate-doom/chocolate-doom.cfg\fR.  The path can be
+overridden using the \fBXDG_DATA_HOME\fR environment variable (see the XDG
+Base Directory Specification).
 .PP
 The \fBchocolate-setup\fR(6) tool provides a simple to use front-end
 for editing \fIchocolate-doom.cfg\fR.

--- a/man/heretic.template
+++ b/man/heretic.template
@@ -19,10 +19,10 @@ behavior.
 @include environ.man
 .SH FILES
 .TP
-\fB$HOME/.chocolate-doom/heretic.cfg\fR
+\fB$HOME/.local/share/chocolate-doom/heretic.cfg\fR
 The main configuration file for Chocolate Heretic.  See \fBheretic.cfg\fR(5).
 .TP
-\fB$HOME/.chocolate-doom/chocolate-heretic.cfg\fR
+\fB$HOME/.local/share/chocolate-doom/chocolate-heretic.cfg\fR
 Extra configuration values that are specific to Chocolate Heretic and not
 present in Vanilla Heretic. See \fBchocolate-heretic.cfg\fR(5).
 .SH SEE ALSO

--- a/man/hexen.template
+++ b/man/hexen.template
@@ -19,10 +19,10 @@ behavior.
 @include environ.man
 .SH FILES
 .TP
-\fB$HOME/.chocolate-doom/hexen.cfg\fR
+\fB$HOME/.local/share/chocolate-doom/hexen.cfg\fR
 The main configuration file for Chocolate Hexen.  See \fBhexen.cfg\fR(5).
 .TP
-\fB$HOME/.chocolate-doom/chocolate-hexen.cfg\fR
+\fB$HOME/.local/share/chocolate-doom/chocolate-hexen.cfg\fR
 Extra configuration values that are specific to Chocolate Hexen and not
 present in Vanilla Hexen.  See \fBchocolate-hexen.cfg\fR(5).
 .SH SEE ALSO

--- a/man/strife.template
+++ b/man/strife.template
@@ -22,10 +22,10 @@ behavior.
 
 .SH FILES
 .TP
-\fB$HOME/.chocolate-doom/strife.cfg\fR
+\fB$HOME/.local/share/chocolate-doom/strife.cfg\fR
 The main configuration file for Chocolate Strife.  See \fBstrife.cfg\fR(5).
 .TP
-\fB$HOME/.chocolate-doom/chocolate-strife.cfg\fR
+\fB$HOME/.local/share/chocolate-doom/chocolate-strife.cfg\fR
 Extra configuration values that are specific to Chocolate Strife and not
 present in Vanilla Strife.  See \fBchocolate-strife.cfg\fR(5).
 .SH SEE ALSO

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -25,6 +25,8 @@
 #include <errno.h>
 #include <assert.h>
 
+#include "SDL_filesystem.h"
+
 #include "config.h"
 
 #include "doomtype.h"
@@ -2101,30 +2103,17 @@ static char *GetDefaultConfigDir(void)
 {
 #if !defined(_WIN32) || defined(_WIN32_WCE)
 
-    // Configuration settings are stored in ~/.chocolate-doom/,
-    // except on Windows, where we behave like Vanilla Doom and
-    // save in the current directory.
+    // Configuration settings are stored in an OS-appropriate path
+    // determined by SDL.  On typical Unix systems, this might be
+    // ~/.local/share/chocolate-doom.  On Windows, we behave like
+    // Vanilla Doom and save in the current directory.
 
-    char *homedir;
     char *result;
 
-    homedir = getenv("HOME");
-
-    if (homedir != NULL)
-    {
-        // put all configuration in a config directory off the
-        // homedir
-
-        result = M_StringJoin(homedir, DIR_SEPARATOR_S,
-                              "." PACKAGE_TARNAME, DIR_SEPARATOR_S, NULL);
-
-        return result;
-    }
-    else
+    result = SDL_GetPrefPath("", PACKAGE_TARNAME);
+    return result;
 #endif /* #ifndef _WIN32 */
-    {
-        return M_StringDuplicate("");
-    }
+    return M_StringDuplicate("");
 }
 
 // 
@@ -2176,12 +2165,12 @@ char *M_GetSaveGameDir(char *iwadname)
     }
     else
     {
-        // ~/.chocolate-doom/savegames
+        // ~/.local/share/chocolate-doom/savegames
 
         topdir = M_StringJoin(configdir, "savegames", NULL);
         M_MakeDirectory(topdir);
 
-        // eg. ~/.chocolate-doom/savegames/doom2.wad/
+        // eg. ~/.local/share/chocolate-doom/savegames/doom2.wad/
 
         savegamedir = M_StringJoin(topdir, DIR_SEPARATOR_S, iwadname,
                                    DIR_SEPARATOR_S, NULL);


### PR DESCRIPTION
The function requires two arguments: an organization name and an
application name.  Let’s set the organization name to an empty string.
This will not cause issues on POSIX-compliant systems, and hopefully
not on other kinds of systems too.  This just avoids an extra
directory to the configuration path.

This should pull Chocolate Doom into compliance with the XDG Base
Directory Specification, resolving #597.