### PR TITLE
introduce a pixel_t type

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -211,7 +211,7 @@ static int 	f_w;
 static int	f_h;
 
 static int 	lightlev; 		// used for funky strobing effect
-static byte*	fb; 			// pseudo-frame buffer
+static pixel_t*	fb; 			// pseudo-frame buffer
 static int 	amclock;
 
 static mpoint_t m_paninc; // how far the window pans each tic (map coords)

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -227,7 +227,7 @@ extern	patch_t *hu_font[HU_FONTSIZE];
 void F_TextWrite (void)
 {
     byte*	src;
-    byte*	dest;
+    pixel_t*	dest;
     
     int		x,y,w;
     signed int	count;
@@ -576,8 +576,8 @@ F_DrawPatchCol
 {
     column_t*	column;
     byte*	source;
-    byte*	dest;
-    byte*	desttop;
+    pixel_t*	dest;
+    pixel_t*	desttop;
     int		count;
 	
     column = (column_t *)((byte *)patch + LONG(patch->columnofs[col]));

--- a/src/doom/f_wipe.c
+++ b/src/doom/f_wipe.c
@@ -34,22 +34,22 @@
 // when zero, stop the wipe
 static boolean	go = 0;
 
-static byte*	wipe_scr_start;
-static byte*	wipe_scr_end;
-static byte*	wipe_scr;
+static pixel_t*	wipe_scr_start;
+static pixel_t*	wipe_scr_end;
+static pixel_t*	wipe_scr;
 
 
 void
 wipe_shittyColMajorXform
-( short*	array,
+( dpixel_t*	array,
   int		width,
   int		height )
 {
     int		x;
     int		y;
-    short*	dest;
+    dpixel_t*	dest;
 
-    dest = (short*) Z_Malloc(width*height*sizeof(*dest), PU_STATIC, 0);
+    dest = (dpixel_t*) Z_Malloc(width*height*sizeof(*dest), PU_STATIC, 0);
 
     for(y=0;y<height;y++)
 	for(x=0;x<width;x++)
@@ -78,8 +78,8 @@ wipe_doColorXForm
   int	ticks )
 {
     boolean	changed;
-    byte*	w;
-    byte*	e;
+    pixel_t*	w;
+    pixel_t*	e;
     int		newval;
 
     changed = false;
@@ -142,8 +142,8 @@ wipe_initMelt
     
     // makes this wipe faster (in theory)
     // to have stuff in column-major format
-    wipe_shittyColMajorXform((short*)wipe_scr_start, width/2, height);
-    wipe_shittyColMajorXform((short*)wipe_scr_end, width/2, height);
+    wipe_shittyColMajorXform((dpixel_t*)wipe_scr_start, width/2, height);
+    wipe_shittyColMajorXform((dpixel_t*)wipe_scr_end, width/2, height);
     
     // setup initial column positions
     // (y<0 => not ready to scroll yet)
@@ -171,8 +171,8 @@ wipe_doMelt
     int		dy;
     int		idx;
     
-    short*	s;
-    short*	d;
+    dpixel_t*	s;
+    dpixel_t*	d;
     boolean	done = true;
 
     width/=2;
@@ -189,8 +189,8 @@ wipe_doMelt
 	    {
 		dy = (y[i] < 16) ? y[i]+1 : 8;
 		if (y[i]+dy >= height) dy = height - y[i];
-		s = &((short *)wipe_scr_end)[i*height+y[i]];
-		d = &((short *)wipe_scr)[y[i]*width+i];
+		s = &((dpixel_t *)wipe_scr_end)[i*height+y[i]];
+		d = &((dpixel_t *)wipe_scr)[y[i]*width+i];
 		idx = 0;
 		for (j=dy;j;j--)
 		{
@@ -198,8 +198,8 @@ wipe_doMelt
 		    idx += width;
 		}
 		y[i] += dy;
-		s = &((short *)wipe_scr_start)[i*height];
-		d = &((short *)wipe_scr)[y[i]*width+i];
+		s = &((dpixel_t *)wipe_scr_start)[i*height];
+		d = &((dpixel_t *)wipe_scr)[y[i]*width+i];
 		idx = 0;
 		for (j=height-y[i];j;j--)
 		{
@@ -272,7 +272,7 @@ wipe_ScreenWipe
     if (!go)
     {
 	go = 1;
-	// wipe_scr = (byte *) Z_Malloc(width*height, PU_STATIC, 0); // DEBUG
+	// wipe_scr = (pixel_t *) Z_Malloc(width*height, PU_STATIC, 0); // DEBUG
 	wipe_scr = I_VideoBuffer;
 	(*wipes[wipeno*3])(width, height, ticks);
     }

--- a/src/doom/r_defs.h
+++ b/src/doom/r_defs.h
@@ -295,7 +295,7 @@ typedef struct
 //  precalculating 24bpp lightmap/colormap LUT.
 //  from darkening PLAYPAL to all black.
 // Could even us emore than 32 levels.
-typedef byte	lighttable_t;	
+typedef pixel_t		lighttable_t;
 
 
 

--- a/src/doom/r_draw.c
+++ b/src/doom/r_draw.c
@@ -60,7 +60,7 @@ int		scaledviewwidth;
 int		viewheight;
 int		viewwindowx;
 int		viewwindowy; 
-byte*		ylookup[MAXHEIGHT]; 
+pixel_t*		ylookup[MAXHEIGHT];
 int		columnofs[MAXWIDTH]; 
 
 // Color tables for different players,
@@ -72,7 +72,7 @@ byte		translations[3][256];
 // Backing buffer containing the bezel drawn around the screen and 
 // surrounding background.
 
-static byte *background_buffer = NULL;
+static pixel_t *background_buffer = NULL;
 
 
 //
@@ -102,7 +102,7 @@ int			dccount;
 void R_DrawColumn (void) 
 { 
     int			count; 
-    byte*		dest; 
+    pixel_t*		dest;
     fixed_t		frac;
     fixed_t		fracstep;	 
  
@@ -208,8 +208,8 @@ void R_DrawColumn (void)
 void R_DrawColumnLow (void) 
 { 
     int			count; 
-    byte*		dest; 
-    byte*		dest2;
+    pixel_t*		dest;
+    pixel_t*		dest2;
     fixed_t		frac;
     fixed_t		fracstep;	 
     int                 x;
@@ -283,7 +283,7 @@ int	fuzzpos = 0;
 void R_DrawFuzzColumn (void) 
 { 
     int			count; 
-    byte*		dest; 
+    pixel_t*		dest;
     fixed_t		frac;
     fixed_t		fracstep;	 
 
@@ -342,8 +342,8 @@ void R_DrawFuzzColumn (void)
 void R_DrawFuzzColumnLow (void) 
 { 
     int			count; 
-    byte*		dest; 
-    byte*		dest2; 
+    pixel_t*		dest;
+    pixel_t*		dest2;
     fixed_t		frac;
     fixed_t		fracstep;	 
     int x;
@@ -424,7 +424,7 @@ byte*	translationtables;
 void R_DrawTranslatedColumn (void) 
 { 
     int			count; 
-    byte*		dest; 
+    pixel_t*		dest;
     fixed_t		frac;
     fixed_t		fracstep;	 
  
@@ -468,8 +468,8 @@ void R_DrawTranslatedColumn (void)
 void R_DrawTranslatedColumnLow (void) 
 { 
     int			count; 
-    byte*		dest; 
-    byte*		dest2; 
+    pixel_t*		dest;
+    pixel_t*		dest2;
     fixed_t		frac;
     fixed_t		fracstep;	 
     int                 x;
@@ -590,7 +590,7 @@ int			dscount;
 void R_DrawSpan (void) 
 { 
     unsigned int position, step;
-    byte *dest;
+    pixel_t *dest;
     int count;
     int spot;
     unsigned int xtemp, ytemp;
@@ -649,7 +649,7 @@ void R_DrawSpan (void)
 
     byte*	source;
     byte*	colormap;
-    byte*	dest;
+    pixel_t*	dest;
     
     unsigned	count;
     usingned	spot; 
@@ -720,7 +720,7 @@ void R_DrawSpanLow (void)
 {
     unsigned int position, step;
     unsigned int xtemp, ytemp;
-    byte *dest;
+    pixel_t *dest;
     int count;
     int spot;
 
@@ -812,7 +812,7 @@ R_InitBuffer
 void R_FillBackScreen (void) 
 { 
     byte*	src;
-    byte*	dest; 
+    pixel_t*	dest;
     int		x;
     int		y; 
     patch_t*	patch;

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -260,7 +260,7 @@
 #define ST_MAPHEIGHT		1
 
 // graphics are drawn to a backing screen and blitted to the real screen
-byte                   *st_backing_screen;
+pixel_t			*st_backing_screen;
 	    
 // main player in game
 static player_t*	plyr; 
@@ -1430,6 +1430,6 @@ void ST_Stop (void)
 void ST_Init (void)
 {
     ST_loadData();
-    st_backing_screen = (byte *) Z_Malloc(ST_WIDTH * ST_HEIGHT * sizeof(*st_backing_screen), PU_STATIC, 0);
+    st_backing_screen = (pixel_t *) Z_Malloc(ST_WIDTH * ST_HEIGHT * sizeof(*st_backing_screen), PU_STATIC, 0);
 }
 

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -90,6 +90,8 @@ typedef enum
 #endif
 
 typedef uint8_t byte;
+typedef uint8_t pixel_t;
+typedef int16_t dpixel_t;
 
 #include <limits.h>
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -140,7 +140,7 @@ static boolean nograbmouse_override = false;
 
 // The screen buffer; this is modified to draw things to the screen
 
-byte *I_VideoBuffer = NULL;
+pixel_t *I_VideoBuffer = NULL;
 
 // If true, game is running as a screensaver
 
@@ -725,7 +725,7 @@ void I_FinishUpdate (void)
 //
 // I_ReadScreen
 //
-void I_ReadScreen (byte* scr)
+void I_ReadScreen (pixel_t* scr)
 {
     memcpy(scr, I_VideoBuffer, SCREENWIDTH*SCREENHEIGHT*sizeof(*scr));
 }

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -49,7 +49,7 @@ int I_GetPaletteIndex(int r, int g, int b);
 void I_UpdateNoBlit (void);
 void I_FinishUpdate (void);
 
-void I_ReadScreen (byte* scr);
+void I_ReadScreen (pixel_t* scr);
 
 void I_BeginRead (void);
 
@@ -84,7 +84,7 @@ extern boolean screenvisible;
 extern int vanilla_keyboard_mapping;
 extern boolean screensaver_mode;
 extern int usegamma;
-extern byte *I_VideoBuffer;
+extern pixel_t *I_VideoBuffer;
 
 extern int screen_width;
 extern int screen_height;

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -56,7 +56,7 @@ byte *xlatab = NULL;
 
 // The screen buffer that the v_video.c code draws to.
 
-static byte *dest_screen = NULL;
+static pixel_t *dest_screen = NULL;
 
 int dirtybox[4]; 
 
@@ -83,12 +83,12 @@ void V_MarkRect(int x, int y, int width, int height)
 //
 // V_CopyRect 
 // 
-void V_CopyRect(int srcx, int srcy, byte *source,
+void V_CopyRect(int srcx, int srcy, pixel_t *source,
                 int width, int height,
                 int destx, int desty)
 { 
-    byte *src;
-    byte *dest; 
+    pixel_t *src;
+    pixel_t *dest;
  
 #ifdef RANGECHECK 
     if (srcx < 0
@@ -142,8 +142,8 @@ void V_DrawPatch(int x, int y, patch_t *patch)
     int count;
     int col;
     column_t *column;
-    byte *desttop;
-    byte *dest;
+    pixel_t *desttop;
+    pixel_t *dest;
     byte *source;
     int w;
 
@@ -206,8 +206,8 @@ void V_DrawPatchFlipped(int x, int y, patch_t *patch)
     int count;
     int col; 
     column_t *column; 
-    byte *desttop;
-    byte *dest;
+    pixel_t *desttop;
+    pixel_t *dest;
     byte *source; 
     int w; 
  
@@ -281,7 +281,8 @@ void V_DrawTLPatch(int x, int y, patch_t * patch)
 {
     int count, col;
     column_t *column;
-    byte *desttop, *dest, *source;
+    pixel_t *desttop, *dest;
+    byte *source;
     int w;
 
     y -= SHORT(patch->topoffset);
@@ -331,7 +332,8 @@ void V_DrawXlaPatch(int x, int y, patch_t * patch)
 {
     int count, col;
     column_t *column;
-    byte *desttop, *dest, *source;
+    pixel_t *desttop, *dest;
+    byte *source;
     int w;
 
     y -= SHORT(patch->topoffset);
@@ -380,7 +382,8 @@ void V_DrawAltTLPatch(int x, int y, patch_t * patch)
 {
     int count, col;
     column_t *column;
-    byte *desttop, *dest, *source;
+    pixel_t *desttop, *dest;
+    byte *source;
     int w;
 
     y -= SHORT(patch->topoffset);
@@ -430,8 +433,9 @@ void V_DrawShadowedPatch(int x, int y, patch_t *patch)
 {
     int count, col;
     column_t *column;
-    byte *desttop, *dest, *source;
-    byte *desttop2, *dest2;
+    pixel_t *desttop, *dest;
+    byte *source;
+    pixel_t *desttop2, *dest2;
     int w;
 
     y -= SHORT(patch->topoffset);
@@ -501,9 +505,9 @@ void V_LoadXlaTable(void)
 // Draw a linear block of pixels into the view buffer.
 //
 
-void V_DrawBlock(int x, int y, int width, int height, byte *src) 
+void V_DrawBlock(int x, int y, int width, int height, pixel_t *src)
 { 
-    byte *dest; 
+    pixel_t *dest;
  
 #ifdef RANGECHECK 
     if (x < 0
@@ -604,7 +608,7 @@ void V_Init (void)
 
 // Set the buffer that the code draws to.
 
-void V_UseBuffer(byte *buffer)
+void V_UseBuffer(pixel_t *buffer)
 {
     dest_screen = buffer;
 }

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -50,7 +50,7 @@ void V_Init (void);
 
 // Draw a block from the specified source screen to the screen.
 
-void V_CopyRect(int srcx, int srcy, byte *source,
+void V_CopyRect(int srcx, int srcy, pixel_t *source,
                 int width, int height,
                 int destx, int desty);
 
@@ -64,7 +64,7 @@ void V_DrawPatchDirect(int x, int y, patch_t *patch);
 
 // Draw a linear block of pixels into the view buffer.
 
-void V_DrawBlock(int x, int y, int width, int height, byte *src);
+void V_DrawBlock(int x, int y, int width, int height, pixel_t *src);
 
 void V_MarkRect(int x, int y, int width, int height);
 
@@ -79,7 +79,7 @@ void V_DrawRawScreen(byte *raw);
 
 // Temporarily switch to using a different buffer to draw graphics, etc.
 
-void V_UseBuffer(byte *buffer);
+void V_UseBuffer(pixel_t *buffer);
 
 // Return to using the normal screen buffer to draw graphics.
 


### PR DESCRIPTION
The pixel_t type is supposed to be the same type as the destination
frame buffer. Why?

Well, once the sdl2-branch is merged, I plan to switch Crispy Doom to
truecolor rendering. This means that each pixel in the framebuffer
will have to be represented by a int32_t type instead of a single
byte. For this, a lot of functions have to get modified and it would
makes things considerably easier to just flip a single typedef. Apart
from the cosmetic change this will not make any difference for Choco,
but it will make maintaining my fork easier and allow for a smaller
interdiff.

Ths patch is by far not complete, but should do alright for Doom
already. I file this pull request in order to check the mood and ask if a
change like this would be accepted at all? It is absolutely no problem
if you decide against it!

Thanks for considering,

Fabian