### PR TITLE
hexen/g_game.c: Include miscellaneous mouse functionality

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,9 @@
   * Fixed an issue where the game crashed while killing the
     Wraithverge in 64-bit builds. (thanks J.Benaim)
   * Added unlimited demo/savegame support. (thanks CapnClever)
+  * Mouse buttons for strafe left/right and move backward, as well as
+    'Double click acts as "use"' mouse option, now function properly.
+    (thanks CapnClever)
 
 ### Strife
   * Support added for automatic loading of the IWAD from the GOG.com

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -312,13 +312,13 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         forward -= forwardmove[pClass][speed];
     }
-    if (gamekeydown[key_straferight] || joystrafemove > 0
-     || joybuttons[joybstraferight])
+    if (gamekeydown[key_straferight] || mousebuttons[mousebstraferight]
+     || joystrafemove > 0 || joybuttons[joybstraferight])
     {
         side += sidemove[pClass][speed];
     }
-    if (gamekeydown[key_strafeleft] || joystrafemove < 0
-     || joybuttons[joybstrafeleft])
+    if (gamekeydown[key_strafeleft] || mousebuttons[mousebstrafeleft]
+     || joystrafemove < 0 || joybuttons[joybstrafeleft])
     {
         side -= sidemove[pClass][speed];
     }
@@ -504,57 +504,66 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         forward += forwardmove[pClass][speed];
     }
-
-//
-// forward double click
-//
-    if (mousebuttons[mousebforward] != dclickstate && dclicktime > 1)
+    if (mousebuttons[mousebbackward])
     {
-        dclickstate = mousebuttons[mousebforward];
-        if (dclickstate)
-            dclicks++;
-        if (dclicks == 2)
-        {
-            cmd->buttons |= BT_USE;
-            dclicks = 0;
-        }
-        else
-            dclicktime = 0;
-    }
-    else
-    {
-        dclicktime += ticdup;
-        if (dclicktime > 20)
-        {
-            dclicks = 0;
-            dclickstate = 0;
-        }
+        forward -= forwardmove[pClass][speed];
     }
 
-//
-// strafe double click
-//
-    bstrafe = mousebuttons[mousebstrafe] || joybuttons[joybstrafe];
-    if (bstrafe != dclickstate2 && dclicktime2 > 1)
+    // Double click to use can be disabled
+
+    if (dclick_use)
     {
-        dclickstate2 = bstrafe;
-        if (dclickstate2)
-            dclicks2++;
-        if (dclicks2 == 2)
+        //
+        // forward double click
+        //
+        if (mousebuttons[mousebforward] != dclickstate && dclicktime > 1)
         {
-            cmd->buttons |= BT_USE;
-            dclicks2 = 0;
+            dclickstate = mousebuttons[mousebforward];
+            if (dclickstate)
+                dclicks++;
+            if (dclicks == 2)
+            {
+                cmd->buttons |= BT_USE;
+                dclicks = 0;
+            }
+            else
+                dclicktime = 0;
         }
         else
-            dclicktime2 = 0;
-    }
-    else
-    {
-        dclicktime2 += ticdup;
-        if (dclicktime2 > 20)
         {
-            dclicks2 = 0;
-            dclickstate2 = 0;
+            dclicktime += ticdup;
+            if (dclicktime > 20)
+            {
+                dclicks = 0;
+                dclickstate = 0;
+            }
+        }
+
+        //
+        // strafe double click
+        //
+        bstrafe = mousebuttons[mousebstrafe] || joybuttons[joybstrafe];
+        if (bstrafe != dclickstate2 && dclicktime2 > 1)
+        {
+            dclickstate2 = bstrafe;
+            if (dclickstate2)
+                dclicks2++;
+            if (dclicks2 == 2)
+            {
+                cmd->buttons |= BT_USE;
+                dclicks2 = 0;
+            }
+            else
+                dclicktime2 = 0;
+        }
+        else
+        {
+            dclicktime2 += ticdup;
+            if (dclicktime2 > 20)
+            {
+                dclicks2 = 0;
+                dclickstate2 = 0;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #813 by resolving everything the issue mentions:

* Move backward, strafe left, and strafe right mouse buttons all work now
* 'Double click acts as "use"' option functions properly