### PR TITLE
Emulate Doom2 map33 behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
     temporary directory and reporting an error instead.  (thanks
     terrorcide)
   * Versions 1.666, 1.7, and 1.8 are emulated. (thanks Nuke.YKT)
+  * Map33 intermission screen and map33-map35 automap names are
+    emulated. (thanks CapnClever)
 
 ### Heretic
   * Added map names for Episode 6, fixing a crash after completing a

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1455,15 +1455,30 @@ void G_DoCompleted (void)
     wminfo.maxsecret = totalsecret; 
     wminfo.maxfrags = 0; 
 
-    // Set par time. Doom episode 4 doesn't have a par time, so this
-    // overflows into the cpars array. It's necessary to emulate this
-    // for statcheck regression testing.
+    // Set par time. Exceptions are added for purposes of
+    // statcheck regression testing.
     if (gamemode == commercial)
-	wminfo.partime = TICRATE*cpars[gamemap-1];
+    {
+        // map33 has no official time: initialize to zero
+        if (gamemap == 33)
+        {
+            wminfo.partime = 0;
+        }
+        else
+        {
+            wminfo.partime = TICRATE*cpars[gamemap-1];
+        }
+    }
+    // Doom episode 4 doesn't have a par time, so this
+    // overflows into the cpars array.
     else if (gameepisode < 4)
-	wminfo.partime = TICRATE*pars[gameepisode][gamemap];
+    {
+        wminfo.partime = TICRATE*pars[gameepisode][gamemap];
+    }
     else
+    {
         wminfo.partime = TICRATE*cpars[gamemap];
+    }
 
     wminfo.pnum = consoleplayer; 
  

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -335,6 +335,12 @@ char *mapnames_commercial[] =
     THUSTR_30,
     THUSTR_31,
     THUSTR_32
+
+    // Emulation: TNT maps 33-35 can be warped to and played if they exist
+    // so include blank names instead of spilling over
+    "",
+    "",
+    ""
 };
 
 void HU_Init(void)
@@ -393,6 +399,11 @@ void HU_Start(void)
 	break;
       case doom2:
 	 s = HU_TITLE2;
+         // Pre-Final Doom compatibility: map33-map35 names don't spill over
+         if (gameversion <= exe_doom_1_9 && gamemap >= 33)
+         {
+             s = "";
+         }
 	 break;
       case pack_plut:
 	s = HU_TITLEP;

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -430,7 +430,8 @@ void WI_drawLF(void)
     }
     else if (wbs->last == NUMCMAPS)
     {
-        // MAP33 - nothing is displayed!
+        // MAP33 - draw "Finished!" only
+        V_DrawPatch((SCREENWIDTH - SHORT(finished->width)) / 2, y, finished);
     }
     else if (wbs->last > NUMCMAPS)
     {
@@ -1472,8 +1473,13 @@ void WI_drawStats(void)
 
     if (wbs->epsd < 3)
     {
-	V_DrawPatch(SCREENWIDTH/2 + SP_TIMEX, SP_TIMEY, par);
-	WI_drawTime(SCREENWIDTH - SP_TIMEX, SP_TIMEY, cnt_par);
+        V_DrawPatch(SCREENWIDTH/2 + SP_TIMEX, SP_TIMEY, par);
+
+        // Emulation: don't draw partime value if map33
+        if (gamemode != commercial || wbs->last != NUMCMAPS)
+        {
+            WI_drawTime(SCREENWIDTH - SP_TIMEX, SP_TIMEY, cnt_par);
+        }
     }
 
 }


### PR DESCRIPTION
Resolves #157 in the following way:

* In DOSBox, automap names are blank in Doom2 and TNT map33, map34, and map35; automap names in Plutonia map33-35 are equivalent to TNT's map01-03. The former is now emulated in Chocolate Doom, as the latter worked accurately prior to changes. (Presumably on a DOS machine the automap names would be junk data, as per the initial report, but unless there's a good way to emulate that, I considered this a reasonable solution.)
* Map33's intermission screen now displays a "FINISHED" on the first line, and no partime value is displayed. (As with the automap issue, DOSBox chooses to set the partime value to zero so I have copied that: otherwise the ticker increases until it hits "SUCKS", and on a DOS machine it could range anywhere between the two.)

Here's the before and after of the map33 intermission screen, with the second image identical to how it appears in vanilla:
![choco-doom-map33-before](https://cloud.githubusercontent.com/assets/8853201/20084187/b74fd710-a52e-11e6-84e1-1bcda30a323b.png)
![choco-doom-map33-after](https://cloud.githubusercontent.com/assets/8853201/20084192/bafa0156-a52e-11e6-9c19-d247e4339fe1.png)