### PR TITLE
Additional Heretic/Hexen demo support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
   * The vanilla limit of 4046 lumps per WAD is now enforced. (thanks
     Jon, Quasar, Edward-san)
   * Solidsegs overflow is emulated like in vanilla. (thanks Quasar)
+  * Heretic/Hexen demo support has expanded. "-demoextend" allows
+    demos to last longer than a single level; "-shortticfix" adjusts
+    low-resolution turning to match Doom's handling; "-maxdemo" and
+    "-longtics" support. (thanks CapnClever)
 
 ### Build systems
   * Improved compatibility with BSD Make. (thanks R.Rebello)

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1031,6 +1031,14 @@ void D_DoomMain(void)
         printf("Playing demo %s.\n", file);
     }
 
+    //!
+    // @category demo
+    //
+    // Record a high turning resolution demo.
+    //
+
+    longtics = M_CheckParm("-longtics") != 0;
+
     if (W_CheckNumForName(DEH_String("E2M1")) == -1)
     {
         gamemode = shareware;

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1037,7 +1037,7 @@ void D_DoomMain(void)
     // Record a high turning resolution demo.
     //
 
-    longtics = M_CheckParm("-longtics") != 0;
+    longtics = M_ParmExists("-longtics");
 
     //!
     // @category demo
@@ -1046,7 +1046,7 @@ void D_DoomMain(void)
     // after level exit.
     //
 
-    demoextend = M_CheckParm("-demoextend");
+    demoextend = M_ParmExists("-demoextend");
 
     if (W_CheckNumForName(DEH_String("E2M1")) == -1)
     {

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1039,6 +1039,15 @@ void D_DoomMain(void)
 
     longtics = M_CheckParm("-longtics") != 0;
 
+    //!
+    // @category demo
+    //
+    // Demo records and plays back without automatically quitting
+    // after level exit.
+    //
+
+    demoextend = M_CheckParm("-demoextend");
+
     if (W_CheckNumForName(DEH_String("E2M1")) == -1)
     {
         gamemode = shareware;

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1034,7 +1034,7 @@ void D_DoomMain(void)
     //!
     // @category demo
     //
-    // Record a high turning resolution demo.
+    // Record or playback a demo with high resolution turning.
     //
 
     longtics = M_ParmExists("-longtics");
@@ -1042,8 +1042,8 @@ void D_DoomMain(void)
     //!
     // @category demo
     //
-    // Demo records and plays back without automatically quitting
-    // after level exit.
+    // Record or playback a demo without automatically quitting
+    // after either level exit or player respawn.
     //
 
     demoextend = M_ParmExists("-demoextend");

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1034,14 +1034,6 @@ void D_DoomMain(void)
     //!
     // @category demo
     //
-    // Record or playback a demo with high resolution turning.
-    //
-
-    longtics = M_ParmExists("-longtics");
-
-    //!
-    // @category demo
-    //
     // Record or playback a demo without automatically quitting
     // after either level exit or player respawn.
     //

--- a/src/heretic/d_net.c
+++ b/src/heretic/d_net.c
@@ -115,9 +115,16 @@ static void LoadGameSettings(net_gamesettings_t *settings)
     startmap = settings->map;
     startskill = settings->skill;
     // TODO startloadgame = settings->loadgame;
+    lowres_turn = settings->lowres_turn;
     nomonsters = settings->nomonsters;
     respawnparm = settings->respawn_monsters;
     consoleplayer = settings->consoleplayer;
+
+    if (lowres_turn)
+    {
+        printf("NOTE: Turning resolution is reduced; this is probably "
+            "because there is a client recording a Vanilla demo.\n");
+    }
 
     for (i = 0; i < MAXPLAYERS; ++i)
     {
@@ -142,7 +149,9 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->nomonsters = nomonsters;
     settings->respawn_monsters = respawnparm;
     settings->timelimit = 0;
-    settings->lowres_turn = false;
+
+    settings->lowres_turn = M_CheckParm("-record") > 0
+                         && M_CheckParm("-longtics") == 0;
 }
 
 static void InitConnectData(net_connect_data_t *connect_data)
@@ -159,7 +168,10 @@ static void InitConnectData(net_connect_data_t *connect_data)
     connect_data->gamemode = gamemode;
     connect_data->gamemission = heretic;
 
-    connect_data->lowres_turn = false;
+    // Are we recording a demo? Possibly set lowres turn mode
+
+    connect_data->lowres_turn = M_CheckParm("-record") > 0
+                             && M_CheckParm("-longtics") == 0;
 
     // Read checksums of our WAD directory and dehacked information
 

--- a/src/heretic/d_net.c
+++ b/src/heretic/d_net.c
@@ -151,7 +151,7 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->timelimit = 0;
 
     settings->lowres_turn = M_ParmExists("-record")
-                        && !M_ParmExists("-longtics");
+                         && !M_ParmExists("-longtics");
 }
 
 static void InitConnectData(net_connect_data_t *connect_data)
@@ -171,7 +171,7 @@ static void InitConnectData(net_connect_data_t *connect_data)
     // Are we recording a demo? Possibly set lowres turn mode
 
     connect_data->lowres_turn = M_ParmExists("-record")
-                            && !M_ParmExists("-longtics");
+                             && !M_ParmExists("-longtics");
 
     // Read checksums of our WAD directory and dehacked information
 

--- a/src/heretic/d_net.c
+++ b/src/heretic/d_net.c
@@ -123,7 +123,7 @@ static void LoadGameSettings(net_gamesettings_t *settings)
     if (lowres_turn)
     {
         printf("NOTE: Turning resolution is reduced; this is probably "
-            "because there is a client recording a Vanilla demo.\n");
+               "because there is a client recording a Vanilla demo.\n");
     }
 
     for (i = 0; i < MAXPLAYERS; ++i)
@@ -150,8 +150,8 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->respawn_monsters = respawnparm;
     settings->timelimit = 0;
 
-    settings->lowres_turn = M_CheckParm("-record") > 0
-                         && M_CheckParm("-longtics") == 0;
+    settings->lowres_turn = M_ParmExists("-record")
+                        && !M_ParmExists("-longtics");
 }
 
 static void InitConnectData(net_connect_data_t *connect_data)

--- a/src/heretic/d_net.c
+++ b/src/heretic/d_net.c
@@ -170,8 +170,8 @@ static void InitConnectData(net_connect_data_t *connect_data)
 
     // Are we recording a demo? Possibly set lowres turn mode
 
-    connect_data->lowres_turn = M_CheckParm("-record") > 0
-                             && M_CheckParm("-longtics") == 0;
+    connect_data->lowres_turn = M_ParmExists("-record")
+                            && !M_ParmExists("-longtics");
 
     // Read checksums of our WAD directory and dehacked information
 

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -531,6 +531,7 @@ extern boolean lowres_turn; // Truncate angleturn in ticcmds to nearest 256.
                             // Used when recording Vanilla demos in netgames.
 extern boolean longtics;    // specifies 16-bit angleturn resolution in demos
 extern boolean demoplayback;
+extern boolean demoextend;      // allow demos to persist through exit/respawn
 extern int skytexture;
 
 extern gamestate_t gamestate;

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -527,6 +527,9 @@ extern boolean DebugSound;      // debug flag for displaying sound info
 extern int GetWeaponAmmo[NUMWEAPONS];
 
 extern boolean demorecording;
+extern boolean lowres_turn; // Truncate angleturn in ticcmds to nearest 256.
+                            // Used when recording Vanilla demos in netgames.
+extern boolean longtics;    // specifies 16-bit angleturn resolution in demos
 extern boolean demoplayback;
 extern int skytexture;
 

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -527,7 +527,6 @@ extern boolean DebugSound;      // debug flag for displaying sound info
 extern int GetWeaponAmmo[NUMWEAPONS];
 
 extern boolean demorecording;
-extern boolean longtics;        // specify high resolution turning in demos
 extern boolean demoplayback;
 extern boolean demoextend;      // allow demos to persist through exit/respawn
 extern int skytexture;

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -527,12 +527,14 @@ extern boolean DebugSound;      // debug flag for displaying sound info
 extern int GetWeaponAmmo[NUMWEAPONS];
 
 extern boolean demorecording;
-extern boolean lowres_turn; // Truncate angleturn in ticcmds to nearest 256.
-                            // Used when recording Vanilla demos in netgames.
-extern boolean longtics;    // specifies 16-bit angleturn resolution in demos
+extern boolean longtics;        // specify high resolution turning in demos
 extern boolean demoplayback;
 extern boolean demoextend;      // allow demos to persist through exit/respawn
 extern int skytexture;
+
+// Truncate angleturn in ticcmds to nearest 256.
+// Used when recording Vanilla demos in netgames.
+extern boolean lowres_turn;
 
 extern gamestate_t gamestate;
 extern skill_t gameskill;

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -114,6 +114,7 @@ boolean longtics;
 boolean lowres_turn;
 boolean shortticfix;        // properly calculates lowres turns like in doom
 boolean demoplayback;
+boolean demoextend;
 byte *demobuffer, *demo_p, *demoend;
 boolean singledemo;             // quit after playing a demo from cmdline
 
@@ -1322,7 +1323,7 @@ void G_DoReborn(int playernum)
 {
     int i;
 
-    if (G_CheckDemoStatus())
+    if (!demoextend && G_CheckDemoStatus()) // quit demo unless -demoextend
         return;
     if (!netgame)
         gameaction = ga_loadlevel;      // reload the level from scratch
@@ -1391,7 +1392,7 @@ void G_DoCompleted(void)
     static int afterSecret[5] = { 7, 5, 5, 5, 4 };
 
     gameaction = ga_nothing;
-    if (G_CheckDemoStatus())
+    if (!demoextend && G_CheckDemoStatus()) // quit demo unless -demoextend
     {
         return;
     }

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -112,7 +112,7 @@ char demoname[32];
 boolean demorecording;
 boolean longtics;
 boolean lowres_turn;
-boolean shortticfix;        // properly calculates lowres turns like in doom
+boolean shortticfix;            // calculate lowres turning like doom
 boolean demoplayback;
 boolean demoextend;
 byte *demobuffer, *demo_p, *demoend;
@@ -1746,9 +1746,9 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
     //!
     // @category demo
     //
-    // Smooths out low turning resolution when recording a demo.
+    // Smooth out low resolution turning when recording a demo.
     //
-    shortticfix = M_CheckParm("-shortticfix") != 0;
+    shortticfix = M_ParmExists("-shortticfix");
 
     G_InitNew(skill, episode, map);
     usergame = false;

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1322,7 +1322,8 @@ void G_DoReborn(int playernum)
 {
     int i;
 
-    if (!demoextend && G_CheckDemoStatus()) // quit demo unless -demoextend
+    // quit demo unless -demoextend
+    if (!demoextend && G_CheckDemoStatus())
         return;
     if (!netgame)
         gameaction = ga_loadlevel;      // reload the level from scratch
@@ -1391,7 +1392,9 @@ void G_DoCompleted(void)
     static int afterSecret[5] = { 7, 5, 5, 5, 4 };
 
     gameaction = ga_nothing;
-    if (!demoextend && G_CheckDemoStatus()) // quit demo unless -demoextend
+
+    // quit demo unless -demoextend
+    if (!demoextend && G_CheckDemoStatus())
     {
         return;
     }

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -112,6 +112,7 @@ char demoname[32];
 boolean demorecording;
 boolean longtics;
 boolean lowres_turn;
+boolean shortticfix;        // properly calculates lowres turns like in doom
 boolean demoplayback;
 byte *demobuffer, *demo_p, *demoend;
 boolean singledemo;             // quit after playing a demo from cmdline
@@ -628,9 +629,29 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     if (lowres_turn)
     {
-        // truncate angleturn to the nearest 256 boundary
-        // for recording demos with single byte values for turn
-        cmd->angleturn &= 0xff00;
+        if (shortticfix)
+        {
+            static signed short carry = 0;
+            signed short desired_angleturn;
+
+            desired_angleturn = cmd->angleturn + carry;
+
+            // round angleturn to the nearest 256 unit boundary
+            // for recording demos with single byte values for turn
+
+            cmd->angleturn = (desired_angleturn + 128) & 0xff00;
+
+            // Carry forward the error from the reduced resolution to the
+            // next tic, so that successive small movements can accumulate.
+
+            carry = desired_angleturn - cmd->angleturn;
+        }
+        else
+        {
+            // truncate angleturn to the nearest 256 boundary
+            // for recording demos with single byte values for turn
+            cmd->angleturn &= 0xff00;
+        }
     }
 }
 
@@ -1718,6 +1739,13 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
     // If not recording a longtics demo, record in low res
 
     lowres_turn = !longtics;
+
+    //!
+    // @category demo
+    //
+    // Smooths out low turning resolution when recording a demo.
+    //
+    shortticfix = M_CheckParm("-shortticfix") != 0;
 
     G_InitNew(skill, episode, map);
     usergame = false;

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -680,7 +680,6 @@ void G_DoLoadLevel(void)
 
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     displayplayer = consoleplayer;      // view the guy you are playing
-    starttime = I_GetTime();
     gameaction = ga_nothing;
     Z_CheckHeap();
 
@@ -1842,6 +1841,8 @@ void G_TimeDemo(char *name)
     }
 
     G_InitNew(skill, episode, map);
+    starttime = I_GetTime();
+
     usergame = false;
     demoplayback = true;
     timingdemo = true;

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -626,8 +626,6 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             BT_SPECIAL | BTS_SAVEGAME | (savegameslot << BTS_SAVESHIFT);
     }
 
-    // low-res turning
-
     if (lowres_turn)
     {
         if (shortticfix)

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1652,6 +1652,9 @@ void G_InitNew(skill_t skill, int episode, int map)
 */
 
 #define DEMOMARKER      0x80
+#define DEMOHEADER_RESPAWN    0x20
+#define DEMOHEADER_LONGTICS   0x10
+#define DEMOHEADER_NOMONSTERS 0x02
 
 void G_ReadDemoTiccmd(ticcmd_t * cmd)
 {
@@ -1791,16 +1794,17 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
     *demo_p = 1; // assume player one exists
     if (respawnparm)
     {
-        *demo_p += 32;
+        *demo_p |= DEMOHEADER_RESPAWN;
     }
     if (longtics)
     {
-        *demo_p += 16;
+        *demo_p |= DEMOHEADER_LONGTICS;
     }
     if (nomonsters)
     {
-        *demo_p += 2;
+        *demo_p |= DEMOHEADER_NOMONSTERS;
     }
+    demo_p++;
     demo_p++;
 
     for (i = 1; i < MAXPLAYERS; i++)
@@ -1838,12 +1842,12 @@ void G_DoPlayDemo(void)
     map = *demo_p++;
 
     // Read special parameter bits: see G_RecordDemo() for details.
-    respawnparm = *demo_p & 32;
-    longtics    = *demo_p & 16;
-    nomonsters  = *demo_p & 2;
+    respawnparm = (*demo_p & DEMOHEADER_RESPAWN) != 0;
+    longtics    = (*demo_p & DEMOHEADER_LONGTICS) != 0;
+    nomonsters  = (*demo_p & DEMOHEADER_NOMONSTERS) != 0;
 
     for (i = 0; i < MAXPLAYERS; i++)
-        playeringame[i] = *demo_p++;
+        playeringame[i] = (*demo_p++) != 0;
 
     precache = false;           // don't spend a lot of time in loadlevel
     G_InitNew(skill, episode, map);
@@ -1872,13 +1876,13 @@ void G_TimeDemo(char *name)
     map = *demo_p++;
 
     // Read special parameter bits: see G_RecordDemo() for details.
-    respawnparm = *demo_p & 32;
-    longtics    = *demo_p & 16;
-    nomonsters  = *demo_p & 2;
+    respawnparm = (*demo_p & DEMOHEADER_RESPAWN) != 0;
+    longtics    = (*demo_p & DEMOHEADER_LONGTICS) != 0;
+    nomonsters  = (*demo_p & DEMOHEADER_NOMONSTERS) != 0;
 
     for (i = 0; i < MAXPLAYERS; i++)
     {
-        playeringame[i] = *demo_p++;
+        playeringame[i] = (*demo_p++) != 0;
     }
 
     G_InitNew(skill, episode, map);

--- a/src/hexen/d_net.c
+++ b/src/hexen/d_net.c
@@ -181,8 +181,8 @@ static void InitConnectData(net_connect_data_t *connect_data)
 
     // Are we recording a demo? Possibly set lowres turn mode
 
-    connect_data->lowres_turn = M_CheckParm("-record") > 0
-                             && M_CheckParm("-longtics") == 0;
+    connect_data->lowres_turn = M_ParmExists("-record")
+                            && !M_ParmExists("-longtics");
 
     connect_data->drone = false;
     connect_data->max_players = maxplayers;

--- a/src/hexen/d_net.c
+++ b/src/hexen/d_net.c
@@ -116,9 +116,16 @@ static void LoadGameSettings(net_gamesettings_t *settings)
     startmap = settings->map;
     startskill = settings->skill;
     // TODO startloadgame = settings->loadgame;
+    lowres_turn = settings->lowres_turn;
     nomonsters = settings->nomonsters;
     respawnparm = settings->respawn_monsters;
     consoleplayer = settings->consoleplayer;
+
+    if (lowres_turn)
+    {
+        printf("NOTE: Turning resolution is reduced; this is probably "
+            "because there is a client recording a Vanilla demo.\n");
+    }
 
     for (i=0; i<maxplayers; ++i)
     {
@@ -154,7 +161,9 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->nomonsters = nomonsters;
     settings->respawn_monsters = respawnparm;
     settings->timelimit = 0;
-    settings->lowres_turn = false;
+
+    settings->lowres_turn = M_CheckParm("-record") > 0
+                         && M_CheckParm("-longtics") == 0;
 }
 
 static void InitConnectData(net_connect_data_t *connect_data)
@@ -170,7 +179,11 @@ static void InitConnectData(net_connect_data_t *connect_data)
     connect_data->gamemode = gamemode;
     connect_data->gamemission = hexen;
 
-    connect_data->lowres_turn = false;
+    // Are we recording a demo? Possibly set lowres turn mode
+
+    connect_data->lowres_turn = M_CheckParm("-record") > 0
+                             && M_CheckParm("-longtics") == 0;
+
     connect_data->drone = false;
     connect_data->max_players = maxplayers;
 

--- a/src/hexen/d_net.c
+++ b/src/hexen/d_net.c
@@ -163,7 +163,7 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->timelimit = 0;
 
     settings->lowres_turn = M_ParmExists("-record")
-                        && !M_ParmExists("-longtics");
+                         && !M_ParmExists("-longtics");
 }
 
 static void InitConnectData(net_connect_data_t *connect_data)
@@ -182,7 +182,7 @@ static void InitConnectData(net_connect_data_t *connect_data)
     // Are we recording a demo? Possibly set lowres turn mode
 
     connect_data->lowres_turn = M_ParmExists("-record")
-                            && !M_ParmExists("-longtics");
+                             && !M_ParmExists("-longtics");
 
     connect_data->drone = false;
     connect_data->max_players = maxplayers;

--- a/src/hexen/d_net.c
+++ b/src/hexen/d_net.c
@@ -124,7 +124,7 @@ static void LoadGameSettings(net_gamesettings_t *settings)
     if (lowres_turn)
     {
         printf("NOTE: Turning resolution is reduced; this is probably "
-            "because there is a client recording a Vanilla demo.\n");
+               "because there is a client recording a Vanilla demo.\n");
     }
 
     for (i=0; i<maxplayers; ++i)
@@ -162,8 +162,8 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->respawn_monsters = respawnparm;
     settings->timelimit = 0;
 
-    settings->lowres_turn = M_CheckParm("-record") > 0
-                         && M_CheckParm("-longtics") == 0;
+    settings->lowres_turn = M_ParmExists("-record")
+                        && !M_ParmExists("-longtics");
 }
 
 static void InitConnectData(net_connect_data_t *connect_data)

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -95,7 +95,7 @@ char demoname[32];
 boolean demorecording;
 boolean longtics;
 boolean lowres_turn;
-boolean shortticfix;        // properly calculates lowres turns like in doom
+boolean shortticfix;            // calculate lowres turning like doom
 boolean demoplayback;
 boolean demoextend;
 byte *demobuffer, *demo_p, *demoend;
@@ -1903,9 +1903,9 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
     //!
     // @category demo
     //
-    // Smooths out low turning resolution when recording a demo.
+    // Smooth out low resolution turning when recording a demo.
     //
-    shortticfix = M_CheckParm("-shortticfix") != 0;
+    shortticfix = M_ParmExists("-shortticfix");
 
     lowres_turn = !longtics;
 

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -1325,7 +1325,8 @@ void G_DoReborn(int playernum)
     boolean foundSpot;
     int bestWeapon;
 
-    if (!demoextend && G_CheckDemoStatus()) // quit demo unless -demoextend
+    // quit demo unless -demoextend
+    if (!demoextend && G_CheckDemoStatus())
     {
         return;
     }
@@ -1520,7 +1521,9 @@ void G_DoCompleted(void)
     int i;
 
     gameaction = ga_nothing;
-    if (!demoextend && G_CheckDemoStatus()) // quit demo unless -demoextend
+
+    // quit demo unless -demoextend
+    if (!demoextend && G_CheckDemoStatus())
     {
         return;
     }
@@ -1771,9 +1774,11 @@ void G_InitNew(skill_t skill, int episode, int map)
     }
 
     // Set up a bunch of globals
-    if (!demoextend) // this prevents map-loading from stopping the demo
-    {                // demoextend is set back to false only if starting a
-                     //  new game or loading a saved one during playback
+    if (!demoextend)
+    {
+        // This prevents map-loading from interrupting a demo.
+        // demoextend is set back to false only if starting a new game or
+        // loading a saved one from the menu, and only during playback.
         demorecording = false;
         demoplayback = false;
         usergame = true;            // will be set false if a demo

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -627,8 +627,6 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             BT_SPECIAL | BTS_SAVEGAME | (savegameslot << BTS_SAVESHIFT);
     }
 
-    // low-res turning
-
     if (lowres_turn)
     {
         if (shortticfix)

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -1811,6 +1811,9 @@ void G_InitNew(skill_t skill, int episode, int map)
 */
 
 #define DEMOMARKER      0x80
+#define DEMOHEADER_RESPAWN    0x20
+#define DEMOHEADER_LONGTICS   0x10
+#define DEMOHEADER_NOMONSTERS 0x02
 
 void G_ReadDemoTiccmd(ticcmd_t * cmd)
 {
@@ -1951,15 +1954,15 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
     *demo_p = 1; // assume player one exists
     if (respawnparm)
     {
-        *demo_p += 32;
+        *demo_p |= DEMOHEADER_RESPAWN;
     }
     if (longtics)
     {
-        *demo_p += 16;
+        *demo_p |= DEMOHEADER_LONGTICS;
     }
     if (nomonsters)
     {
-        *demo_p += 2;
+        *demo_p |= DEMOHEADER_NOMONSTERS;
     }
     demo_p++;
     *demo_p++ = PlayerClass[0];
@@ -2002,13 +2005,13 @@ void G_DoPlayDemo(void)
     map = *demo_p++;
 
     // Read special parameter bits: see G_RecordDemo() for details.
-    respawnparm = *demo_p & 32;
-    longtics    = *demo_p & 16;
-    nomonsters  = *demo_p & 2;
+    respawnparm = (*demo_p & DEMOHEADER_RESPAWN) != 0;
+    longtics    = (*demo_p & DEMOHEADER_LONGTICS) != 0;
+    nomonsters  = (*demo_p & DEMOHEADER_NOMONSTERS) != 0;
 
     for (i = 0; i < maxplayers; i++)
     {
-        playeringame[i] = *demo_p++;
+        playeringame[i] = (*demo_p++) != 0;
         PlayerClass[i] = *demo_p++;
     }
 
@@ -2042,13 +2045,13 @@ void G_TimeDemo(char *name)
     map = *demo_p++;
 
     // Read special parameter bits: see G_RecordDemo() for details.
-    respawnparm = *demo_p & 32;
-    longtics    = *demo_p & 16;
-    nomonsters  = *demo_p & 2;
+    respawnparm = (*demo_p & DEMOHEADER_RESPAWN) != 0;
+    longtics    = (*demo_p & DEMOHEADER_LONGTICS) != 0;
+    nomonsters  = (*demo_p & DEMOHEADER_NOMONSTERS) != 0;
 
     for (i = 0; i < maxplayers; i++)
     {
-        playeringame[i] = *demo_p++;
+        playeringame[i] = (*demo_p++) != 0;
         PlayerClass[i] = *demo_p++;
     }
 

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -97,6 +97,7 @@ boolean longtics;
 boolean lowres_turn;
 boolean shortticfix;        // properly calculates lowres turns like in doom
 boolean demoplayback;
+boolean demoextend;
 byte *demobuffer, *demo_p, *demoend;
 boolean singledemo;             // quit after playing a demo from cmdline
 
@@ -1325,7 +1326,7 @@ void G_DoReborn(int playernum)
     boolean foundSpot;
     int bestWeapon;
 
-    if (G_CheckDemoStatus())
+    if (!demoextend && G_CheckDemoStatus()) // quit demo unless -demoextend
     {
         return;
     }
@@ -1520,7 +1521,7 @@ void G_DoCompleted(void)
     int i;
 
     gameaction = ga_nothing;
-    if (G_CheckDemoStatus())
+    if (!demoextend && G_CheckDemoStatus()) // quit demo unless -demoextend
     {
         return;
     }
@@ -1771,10 +1772,14 @@ void G_InitNew(skill_t skill, int episode, int map)
     }
 
     // Set up a bunch of globals
-    usergame = true;            // will be set false if a demo
+    if (!demoextend) // this prevents map-loading from stopping the demo
+    {                // demoextend is set back to false only if starting a
+                     //  new game or loading a saved one during playback
+        demorecording = false;
+        demoplayback = false;
+        usergame = true;            // will be set false if a demo
+    }
     paused = false;
-    demorecording = false;
-    demoplayback = false;
     viewactive = true;
     gameepisode = episode;
     gamemap = map;

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -23,6 +23,7 @@
 #include "i_video.h"
 #include "i_system.h"
 #include "i_timer.h"
+#include "m_argv.h"
 #include "m_controls.h"
 #include "m_misc.h"
 #include "p_local.h"
@@ -93,7 +94,7 @@ int levelstarttic;              // gametic at level start
 char demoname[32];
 boolean demorecording;
 boolean demoplayback;
-byte *demobuffer, *demo_p;
+byte *demobuffer, *demo_p, *demoend;
 boolean singledemo;             // quit after playing a demo from cmdline
 
 boolean precache = true;        // if true, load all graphics at start
@@ -1798,6 +1799,14 @@ void G_WriteDemoTiccmd(ticcmd_t * cmd)
     *demo_p++ = cmd->lookfly;
     *demo_p++ = cmd->arti;
     demo_p -= 6;
+
+    if (demo_p > demoend - 16)
+    {
+        // no more space
+        G_CheckDemoStatus();
+        return;
+    }
+
     G_ReadDemoTiccmd(cmd);      // make SURE it is exactly the same
 }
 
@@ -1815,12 +1824,29 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
                   char *name)
 {
     int i;
+    int maxsize;
 
     G_InitNew(skill, episode, map);
     usergame = false;
     M_StringCopy(demoname, name, sizeof(demoname));
     M_StringConcat(demoname, ".lmp", sizeof(demoname));
-    demobuffer = demo_p = Z_Malloc(0x20000, PU_STATIC, NULL);
+    maxsize = 0x20000;
+
+    //!
+    // @arg <size>
+    // @category demo
+    // @vanilla
+    //
+    // Specify the demo buffer size (KiB)
+    //
+
+    i = M_CheckParmWithArgs("-maxdemo", 1);
+    if (i)
+        maxsize = atoi(myargv[i + 1]) * 1024;
+    demobuffer = Z_Malloc(maxsize, PU_STATIC, NULL);
+    demoend = demobuffer + maxsize;
+
+    demo_p = demobuffer;
     *demo_p++ = skill;
     *demo_p++ = episode;
     *demo_p++ = map;
@@ -1830,6 +1856,7 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
         *demo_p++ = playeringame[i];
         *demo_p++ = PlayerClass[i];
     }
+
     demorecording = true;
 }
 

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -93,6 +93,8 @@ int levelstarttic;              // gametic at level start
 
 char demoname[32];
 boolean demorecording;
+boolean longtics;
+boolean lowres_turn;
 boolean demoplayback;
 byte *demobuffer, *demo_p, *demoend;
 boolean singledemo;             // quit after playing a demo from cmdline
@@ -621,6 +623,15 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         sendsave = false;
         cmd->buttons =
             BT_SPECIAL | BTS_SAVEGAME | (savegameslot << BTS_SAVESHIFT);
+    }
+
+    // low-res turning
+
+    if (lowres_turn)
+    {
+        // truncate angleturn to the nearest 256 boundary
+        // for recording demos with single byte values for turn
+        cmd->angleturn &= 0xff00;
     }
 }
 
@@ -1782,7 +1793,19 @@ void G_ReadDemoTiccmd(ticcmd_t * cmd)
     }
     cmd->forwardmove = ((signed char) *demo_p++);
     cmd->sidemove = ((signed char) *demo_p++);
-    cmd->angleturn = ((unsigned char) *demo_p++) << 8;
+
+    // If this is a longtics demo, read back in higher resolution
+
+    if (longtics)
+    {
+        cmd->angleturn = *demo_p++;
+        cmd->angleturn |= (*demo_p++) << 8;
+    }
+    else
+    {
+        cmd->angleturn = ((unsigned char) *demo_p++) << 8;
+    }
+
     cmd->buttons = (unsigned char) *demo_p++;
     cmd->lookfly = (unsigned char) *demo_p++;
     cmd->arti = (unsigned char) *demo_p++;
@@ -1790,15 +1813,34 @@ void G_ReadDemoTiccmd(ticcmd_t * cmd)
 
 void G_WriteDemoTiccmd(ticcmd_t * cmd)
 {
+    byte *demo_start;
+
     if (gamekeydown[key_demo_quit]) // press to end demo recording
         G_CheckDemoStatus();
+
+    demo_start = demo_p;
+
     *demo_p++ = cmd->forwardmove;
     *demo_p++ = cmd->sidemove;
-    *demo_p++ = cmd->angleturn >> 8;
+
+    // If this is a longtics demo, record in higher resolution
+
+    if (longtics)
+    {
+        *demo_p++ = (cmd->angleturn & 0xff);
+        *demo_p++ = (cmd->angleturn >> 8) & 0xff;
+    }
+    else
+    {
+        *demo_p++ = cmd->angleturn >> 8;
+    }
+
     *demo_p++ = cmd->buttons;
     *demo_p++ = cmd->lookfly;
     *demo_p++ = cmd->arti;
-    demo_p -= 6;
+
+    // reset demo pointer back
+    demo_p = demo_start;
 
     if (demo_p > demoend - 16)
     {
@@ -1825,6 +1867,10 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
 {
     int i;
     int maxsize;
+
+    // If not recording a longtics demo, record in low res
+
+    lowres_turn = !longtics;
 
     G_InitNew(skill, episode, map);
     usergame = false;

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -682,7 +682,6 @@ void G_DoLoadLevel(void)
     SN_StopAllSequences();
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     displayplayer = consoleplayer;      // view the guy you are playing   
-    starttime = I_GetTime();
     gameaction = ga_nothing;
     Z_CheckHeap();
 
@@ -2009,6 +2008,8 @@ void G_TimeDemo(char *name)
     }
 
     G_InitNew(skill, episode, map);
+    starttime = I_GetTime();
+
     usergame = false;
     demoplayback = true;
     timingdemo = true;

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -676,6 +676,14 @@ static void HandleArgs(void)
         ST_Message("Playing demo %s.\n", myargv[p+1]);
     }
 
+    //!
+    // @category demo
+    //
+    // Record a high turning resolution demo.
+    //
+
+    longtics = M_CheckParm("-longtics") != 0;
+
     if (M_ParmExists("-testcontrols"))
     {
         autostart = true;

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -682,7 +682,7 @@ static void HandleArgs(void)
     // Record a high turning resolution demo.
     //
 
-    longtics = M_CheckParm("-longtics") != 0;
+    longtics = M_ParmExists("-longtics");
 
     //!
     // @category demo
@@ -691,7 +691,7 @@ static void HandleArgs(void)
     // after level exit.
     //
 
-    demoextend = M_CheckParm("-demoextend");
+    demoextend = M_ParmExists("-demoextend");
 
     if (M_ParmExists("-testcontrols"))
     {

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -679,14 +679,6 @@ static void HandleArgs(void)
     //!
     // @category demo
     //
-    // Record or playback a demo with high resolution turning.
-    //
-
-    longtics = M_ParmExists("-longtics");
-
-    //!
-    // @category demo
-    //
     // Record or playback a demo without automatically quitting
     // after either level exit or player respawn.
     //

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -684,6 +684,15 @@ static void HandleArgs(void)
 
     longtics = M_CheckParm("-longtics") != 0;
 
+    //!
+    // @category demo
+    //
+    // Demo records and plays back without automatically quitting
+    // after level exit.
+    //
+
+    demoextend = M_CheckParm("-demoextend");
+
     if (M_ParmExists("-testcontrols"))
     {
         autostart = true;

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -679,7 +679,7 @@ static void HandleArgs(void)
     //!
     // @category demo
     //
-    // Record a high turning resolution demo.
+    // Record or playback a demo with high resolution turning.
     //
 
     longtics = M_ParmExists("-longtics");
@@ -687,8 +687,8 @@ static void HandleArgs(void)
     //!
     // @category demo
     //
-    // Demo records and plays back without automatically quitting
-    // after level exit.
+    // Record or playback a demo without automatically quitting
+    // after either level exit or player respawn.
     //
 
     demoextend = M_ParmExists("-demoextend");

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -632,12 +632,14 @@ extern player_t players[MAXPLAYERS];
 
 extern boolean DebugSound;      // debug flag for displaying sound info
 
-extern boolean lowres_turn; // Truncate angleturn in ticcmds to nearest 256.
-                            // Used when recording Vanilla demos in netgames.
-extern boolean longtics;    // specifies 16-bit angleturn resolution in demos
+extern boolean longtics;        // specify high resolution turning in demos
 extern boolean demoplayback;
 extern boolean demoextend;      // allow demos to persist through exit/respawn
 extern int maxzone;             // Maximum chunk allocated for zone heap
+
+// Truncate angleturn in ticcmds to nearest 256.
+// Used when recording Vanilla demos in netgames.
+extern boolean lowres_turn;
 
 extern int Sky1Texture;
 extern int Sky2Texture;

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -636,6 +636,7 @@ extern boolean lowres_turn; // Truncate angleturn in ticcmds to nearest 256.
                             // Used when recording Vanilla demos in netgames.
 extern boolean longtics;    // specifies 16-bit angleturn resolution in demos
 extern boolean demoplayback;
+extern boolean demoextend;      // allow demos to persist through exit/respawn
 extern int maxzone;             // Maximum chunk allocated for zone heap
 
 extern int Sky1Texture;

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -632,6 +632,9 @@ extern player_t players[MAXPLAYERS];
 
 extern boolean DebugSound;      // debug flag for displaying sound info
 
+extern boolean lowres_turn; // Truncate angleturn in ticcmds to nearest 256.
+                            // Used when recording Vanilla demos in netgames.
+extern boolean longtics;    // specifies 16-bit angleturn resolution in demos
 extern boolean demoplayback;
 extern int maxzone;             // Maximum chunk allocated for zone heap
 

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -632,7 +632,6 @@ extern player_t players[MAXPLAYERS];
 
 extern boolean DebugSound;      // debug flag for displaying sound info
 
-extern boolean longtics;        // specify high resolution turning in demos
 extern boolean demoplayback;
 extern boolean demoextend;      // allow demos to persist through exit/respawn
 extern int maxzone;             // Maximum chunk allocated for zone heap

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -130,6 +130,7 @@ boolean MenuActive;
 int InfoType;
 int messageson = true;
 boolean mn_SuicideConsole;
+boolean demoextend; // from h2def.h
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 
@@ -895,6 +896,10 @@ static void SCNetCheck2(int option)
 
 static void SCLoadGame(int option)
 {
+    if (demoplayback)
+    {
+        demoextend = false;
+    }
     if (!SlotStatus[option])
     {                           // Don't try to load from an empty slot
         return;
@@ -1003,6 +1008,11 @@ static void SCClass(int option)
 
 static void SCSkill(int option)
 {
+    if (demoplayback)
+    {
+        demoextend = false;
+    }
+
     PlayerClass[consoleplayer] = MenuPClass;
     G_DeferredNewGame(option);
     SB_SetClassData();

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -898,6 +898,7 @@ static void SCLoadGame(int option)
 {
     if (demoplayback)
     {
+        // deactivate playback, return control to player
         demoextend = false;
     }
     if (!SlotStatus[option])
@@ -1010,6 +1011,7 @@ static void SCSkill(int option)
 {
     if (demoplayback)
     {
+        // deactivate playback, return control to player
         demoextend = false;
     }
 


### PR DESCRIPTION
Resolves #432 . I'll paste the summary of what I there:

* `-maxdemo` support is added.
* `-timedemo` was fixed to count realtics starting from the beginning of playback rather than the start of the map. It didn't matter before because you couldn't play back demos with more than one level anyway.
* `-longtics` and corresponding "lowres_turn" compatibility was added. This also fixed up network game consistency problems when some players record demos and others don't.
* New command `-demoextend` allows a demo to continue after a level exit or after a player respawn. Hexen required some additional code to prevent recording and playback to suddenly stop whenever a map loads, but I tried to be as minimally intrusive with respect to functionality as possible.
* New command `-shortticfix` smooths out the mouse when recording with lowres turning, equivalent to Doom's handling. Heretic/Hexen lacks code that correctly manages shorttic turning resolution, and by default the turning control is incredibly sensitive to the right and difficult to finely adjust to the left.

The only piece I didn't include was "unlimited demo size" support. Since Heretic and Hexen are also missing the unlimited savegame size support as well, I decided to leave it for a separate implementation (as a partial implementation of the Compatibility features would needlessly complicate chocolate-setup compared to adding them together).

For anyone who already pulled in these changes earlier, I amended NEWS.md to the last commit so be aware of that tiny conflict.

EDIT: Accidentally referenced the wrong issue.