### PR TITLE
Fix network player name binding in Heretic/Hexen

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -755,6 +755,10 @@ void D_BindVariables(void)
     M_BindMenuControls();
     M_BindMapControls();
 
+#ifdef FEATURE_MULTIPLAYER
+    NET_BindVariables();
+#endif
+
     M_BindIntVariable("mouse_sensitivity",      &mouseSensitivity);
     M_BindIntVariable("sfx_volume",             &snd_MaxVolume);
     M_BindIntVariable("music_volume",           &snd_MusicVolume);

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -150,6 +150,10 @@ void D_BindVariables(void)
     key_multi_msgplayer[6] = CT_KEY_PLAYER7;
     key_multi_msgplayer[7] = CT_KEY_PLAYER8;
 
+#ifdef FEATURE_MULTIPLAYER
+    NET_BindVariables();
+#endif
+
     M_BindIntVariable("graphical_startup",      &graphical_startup);
     M_BindIntVariable("mouse_sensitivity",      &mouseSensitivity);
     M_BindIntVariable("sfx_volume",             &snd_MaxVolume);


### PR DESCRIPTION
Resolves #612.

The player_name config variable only appeared as a result of starting/joining a network game: the addition of this function (which is just a copy-paste from Doom's equivalent file) ensures that the variable persists between sessions and regardless of the type of game.