### PR TITLE
Create a savegame name by pressing Fire with joystick.

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1449,6 +1449,23 @@ boolean M_Responder (event_t* ev)
             key = key_menu_abort;
             joywait = I_GetTime() + 5;
         }
+
+        // Fill-in the savegame name if user press Fire on the joystick
+        if (saveStringEnter && joybmenu >= 0 && ev->data1&1)
+        {
+            // Create a savegame string
+            char savestring[SAVESTRINGSIZE];
+
+            memset(savestring, 0, SAVESTRINGSIZE);
+            M_snprintf(savestring, SAVESTRINGSIZE - 1, "JOYSTICK SLOT %i", saveSlot);
+            saveCharIndex = strlen(savestring);
+            memcpy(savegamestrings[saveSlot], savestring, SAVESTRINGSIZE);
+
+            // Simulate a KEY_ENTER press. Wait a log time to generate another
+            // keypress.
+            key = KEY_ENTER;
+            joywait = I_GetTime() + 15;
+        }
     }
     else
     {

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1460,11 +1460,6 @@ boolean M_Responder (event_t* ev)
             M_snprintf(savestring, SAVESTRINGSIZE - 1, "JOYSTICK SLOT %i", saveSlot);
             saveCharIndex = strlen(savestring);
             memcpy(savegamestrings[saveSlot], savestring, SAVESTRINGSIZE);
-
-            // Simulate a KEY_ENTER press. Wait a log time to generate another
-            // keypress.
-            key = KEY_ENTER;
-            joywait = I_GetTime() + 15;
         }
     }
     else


### PR DESCRIPTION
This PR generates and automatic Savegame name when pressing Fire with the joystick. There is a minor side effect: when a savegame name is generated after pressing Fire the game is saved and the current weapon is also Fired. Otherwise, it works OK.