### PR TITLE
Adjust NES30Pro joypad settings, add FC30 Pro

### DIFF
--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -460,40 +460,11 @@ static const known_joystick_t known_joysticks[] =
         nes30_pro_controller,
     },
 
-    // 8Bitdo FC30 Pro, http://8bitdo.cn/fc30pro/
-    // variant of the above, connected over USB
-    {
-        "8Bitdo FC30 Pro",
-        4, 15, 1,
-        nes30_pro_controller,
-    },
-
-    // the above, via USB on Linux/Raspbian (odd values)
-    {
-        "8Bitdo FC30 Pro*",
-        6, 15, 1,
-        nes30_pro_controller,
-    },
-
     // the above, NES variant, via USB on Linux/Raspbian (odd values)
     {
         "8Bitdo NES30 Pro*",
         6, 15, 1,
         nes30_pro_controller,
-    },
-
-    // the above, connected over bluetooth
-    {
-        "8Bitdo FC30 Pro",
-        4, 16, 1,
-        nes30_pro_controller,
-    },
-
-    // yet another variant, Linux/bluetooth
-    {
-        "8Bitdo FC30 Pro",
-	6, 16, 1,
-	nes30_pro_controller,
     },
 
     // the above, NES variant, connected over bluetooth
@@ -509,6 +480,45 @@ static const known_joystick_t known_joysticks[] =
     {
         "8Bitdo NES30 Pro Joystick",
         6, 16, 1,
+        nes30_pro_controller,
+    },
+
+    // variant of the above, via USB on Mac
+    // Note: untested, but theorized to exist based on us comparing
+    // a NES30 Pro tested on Linux with a FC30 Pro tested with Mac & Linux
+    {
+        "8Bitdo NES30 Pro",
+        4, 15, 1,
+        nes30_pro_controller,
+    },
+
+
+    // 8Bitdo FC30 Pro, http://8bitdo.cn/fc30pro/
+    // connected over bluetooth
+    {
+        "8Bitdo FC30 Pro",
+        4, 16, 1,
+        nes30_pro_controller,
+    },
+
+    // variant of the above, via USB on Linux/Raspbian
+    {
+        "8Bitdo FC30 Pro*",
+        6, 15, 1,
+        nes30_pro_controller,
+    },
+
+    // variant of the above, Linux/bluetooth
+    {
+        "8Bitdo FC30 Pro",
+	6, 16, 1,
+	nes30_pro_controller,
+    },
+
+    // variant of the above, via USB on Mac
+    {
+        "8Bitdo FC30 Pro",
+        4, 15, 1,
         nes30_pro_controller,
     },
 

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -326,20 +326,21 @@ static const joystick_config_t pc_gameport_controller[] =
     {NULL, 0},
 };
 
-// http://www.8bitdo.com/nes30pro/
+// http://www.8bitdo.com/nes30pro/ and http://www.8bitdo.com/fc30pro/
 static const joystick_config_t nes30_pro_controller[] =
 {
     {"joystick_x_axis",        CREATE_HAT_AXIS(0, HAT_AXIS_HORIZONTAL)},
     {"joystick_y_axis",        CREATE_HAT_AXIS(0, HAT_AXIS_VERTICAL)},
     {"joyb_fire",              4},  // Y
     {"joyb_speed",             1},  // B
-    {"joyb_jump",              2},  // X
+    {"joyb_jump",              3},  // X
     {"joyb_use",               0},  // A
-    {"joyb_strafeleft",        8},  // L1
-    {"joyb_straferight",       9}, // R1
-    {"joyb_prevweapon",        6},  // L2
-    {"joyb_nextweapon",        7},  // R2
+    {"joyb_strafeleft",        6},  // L1
+    {"joyb_straferight",       7}, // R1
+    {"joyb_prevweapon",        8},  // L2
+    {"joyb_nextweapon",        9},  // R2
     {"joyb_menu_activate",     11}, // Start
+    {"joyb_toggle_automap",    10}, // Select
     {NULL, 0},
 };
 
@@ -453,9 +454,23 @@ static const known_joystick_t known_joysticks[] =
     },
 
     // 8Bitdo NES30 Pro, http://www.8bitdo.com/nes30pro/
-    // Probably some of their other controllers can use the same config.
     {
         "8Bitdo NES30 Pro",
+        4, 16, 1,
+        nes30_pro_controller,
+    },
+
+    // 8Bitdo FC30 Pro, http://8bitdo.cn/fc30pro/
+    // variant of the above, connected over USB
+    {
+        "8Bitdo FC30 Pro",
+        4, 15, 1,
+        nes30_pro_controller,
+    },
+
+    // the above, connected over bluetooth
+    {
+        "8Bitdo FC30 Pro",
         4, 16, 1,
         nes30_pro_controller,
     },

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -496,6 +496,15 @@ static const known_joystick_t known_joysticks[] =
         nes30_pro_controller,
     },
 
+    // 8bitdo NES30 Pro, in joystick mode (R1+Power), swaps the D-Pad
+    // and analog stick inputs.  Only applicable over Bluetooth. On USB,
+    // this mode registers the device as an Xbox 360 pad.
+    {
+        "8Bitdo NES30 Pro Joystick",
+        6, 16, 1,
+        nes30_pro_controller,
+    },
+
     // 8Bitdo SFC30 SNES replica controller
     // in default mode and in controller mode (Start+R)
     // the latter suffixes "Joystick" to the name

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -475,10 +475,24 @@ static const known_joystick_t known_joysticks[] =
         nes30_pro_controller,
     },
 
+    // the above, NES variant, via USB on Linux/Raspbian (odd values)
+    {
+        "8Bitdo NES30 Pro*",
+        6, 15, 1,
+        nes30_pro_controller,
+    },
+
     // the above, connected over bluetooth
     {
         "8Bitdo FC30 Pro",
         4, 16, 1,
+        nes30_pro_controller,
+    },
+
+    // the above, NES variant, connected over bluetooth
+    {
+        "8Bitdo NES30 Pro",
+        6, 16, 1,
         nes30_pro_controller,
     },
 

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -489,6 +489,13 @@ static const known_joystick_t known_joysticks[] =
         nes30_pro_controller,
     },
 
+    // yet another variant, Linux/bluetooth
+    {
+        "8Bitdo FC30 Pro",
+	6, 16, 1,
+	nes30_pro_controller,
+    },
+
     // the above, NES variant, connected over bluetooth
     {
         "8Bitdo NES30 Pro",

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -468,6 +468,13 @@ static const known_joystick_t known_joysticks[] =
         nes30_pro_controller,
     },
 
+    // the above, via USB on Linux/Raspbian (odd values)
+    {
+        "8Bitdo FC30 Pro*",
+        6, 15, 1,
+        nes30_pro_controller,
+    },
+
     // the above, connected over bluetooth
     {
         "8Bitdo FC30 Pro",


### PR DESCRIPTION
I'd like it if someone with a NES30 Pro (@fragglet?) could double-check this before merging.

I acquired an FC30 Pro which should be identical to the NES30 Pro except for Device IDs. However
the existing NES30 Pro mapping didn't match up. I've adjusted it to match to the controller I have here. I suspect that this mapping was added in the SDL1 branch and its out-of-date for SDL2.

Add known_joysticks entries for the FC30 Pro in USB and Bluetooth modes.