### PR TITLE
Add flag to activate vsync.

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1199,6 +1199,9 @@ static void SetVideoMode(void)
     // The SDL_RENDERER_TARGETTEXTURE flag is required to render the
     // intermediate texture into the upscaled texture.
     renderer_flags = SDL_RENDERER_TARGETTEXTURE;
+	
+    // Turn on vsync
+    renderer_flags |= SDL_RENDERER_PRESENTVSYNC;
 
     if (force_software_renderer)
     {


### PR DESCRIPTION
The current SDL2 build demonstrates screen tearing, which wasn't present on the original DOS version. Turning on vsync eliminates this.