### PR TITLE
p_saveg.c: initialize result in saveg_read8()

### DIFF
--- a/src/doom/p_saveg.c
+++ b/src/doom/p_saveg.c
@@ -77,7 +77,7 @@ char *P_SaveGameFile(int slot)
 
 static byte saveg_read8(void)
 {
-    byte result;
+    byte result = -1;
 
     if (fread(&result, 1, 1, save_stream) < 1)
     {


### PR DESCRIPTION
When Choco has reaches the end of a savegame file, further attempts to
read from this file with fread() will fail and the result variable
will not get set set. Since the result variable does not get initialized
either, saveg_read8() will return some "random" value.

However, as it turns out, the uninitlaized value of the result
variable isn't that random at all, but most often 0. Unfortunately, 0
has a specific meaning in the context of p_saveg.c, as it is the value
of tc_ceiling in enum specials_e. As a result, the tclass variable in
P_UnArchiveSpecials() will get interpreted as tc_ceiling and lead to
the construction of ceiling thinkers until Choco runs out of zone
memory.

What this little change does is initialize the result variable
returned by saveg_read8() to some arbitrary value that has no further
meaning in any of the enums in p_save.c. This will lead to Choco
erroring out with an "unknown tclass" message, which is consistent
with Vanilla. The actual tclass value may be different, but since it
is expected to be somehow "random" this isn't something I plan to
emulate any further at this point.

Fixes #794, #658, #85.