### PR TITLE
pcsound: Partial fix for #795

### DIFF
--- a/pcsound/pcsound_linux.c
+++ b/pcsound/pcsound_linux.c
@@ -89,6 +89,7 @@ static void AdjustedSleep(unsigned int ms)
 
 static int SoundThread(void *unused)
 {
+    int current_freq = 0;
     int frequency;
     int duration;
     int cycles;
@@ -97,16 +98,20 @@ static int SoundThread(void *unused)
     {
         callback(&duration, &frequency);
 
-        if (frequency != 0) 
+        if (current_freq != frequency)
         {
-            cycles = PCSOUND_8253_FREQUENCY / frequency;
-        }
-        else
-        {
-            cycles = 0;
-        }
+            current_freq = frequency;
+            if (frequency != 0)
+            {
+                cycles = PCSOUND_8253_FREQUENCY / frequency;
+            }
+            else
+            {
+                cycles = 0;
+            }
 
-        ioctl(console_handle, KIOCSOUND, cycles);
+            ioctl(console_handle, KIOCSOUND, cycles);
+        }
 
         AdjustedSleep(duration);
     }

--- a/pcsound/pcsound_sdl.c
+++ b/pcsound/pcsound_sdl.c
@@ -62,7 +62,7 @@ static void PCSound_Mix_Callback(int chan, void *stream, int len, void *udata)
     Sint16 *leftptr;
     Sint16 *rightptr;
     Sint16 this_value;
-    int oldfreq;
+    int frequency;
     int i;
     int nsamples;
 
@@ -82,19 +82,14 @@ static void PCSound_Mix_Callback(int chan, void *stream, int len, void *udata)
 
         while (current_remaining == 0) 
         {
-            oldfreq = current_freq;
-
             // Get the next frequency to play
 
-            callback(&current_remaining, &current_freq);
+            callback(&current_remaining, &frequency);
 
-            if (current_freq != 0)
+            if (current_freq != frequency)
             {
-                // Adjust phase to match to the new frequency.
-                // This gives us a smooth transition between different tones,
-                // with no impulse changes.
-
-                phase_offset = (phase_offset * oldfreq) / current_freq;
+                current_freq = frequency;
+                phase_offset = 0;
             }
 
             current_remaining = (current_remaining * mixing_freq) / 1000;


### PR DESCRIPTION
I've created this PR from the patch posted in issue #795.

A bit of a summary (partially covered in the issue's discussion):
- This modifies the Linux and SDL drivers. The BSD and (currently-disabled) WIN32 drivers are untouched. I'm not sure about this, but doing direct I/O writes (as done in the OPL drivers) might work better for at least one of these drivers (although not on newer Windows setups).
- A short description of the change: A new square wave is started when a different value (frequency) is read from the PC sound data, otherwise the current square wave (if any) is still being continuously generated.

While the issue's discussion already has a few sound recordings, it'll still be useful if anybody can make a recording from Vanilla Doom under DOS.

Note that this should be done under real DOS, *not* DOSBox (which currently doesn't faithfully recreate the sounds as fixed here).

Also, while using NTVDM or DOSEMU is a possibility, I found out that booting real DOS (even FreeDOS) instead might be more reliable. This is the case on non-vintage hardware, though, which may also have an impact.