### PR TITLE
VGA Porch border emulation

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -126,6 +126,10 @@ int fullscreen = true;
 
 int aspect_ratio_correct = true;
 
+// VGA Porch palette change emulation
+
+int vga_porch_flash = false;
+
 // Force software rendering, for systems which lack effective hardware
 // acceleration
 
@@ -740,11 +744,15 @@ void I_FinishUpdate (void)
     if (palette_to_set)
     {
         SDL_SetPaletteColors(screenbuffer->format->palette, palette, 0, 256);
-        // "flash" the pillars/letterboxes with palette changes, emulating
-        // VGA "porch" behaviour (GitHub issue #832)
-        SDL_SetRenderDrawColor(renderer, palette[0].r, palette[0].g,
-            palette[0].b, SDL_ALPHA_OPAQUE);
         palette_to_set = false;
+
+        if (vga_porch_flash)
+        {
+            // "flash" the pillars/letterboxes with palette changes, emulating
+            // VGA "porch" behaviour (GitHub issue #832)
+            SDL_SetRenderDrawColor(renderer, palette[0].r, palette[0].g,
+                palette[0].b, SDL_ALPHA_OPAQUE);
+        }
     }
 
     // Blit from the paletted 8-bit screen buffer to the intermediate
@@ -1393,6 +1401,7 @@ void I_BindVideoVariables(void)
     M_BindIntVariable("fullscreen",                &fullscreen);
     M_BindIntVariable("video_display",             &video_display);
     M_BindIntVariable("aspect_ratio_correct",      &aspect_ratio_correct);
+    M_BindIntVariable("vga_porch_flash",           &vga_porch_flash);
     M_BindIntVariable("startup_delay",             &startup_delay);
     M_BindIntVariable("fullscreen_width",          &fullscreen_width);
     M_BindIntVariable("fullscreen_height",         &fullscreen_height);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -740,6 +740,10 @@ void I_FinishUpdate (void)
     if (palette_to_set)
     {
         SDL_SetPaletteColors(screenbuffer->format->palette, palette, 0, 256);
+        // "flash" the pillars/letterboxes with palette changes, emulating
+        // VGA "porch" behaviour (GitHub issue #832)
+        SDL_SetRenderDrawColor(renderer, palette[0].r, palette[0].g,
+            palette[0].b, SDL_ALPHA_OPAQUE);
         palette_to_set = false;
     }
 

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -90,6 +90,7 @@ extern int screen_width;
 extern int screen_height;
 extern int fullscreen;
 extern int aspect_ratio_correct;
+extern int vga_porch_flash;
 extern int force_software_renderer;
 
 #endif

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -728,6 +728,13 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(aspect_ratio_correct),
 
     //!
+    // If non-zero, any pillar/letter boxes drawn around the game area
+    // will "flash" when the game palette changes, simulating the VGA
+    // "porch"
+
+    CONFIG_VARIABLE_INT(vga_porch_flash),
+
+    //!
     // Window width when running in windowed mode.
     //
 

--- a/src/setup/display.c
+++ b/src/setup/display.c
@@ -66,6 +66,7 @@ static window_size_t window_sizes_scaled[] =
 static char *video_driver = "";
 static char *window_position = "";
 static int aspect_ratio_correct = 1;
+static int vga_porch_flash = 0;
 static int force_software_renderer = 0;
 static int fullscreen = 1;
 static int fullscreen_width = 0, fullscreen_height = 0;
@@ -205,6 +206,8 @@ static void AdvancedDisplayConfig(TXT_UNCAST_ARG(widget),
         TXT_NewCheckBox("Save screenshots in PNG format",
                         &png_screenshots),
 #endif
+        TXT_NewCheckBox("Flash borders (VGA porch emulation)",
+                        &vga_porch_flash),
         NULL);
 
     TXT_SignalConnect(ar_checkbox, "changed", GenerateSizesTable, sizes_table);
@@ -260,6 +263,7 @@ void BindDisplayVariables(void)
     M_BindStringVariable("window_position",        &window_position);
     M_BindIntVariable("usegamma",                  &usegamma);
     M_BindIntVariable("png_screenshots",           &png_screenshots);
+    M_BindIntVariable("vga_porch_flash",           &vga_porch_flash);
     M_BindIntVariable("force_software_renderer",   &force_software_renderer);
     M_BindIntVariable("max_scaling_buffer_pixels", &max_scaling_buffer_pixels);
 


### PR DESCRIPTION
Set the renderer draw colour to the current palette's 0-index,
rather than just black. This means the pillars/letterboxes "flash"
when the palette changes (such as item pick up, being hurt, etc.)

This emulates the behaviour of the VGA "porch" region with Vanilla.

Fixes #832.