### PR TITLE
v_video.c: Enhance V_DrawMouseSpeedBox in non-acceleration cases

### DIFF
--- a/src/v_video.c
+++ b/src/v_video.c
@@ -867,6 +867,18 @@ void V_ScreenShot(char *format)
 #define MOUSE_SPEED_BOX_WIDTH  120
 #define MOUSE_SPEED_BOX_HEIGHT 9
 
+//
+// V_DrawMouseSpeedBox
+//
+
+// If box is only to calibrate speed, testing relative speed (as a measure
+// of game pixels to movement units) is important whether physical mouse DPI
+// is high or low. Line resolution starts at 1 pixel per 1 move-unit: if
+// line maxes out, resolution becomes 1 pixel per 2 move-units, then per
+// 3 move-units, etc.
+
+static int linelen_multiplier = 1;
+
 void V_DrawMouseSpeedBox(int speed)
 {
     extern int usemouse;
@@ -875,6 +887,8 @@ void V_DrawMouseSpeedBox(int speed)
     int original_speed;
     int redline_x;
     int linelen;
+    int i;
+    boolean draw_acceleration = false;
 
     // Get palette indices for colors for widget. These depend on the
     // palette of the game being played.
@@ -886,12 +900,17 @@ void V_DrawMouseSpeedBox(int speed)
     yellow = I_GetPaletteIndex(0xff, 0xff, 0x00);
     white = I_GetPaletteIndex(0xff, 0xff, 0xff);
 
-    // If the mouse is turned off or acceleration is turned off, don't
-    // draw the box at all.
-
-    if (!usemouse || fabs(mouse_acceleration - 1) < 0.01)
+    // If the mouse is turned off, don't draw the box at all.
+    if (!usemouse)
     {
         return;
+    }
+
+    // If acceleration is used, draw a box that helps to calibrate the
+    // threshold point.
+    if (mouse_threshold > 0 && fabs(mouse_acceleration - 1) > 0.01)
+    {
+        draw_acceleration = true;
     }
 
     // Calculate box position
@@ -904,41 +923,44 @@ void V_DrawMouseSpeedBox(int speed)
     V_DrawBox(box_x, box_y,
               MOUSE_SPEED_BOX_WIDTH, MOUSE_SPEED_BOX_HEIGHT, bordercolor);
 
-    // Calculate the position of the red line.  This is 1/3 of the way
-    // along the box.
+    // Calculate the position of the red threshold line when calibrating
+    // acceleration.  This is 1/3 of the way along the box.
 
     redline_x = MOUSE_SPEED_BOX_WIDTH / 3;
 
-    // Undo acceleration and get back the original mouse speed
+    // Calculate line length
 
-    if (speed < mouse_threshold)
+    if (draw_acceleration && speed >= mouse_threshold)
     {
-        original_speed = speed;
-    }
-    else
-    {
+        // Undo acceleration and get back the original mouse speed
         original_speed = speed - mouse_threshold;
         original_speed = (int) (original_speed / mouse_acceleration);
         original_speed += mouse_threshold;
+
+        linelen = (original_speed * redline_x) / mouse_threshold;
     }
-
-    // Calculate line length
-
-    linelen = (original_speed * redline_x) / mouse_threshold;
+    else
+    {
+        linelen = speed / linelen_multiplier;
+    }
 
     // Draw horizontal "thermometer" 
 
     if (linelen > MOUSE_SPEED_BOX_WIDTH - 1)
     {
         linelen = MOUSE_SPEED_BOX_WIDTH - 1;
+        if (!draw_acceleration)
+        {
+            linelen_multiplier++;
+        }
     }
 
     V_DrawHorizLine(box_x + 1, box_y + 4, MOUSE_SPEED_BOX_WIDTH - 2, black);
 
-    if (linelen < redline_x)
+    if (!draw_acceleration || linelen < redline_x)
     {
         V_DrawHorizLine(box_x + 1, box_y + MOUSE_SPEED_BOX_HEIGHT / 2,
-                      linelen, white);
+                        linelen, white);
     }
     else
     {
@@ -948,9 +970,21 @@ void V_DrawMouseSpeedBox(int speed)
                         linelen - redline_x, yellow);
     }
 
-    // Draw red line
-
-    V_DrawVertLine(box_x + redline_x, box_y + 1,
-                 MOUSE_SPEED_BOX_HEIGHT - 2, red);
+    if (draw_acceleration)
+    {
+        // Draw acceleration threshold line
+        V_DrawVertLine(box_x + redline_x, box_y + 1,
+                       MOUSE_SPEED_BOX_HEIGHT - 2, red);
+    }
+    else
+    {
+        // Draw multiplier lines to indicate current resolution
+        for (i = 1; i < linelen_multiplier; i++)
+        {
+            V_DrawVertLine(
+                box_x + (i * MOUSE_SPEED_BOX_WIDTH / linelen_multiplier),
+                box_y + 1, MOUSE_SPEED_BOX_HEIGHT - 2, yellow);
+        }
+    }
 }
 


### PR DESCRIPTION
Resolves #791.

EDIT: Functionality has changed: see later comments for explanation. Original description below:

> Since the box isn't drawn when acceleration is irrelevant to the thermometer, I went with the simplest solution and added `mouse_threshold == 0` to the no-draw condition.