### PR TITLE
move joystick hysteresis to i_video

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -33,6 +33,7 @@
 #include "m_misc.h"
 #include "i_system.h"
 #include "i_timer.h"
+#include "i_video.h"
 
 // Needs access to LFB.
 #include "v_video.h"
@@ -599,14 +600,13 @@ AM_Responder
 
     int rc;
     static int bigstate=0;
-    static int joywait = 0;
     static char buffer[20];
     int key;
 
     rc = false;
 
     if (ev->type == ev_joystick && joybautomap >= 0
-        && (ev->data1 & (1 << joybautomap)) != 0 && joywait < I_GetTime())
+        && (ev->data1 & (1 << joybautomap)) != 0)
     {
         joywait = I_GetTime() + 5;
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1366,7 +1366,6 @@ boolean M_Responder (event_t* ev)
     int             ch;
     int             key;
     int             i;
-    static  int     joywait = 0;
     static  int     mousewait = 0;
     static  int     mousey = 0;
     static  int     lasty = 0;
@@ -1413,7 +1412,7 @@ boolean M_Responder (event_t* ev)
     ch = 0;
     key = -1;
 	
-    if (ev->type == ev_joystick && joywait < I_GetTime())
+    if (ev->type == ev_joystick)
     {
         // Simulate key presses from joystick events to interact with the menu.
 
@@ -1453,7 +1452,6 @@ boolean M_Responder (event_t* ev)
             else if (saveStringEnter)
             {
                 key = KEY_ENTER;
-                // XXX: fire action bleeding into game
             }
             else
             {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -191,6 +191,9 @@ static boolean need_resize = false;
 
 int usegamma = 0;
 
+// Joystick/gamepad hysteresis
+unsigned int joywait = 0;
+
 static boolean MouseShouldBeGrabbed()
 {
     // never grab the mouse when in screensaver mode
@@ -500,7 +503,10 @@ void I_StartTic (void)
         I_ReadMouse();
     }
 
-    I_UpdateJoystick();
+    if (joywait < I_GetTime())
+    {
+        I_UpdateJoystick();
+    }
 }
 
 

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -97,4 +97,7 @@ extern int force_software_renderer;
 extern char *window_position;
 void I_GetWindowPosition(int *x, int *y, int w, int h);
 
+// Joystic/gamepad hysteresis
+extern unsigned int joywait;
+
 #endif


### PR DESCRIPTION
Move the joywait global variable from doom/am_map and doom/m_menu to a public
global in i_video. Add a check for that variable in the main event dispatch
loop; we can therefore remove the tests further down the call stack in the
menu and automap code.

Set the joywait var forward 5 tics when the joypad is used to save a game
to avoid a fire event leaking through to the game after the menu is dismissed.

Work is still needed to adjust heretic/hexen/strife (but quite a lot of the
recent joystick improvements need porting to them once we're satisfied with
the implementation in Doom).

Fixes #895