### PR TITLE
Add CheckACSPresent and gracefully exit

### DIFF
--- a/src/hexen/p_acs.c
+++ b/src/hexen/p_acs.c
@@ -56,6 +56,8 @@ typedef struct
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
 
+void CheckACSPresent(int number);
+
 // PRIVATE FUNCTION PROTOTYPES ---------------------------------------------
 
 static void StartOpenACS(int number, int infoIndex, int *address);
@@ -783,6 +785,23 @@ static int GetACSIndex(int number)
         }
     }
     return -1;
+}
+
+//==========================================================================
+//
+// CheckACSPresent
+//
+// Placing Korax in a PWAD without extra steps will result in a crash in
+// Vanilla because the relevant ACS scripts are not initialised
+//
+//==========================================================================
+
+void CheckACSPresent(int number)
+{
+    if (GetACSIndex(number) == -1)
+    {
+        I_Error("Required ACS script %d not initialised", number);
+    }
 }
 
 //==========================================================================

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -4946,6 +4946,7 @@ void A_KoraxChase(mobj_t * actor)
             P_Teleport(actor, spot->x, spot->y, spot->angle, true);
         }
 
+        CheckACSPresent(249);
         P_StartACS(249, 0, args, actor, NULL, 0);
         actor->special2.i = 1;    // Don't run again
 
@@ -5023,6 +5024,7 @@ void A_KoraxBonePop(mobj_t * actor)
     if (mo)
         KSpiritInit(mo, actor);
 
+    CheckACSPresent(255);
     P_StartACS(255, 0, args, actor, NULL, 0);   // Death script
 }
 
@@ -5140,18 +5142,23 @@ void A_KoraxCommand(mobj_t * actor)
     switch (P_Random() % numcommands)
     {
         case 0:
+            CheckACSPresent(250);
             P_StartACS(250, 0, args, actor, NULL, 0);
             break;
         case 1:
+            CheckACSPresent(251);
             P_StartACS(251, 0, args, actor, NULL, 0);
             break;
         case 2:
+            CheckACSPresent(252);
             P_StartACS(252, 0, args, actor, NULL, 0);
             break;
         case 3:
+            CheckACSPresent(253);
             P_StartACS(253, 0, args, actor, NULL, 0);
             break;
         case 4:
+            CheckACSPresent(254);
             P_StartACS(254, 0, args, actor, NULL, 0);
             break;
     }

--- a/src/hexen/p_spec.h
+++ b/src/hexen/p_spec.h
@@ -546,6 +546,7 @@ void P_TagFinished(int tag);
 void P_PolyobjFinished(int po);
 void P_ACSInitNewGame(void);
 void P_CheckACSStore(void);
+void CheckACSPresent(int number);
 
 extern int ACScriptCount;
 extern byte *ActionCodeBase;


### PR DESCRIPTION
Seems to do the job for me, haven't checked the Wyvern yet though.

Commit message follows

----

Avoid a segfault if Korax is included in a PWAD without the proper
ACS/MAPINFO/etc stuff, instead exit via I_Error.

Fixes #761