### PR TITLE
g_game.c: Don't overwrite Heretic/Hexen demo playback arguments

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1885,9 +1885,11 @@ void G_DoPlayDemo(void)
     map = *demo_p++;
 
     // Read special parameter bits: see G_RecordDemo() for details.
-    respawnparm = (*demo_p & DEMOHEADER_RESPAWN) != 0;
-    longtics    = (*demo_p & DEMOHEADER_LONGTICS) != 0;
-    nomonsters  = (*demo_p & DEMOHEADER_NOMONSTERS) != 0;
+    longtics = (*demo_p & DEMOHEADER_LONGTICS) != 0;
+
+    // don't overwrite arguments from the command line
+    respawnparm |= (*demo_p & DEMOHEADER_RESPAWN) != 0;
+    nomonsters  |= (*demo_p & DEMOHEADER_NOMONSTERS) != 0;
 
     for (i = 0; i < MAXPLAYERS; i++)
         playeringame[i] = (*demo_p++) != 0;

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -2049,9 +2049,11 @@ void G_DoPlayDemo(void)
     map = *demo_p++;
 
     // Read special parameter bits: see G_RecordDemo() for details.
-    respawnparm = (*demo_p & DEMOHEADER_RESPAWN) != 0;
-    longtics    = (*demo_p & DEMOHEADER_LONGTICS) != 0;
-    nomonsters  = (*demo_p & DEMOHEADER_NOMONSTERS) != 0;
+    longtics = (*demo_p & DEMOHEADER_LONGTICS) != 0;
+
+    // don't overwrite arguments from the command line
+    respawnparm |= (*demo_p & DEMOHEADER_RESPAWN) != 0;
+    nomonsters  |= (*demo_p & DEMOHEADER_NOMONSTERS) != 0;
 
     for (i = 0; i < maxplayers; i++)
     {


### PR DESCRIPTION
Resolves #803.

The command line parameters `-nomonsters` and -respawn` didn't work when playing back demos, as is necessary when playing back vanilla demos, instead only setting values based on the special bits used by Chocolate to auto-detect them (when recorded specifically by Chocolate). This fix allows either to work.