### PR TITLE
bash-completion: Use autoconf substitutions for the chocolate name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,10 +141,11 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 WINDOWS_RC_VERSION=`echo $PACKAGE_VERSION | sed 's/-.*//; s/\./, /g; s/$/, 0/'`
 
-PROGRAM_PREFIX=${PACKAGE_SHORTNAME,}-
-
 dnl Without a hyphen. This is used for the bash-completion scripts.
-PROGRAM_SPREFIX=${PACKAGE_SHORTNAME,}
+PROGRAM_SPREFIX=$(echo $PACKAGE_SHORTNAME | tr A-Z a-z)
+
+dnl With a hyphen, used almost everywhere else.
+PROGRAM_PREFIX=${PROGRAM_SPREFIX}-
 
 AC_SUBST(PROGRAM_PREFIX)
 AC_DEFINE_UNQUOTED(PROGRAM_PREFIX, "$PROGRAM_PREFIX",

--- a/configure.ac
+++ b/configure.ac
@@ -141,15 +141,15 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 WINDOWS_RC_VERSION=`echo $PACKAGE_VERSION | sed 's/-.*//; s/\./, /g; s/$/, 0/'`
 
-# This controls the prefix added to the start of program names.  For example,
-# if this is changed to "lemon-", the programs generated will be named
-# lemon-doom, lemon-heretic, etc.
+PROGRAM_PREFIX=${PACKAGE_SHORTNAME,}-
 
-PROGRAM_PREFIX=chocolate-
+dnl Without a hyphen. This is used for the bash-completion scripts.
+PROGRAM_SPREFIX=${PACKAGE_SHORTNAME,}
 
 AC_SUBST(PROGRAM_PREFIX)
 AC_DEFINE_UNQUOTED(PROGRAM_PREFIX, "$PROGRAM_PREFIX",
                    Change this when you create your awesome forked version)
+AC_SUBST(PROGRAM_SPREFIX)
 
 AM_CONFIG_HEADER(config.h:config.hin)
 
@@ -179,6 +179,10 @@ AC_OUTPUT([
 Makefile
 man/Makefile
 man/bash-completion/Makefile
+man/bash-completion/doom.template
+man/bash-completion/heretic.template
+man/bash-completion/hexen.template
+man/bash-completion/strife.template
 opl/Makefile
 opl/examples/Makefile
 pcsound/Makefile

--- a/man/bash-completion/.gitignore
+++ b/man/bash-completion/.gitignore
@@ -2,3 +2,4 @@
 *heretic
 *hexen
 *strife
+*.template

--- a/man/bash-completion/doom.template.in
+++ b/man/bash-completion/doom.template.in
@@ -1,6 +1,6 @@
-# bash completion for Chocolate Heretic                    -*- shell-script -*-
+# bash completion for @PACKAGE_SHORTNAME@ Doom               -*- shell-script -*-
 
-_chocolate_heretic()
+_@PROGRAM_SPREFIX@_doom()
 {
     local cur prev words cword
     _init_completion || return
@@ -25,13 +25,16 @@ _chocolate_heretic()
             _filedir lmp
             ;;
         -deh)
-            _filedir hhe
+            _filedir '@(bex|deh)'
             ;;
     esac
 
     case $prev in
-        -hhever)
-            COMPREPLY=(1.0 1.2 1.3)
+        -pack)
+            COMPREPLY=(doom2 tnt plutonia)
+            ;;
+        -gameversion)
+            COMPREPLY=(1.9 ultimate final final2 hacx chex)
             ;;
         -setmem)
             COMPREPLY=(dos622 dos71 dosbox)
@@ -43,6 +46,6 @@ _chocolate_heretic()
     fi
 } &&
 
-complete -F _chocolate_heretic chocolate-heretic
+complete -F _@PROGRAM_SPREFIX@_doom @PROGRAM_PREFIX@doom
 
 # ex: ts=4 sw=4 et filetype=sh

--- a/man/bash-completion/heretic.template.in
+++ b/man/bash-completion/heretic.template.in
@@ -1,6 +1,6 @@
-# bash completion for Chocolate Doom                       -*- shell-script -*-
+# bash completion for @PACKAGE_SHORTNAME@ Heretic            -*- shell-script -*-
 
-_chocolate_doom()
+_@PROGRAM_SPREFIX@_heretic()
 {
     local cur prev words cword
     _init_completion || return
@@ -25,16 +25,13 @@ _chocolate_doom()
             _filedir lmp
             ;;
         -deh)
-            _filedir '@(bex|deh)'
+            _filedir hhe
             ;;
     esac
 
     case $prev in
-        -pack)
-            COMPREPLY=(doom2 tnt plutonia)
-            ;;
-        -gameversion)
-            COMPREPLY=(1.9 ultimate final final2 hacx chex)
+        -hhever)
+            COMPREPLY=(1.0 1.2 1.3)
             ;;
         -setmem)
             COMPREPLY=(dos622 dos71 dosbox)
@@ -46,6 +43,6 @@ _chocolate_doom()
     fi
 } &&
 
-complete -F _chocolate_doom chocolate-doom
+complete -F _@PROGRAM_SPREFIX@_heretic @PROGRAM_PREFIX@heretic
 
 # ex: ts=4 sw=4 et filetype=sh

--- a/man/bash-completion/hexen.template.in
+++ b/man/bash-completion/hexen.template.in
@@ -1,6 +1,6 @@
-# bash completion for Chocolate Hexen                     -*- shell-script -*-
+# bash completion for @PACKAGE_SHORTNAME@ Hexen              -*- shell-script -*-
 
-_chocolate_hexen()
+_@PROGRAM_SPREFIX@_hexen()
 {
     local cur prev words cword
     _init_completion || return
@@ -37,6 +37,6 @@ _chocolate_hexen()
     fi
 } &&
 
-complete -F _chocolate_hexen chocolate-hexen
+complete -F _@PROGRAM_SPREFIX@_hexen @PROGRAM_PREFIX@hexen
 
 # ex: ts=4 sw=4 et filetype=sh

--- a/man/bash-completion/strife.template.in
+++ b/man/bash-completion/strife.template.in
@@ -1,6 +1,6 @@
-# bash completion for Chocolate Strife                     -*- shell-script -*-
+# bash completion for @PACKAGE_SHORTNAME@ Strife             -*- shell-script -*-
 
-_chocolate_strife()
+_@PROGRAM_SPREFIX@_strife()
 {
     local cur prev words cword
     _init_completion || return
@@ -43,6 +43,6 @@ _chocolate_strife()
     fi
 } &&
 
-complete -F _chocolate_strife chocolate-strife
+complete -F _@PROGRAM_SPREFIX@_strife @PROGRAM_PREFIX@strife
 
 # ex: ts=4 sw=4 et filetype=sh


### PR DESCRIPTION
Introduce a new PROGRAM_SPREFIX variable in configure.ac, which is
basically identical to PROGRAM_PREFIX but without the trailing hyphen.
PROGRAM_PREFIX was also redefined so that it bases its name from
PACKAGE_SHORTNAME, reducing the number of hardcoded chocolates in the
source.

I tried to avoid a new autoconf variable and just have a hyphen-less version in configure.ac instead, editing all the other files to follow suit, but automake really doesn't like constructs like `@PROGRAM_PREFIX@-doom`.

This is an effort to resolve https://github.com/fabiangreffrath/crispy-doom/issues/158