### PR TITLE
WIP joystick cleanup

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1419,35 +1419,39 @@ boolean M_Responder (event_t* ev)
 	    key = key_menu_right;
 	    joywait = I_GetTime() + 2;
 	}
-		
-	if (ev->data1&1)
+
+#define JOY_BUTTON_PRESSED(x) ((x) >= 0 && (ev->data1 & (1 << (x))) != 0)
+
+	if (JOY_BUTTON_PRESSED(joybfire))
 	{
-	    key = key_menu_forward;
+            // Simulate a 'Y' keypress when Doom show a Y/N dialog with Fire button.
+            if (messageToPrint && messageNeedsInput)
+            {
+                key = key_menu_confirm;
+            }
+            else
+            {
+                key = key_menu_forward;
+            }
 	    joywait = I_GetTime() + 5;
 	}
-	if (ev->data1&2)
+	if (JOY_BUTTON_PRESSED(joybuse))
 	{
-	    key = key_menu_back;
+            // Simulate a 'N' keypress when Doom show a Y/N dialog with Use button.
+            if (messageToPrint && messageNeedsInput)
+            {
+                key = key_menu_abort;
+            }
+            else
+            {
+                key = key_menu_back;
+            }
 	    joywait = I_GetTime() + 5;
 	}
-        if (joybmenu >= 0 && (ev->data1 & (1 << joybmenu)) != 0)
+        if (JOY_BUTTON_PRESSED(joybmenu))
         {
             key = key_menu_activate;
 	    joywait = I_GetTime() + 5;
-        }
-
-        // Simulate a 'Y' keypress when Doom show a Y/N dialog with Fire button.
-        if (messageToPrint && messageNeedsInput && joybmenu >= 0 && ev->data1&1)
-        {
-            key = key_menu_confirm;
-            joywait = I_GetTime() + 5;
-        }
-
-        // Simulate a 'N' keypress when Doom show a Y/N dialog with Use button.
-        if (messageToPrint && messageNeedsInput && joybmenu >= 0 && ev->data1&2)
-        {
-            key = key_menu_abort;
-            joywait = I_GetTime() + 5;
         }
     }
     else


### PR DESCRIPTION
**this is Work In Progress for now, I just wanted to push it so people could comment, I'm too tired to be sure it's ready tonight**

Introduce JOY_BUTTON_PRESSED to tidy up bitmask checks against the
event field which corresponds to joystick buttons.

Re-order the new context checks for Y/N questions so they are
nested under the existing checks for use/fire button presses.

This cleans up some double-presses and some undefined behaviour
with the unbound button X.