### PR TITLE
textscreen zenity chooser file filter tweaks

### DIFF
--- a/textscreen/txt_fileselect.c
+++ b/textscreen/txt_fileselect.c
@@ -512,6 +512,43 @@ int TXT_CanSelectFiles(void)
     return ZenityAvailable();
 }
 
+/*
+ * ExpandExtension
+ * given an extension (like wad)
+ * return a pointer to a string that is a case-insensitive
+ * pattern representation (like [Ww][Aa][Dd])
+ */
+static char * ExpandExtension(char *orig)
+{
+    int oldlen,newlen, i;
+    char *c,*newext = NULL;
+
+    oldlen = strlen(orig);
+    newlen = oldlen * 4; // pathalogical case: 'w' => '[Ww]'
+    newext = (char *)malloc(newlen+1);
+    if (newext)
+    {
+        c = newext;
+        for (i = 0; i < oldlen; ++i)
+        {
+            if (isalpha(orig[i]))
+            {
+                *c++ = '[';
+                *c++ = tolower(orig[i]);
+                *c++ = toupper(orig[i]);
+                *c++ = ']';
+            }
+            else
+            {
+                *c++ = orig[i];
+            }
+        }
+        *c = 0;
+    }
+
+    return newext;
+}
+
 char *TXT_SelectFile(char *window_title, char **extensions)
 {
     unsigned int i;
@@ -547,11 +584,16 @@ char *TXT_SelectFile(char *window_title, char **extensions)
     {
         for (i = 0; extensions[i] != NULL; ++i)
         {
-            len = 30 + strlen(extensions[i]) * 2;
-            argv[argc] = malloc(len);
-            TXT_snprintf(argv[argc], len, "--file-filter=.%s | *.%s",
-                         extensions[i], extensions[i]);
-            ++argc;
+            char * newext = ExpandExtension(extensions[i]);
+            if (newext)
+            {
+                len = 30 + strlen(extensions[i]) + strlen(newext);
+                argv[argc] = malloc(len);
+                TXT_snprintf(argv[argc], len, "--file-filter=.%s | *.%s",
+                             extensions[i], newext);
+                ++argc;
+                free(newext);
+            }
         }
     }
 

--- a/textscreen/txt_fileselect.c
+++ b/textscreen/txt_fileselect.c
@@ -562,7 +562,7 @@ char *TXT_SelectFile(char *window_title, char **extensions)
         return NULL;
     }
 
-    argv = calloc(4 + NumExtensions(extensions), sizeof(char *));
+    argv = calloc(5 + NumExtensions(extensions), sizeof(char *));
     argv[0] = ZENITY_BINARY;
     argv[1] = "--file-selection";
     argc = 2;
@@ -595,6 +595,9 @@ char *TXT_SelectFile(char *window_title, char **extensions)
                 free(newext);
             }
         }
+
+        argv[argc] = strdup("--file-filter=*.* | *.*");
+        ++argc;
     }
 
     argv[argc] = NULL;

--- a/textscreen/txt_fileselect.c
+++ b/textscreen/txt_fileselect.c
@@ -512,40 +512,42 @@ int TXT_CanSelectFiles(void)
     return ZenityAvailable();
 }
 
-/*
- * ExpandExtension
- * given an extension (like wad)
- * return a pointer to a string that is a case-insensitive
- * pattern representation (like [Ww][Aa][Dd])
- */
-static char * ExpandExtension(char *orig)
+//
+// ExpandExtension
+// given an extension (like wad)
+// return a pointer to a string that is a case-insensitive
+// pattern representation (like [Ww][Aa][Dd])
+//
+static char *ExpandExtension(char *orig)
 {
-    int oldlen,newlen, i;
-    char *c,*newext = NULL;
+    int oldlen, newlen, i;
+    char *c, *newext = NULL;
 
     oldlen = strlen(orig);
-    newlen = oldlen * 4; // pathalogical case: 'w' => '[Ww]'
-    newext = (char *)malloc(newlen+1);
-    if (newext)
+    newlen = oldlen * 4; // pathological case: 'w' => '[Ww]'
+    newext = malloc(newlen+1);
+
+    if (newext == NULL)
     {
-        c = newext;
-        for (i = 0; i < oldlen; ++i)
-        {
-            if (isalpha(orig[i]))
-            {
-                *c++ = '[';
-                *c++ = tolower(orig[i]);
-                *c++ = toupper(orig[i]);
-                *c++ = ']';
-            }
-            else
-            {
-                *c++ = orig[i];
-            }
-        }
-        *c = 0;
+        return NULL;
     }
 
+    c = newext;
+    for (i = 0; i < oldlen; ++i)
+    {
+        if (isalpha(orig[i]))
+        {
+            *c++ = '[';
+            *c++ = tolower(orig[i]);
+            *c++ = toupper(orig[i]);
+            *c++ = ']';
+        }
+        else
+        {
+            *c++ = orig[i];
+        }
+    }
+    *c = '\0';
     return newext;
 }
 


### PR DESCRIPTION
Two tweaks

 * adjust patterns to be case-insensitive
 * add a *.* pattern so user can select any file if they wish