### PR TITLE
video: apply windows self-resizing only after a 500 ms delay

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -320,7 +320,7 @@ static void AdjustWindowSize(void)
 
 static void HandleWindowEvent(SDL_WindowEvent *event)
 {
-    int i, flags;
+    int i;
 
     switch (event->event)
     {
@@ -336,15 +336,7 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
 
         case SDL_WINDOWEVENT_RESIZED:
             need_resize = true;
-            // When the window is resized (we're not in fullscreen mode),
-            // save the new window size.
-            flags = SDL_GetWindowFlags(screen);
-            if ((flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0)
-            {
-                SDL_GetWindowSize(screen, &window_width, &window_height);
-
-                last_resize_time = SDL_GetTicks();
-            }
+            last_resize_time = SDL_GetTicks();
             break;
 
         // Don't render the screen when the window is minimized:
@@ -719,11 +711,19 @@ void I_FinishUpdate (void)
 
     if (need_resize && SDL_GetTicks() > last_resize_time + 500)
     {
-        // Adjust the window by resizing again so that the window
-        // is the right aspect ratio.
-        AdjustWindowSize();
-        SDL_SetWindowSize(screen, window_width, window_height);
+        int flags;
+        // When the window is resized (we're not in fullscreen mode),
+        // save the new window size.
+        flags = SDL_GetWindowFlags(screen);
+        if ((flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0)
+        {
+            SDL_GetWindowSize(screen, &window_width, &window_height);
 
+            // Adjust the window by resizing again so that the window
+            // is the right aspect ratio.
+            AdjustWindowSize();
+            SDL_SetWindowSize(screen, window_width, window_height);
+        }
         CreateUpscaledTexture(false);
         need_resize = false;
         palette_to_set = true;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -189,6 +189,7 @@ static boolean window_focused = true;
 
 static boolean need_resize = false;
 static unsigned int last_resize_time;
+#define RESIZE_DELAY 500
 
 // Gamma correction level to use
 
@@ -711,7 +712,7 @@ void I_FinishUpdate (void)
 
     if (need_resize)
     {
-        if (SDL_GetTicks() > last_resize_time + 500)
+        if (SDL_GetTicks() > last_resize_time + RESIZE_DELAY)
         {
             int flags;
             // When the window is resized (we're not in fullscreen mode),

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -188,6 +188,7 @@ static boolean window_focused = true;
 // Window resize state.
 
 static boolean need_resize = false;
+static unsigned int last_resize_time;
 
 // Gamma correction level to use
 
@@ -342,10 +343,7 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
             {
                 SDL_GetWindowSize(screen, &window_width, &window_height);
 
-                // Adjust the window by resizing again so that the window
-                // is the right aspect ratio.
-                AdjustWindowSize();
-                SDL_SetWindowSize(screen, window_width, window_height);
+                last_resize_time = SDL_GetTicks();
             }
             break;
 
@@ -719,8 +717,13 @@ void I_FinishUpdate (void)
     if (noblit)
         return;
 
-    if (need_resize)
+    if (need_resize && SDL_GetTicks() > last_resize_time + 500)
     {
+        // Adjust the window by resizing again so that the window
+        // is the right aspect ratio.
+        AdjustWindowSize();
+        SDL_SetWindowSize(screen, window_width, window_height);
+
         CreateUpscaledTexture(false);
         need_resize = false;
         palette_to_set = true;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -709,24 +709,31 @@ void I_FinishUpdate (void)
     if (noblit)
         return;
 
-    if (need_resize && SDL_GetTicks() > last_resize_time + 500)
+    if (need_resize)
     {
-        int flags;
-        // When the window is resized (we're not in fullscreen mode),
-        // save the new window size.
-        flags = SDL_GetWindowFlags(screen);
-        if ((flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0)
+        if (SDL_GetTicks() > last_resize_time + 500)
         {
-            SDL_GetWindowSize(screen, &window_width, &window_height);
+            int flags;
+            // When the window is resized (we're not in fullscreen mode),
+            // save the new window size.
+            flags = SDL_GetWindowFlags(screen);
+            if ((flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0)
+            {
+                SDL_GetWindowSize(screen, &window_width, &window_height);
 
-            // Adjust the window by resizing again so that the window
-            // is the right aspect ratio.
-            AdjustWindowSize();
-            SDL_SetWindowSize(screen, window_width, window_height);
+                // Adjust the window by resizing again so that the window
+                // is the right aspect ratio.
+                AdjustWindowSize();
+                SDL_SetWindowSize(screen, window_width, window_height);
+            }
+            CreateUpscaledTexture(false);
+            need_resize = false;
+            palette_to_set = true;
         }
-        CreateUpscaledTexture(false);
-        need_resize = false;
-        palette_to_set = true;
+        else
+        {
+            return;
+        }
     }
 
     UpdateGrab();


### PR DESCRIPTION
This hopefully reduced the flicker experienced with certain window
managers on certain display servers when the window is manually
resized and then resizes itself again to match the right aspect ratio.

Fixes #856