### PR TITLE
Enable SDL_HINT_GRAB_KEYBOARD for special keys

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1306,6 +1306,12 @@ static void SetVideoMode(void)
 
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 
+    //
+    // This enables us to receive key press events for "special" keys like
+    // "Print Screen" which might be bound to actions (see GH issue #765)
+    //
+    SDL_SetHint(SDL_HINT_GRAB_KEYBOARD, "1");
+
     // Create the intermediate texture that the RGBA surface gets loaded into.
     // The SDL_TEXTUREACCESS_STREAMING flag means that this texture's content
     // is going to change frequently.

--- a/src/setup/txt_keyinput.c
+++ b/src/setup/txt_keyinput.c
@@ -27,6 +27,8 @@
 
 #define KEY_INPUT_WIDTH 8
 
+extern SDL_Window *TXT_SDLWindow;
+
 static int KeyPressCallback(txt_window_t *window, int key, 
                             TXT_UNCAST_ARG(key_input))
 {
@@ -58,8 +60,7 @@ static int KeyPressCallback(txt_window_t *window, int key,
 
 static void ReleaseGrab(TXT_UNCAST_ARG(window), TXT_UNCAST_ARG(unused))
 {
-    // SDL2-TODO: Needed?
-    // SDL_WM_GrabInput(SDL_GRAB_OFF);
+    SDL_SetWindowGrab(TXT_SDLWindow, SDL_FALSE);
 }
 
 static void OpenPromptWindow(txt_key_input_t *key_input)
@@ -81,8 +82,7 @@ static void OpenPromptWindow(txt_key_input_t *key_input)
     // handheld devices, the hardware keypresses are only
     // detected when input is grabbed.
 
-    // SDL2-TODO: Needed?
-    //SDL_WM_GrabInput(SDL_GRAB_ON);
+    SDL_SetWindowGrab(TXT_SDLWindow, SDL_TRUE);
     TXT_SignalConnect(window, "closed", ReleaseGrab, NULL);
 }
 

--- a/src/setup/txt_keyinput.c
+++ b/src/setup/txt_keyinput.c
@@ -27,8 +27,6 @@
 
 #define KEY_INPUT_WIDTH 8
 
-extern SDL_Window *TXT_SDLWindow;
-
 static int KeyPressCallback(txt_window_t *window, int key, 
                             TXT_UNCAST_ARG(key_input))
 {
@@ -58,11 +56,6 @@ static int KeyPressCallback(txt_window_t *window, int key,
     }
 }
 
-static void ReleaseGrab(TXT_UNCAST_ARG(window), TXT_UNCAST_ARG(unused))
-{
-    SDL_SetWindowGrab(TXT_SDLWindow, SDL_FALSE);
-}
-
 static void OpenPromptWindow(txt_key_input_t *key_input)
 {
     txt_window_t *window;
@@ -77,13 +70,6 @@ static void OpenPromptWindow(txt_key_input_t *key_input)
 
     // Switch to raw input mode while we're grabbing the key.
     TXT_SetInputMode(TXT_INPUT_RAW);
-
-    // Grab input while reading the key.  On Windows Mobile
-    // handheld devices, the hardware keypresses are only
-    // detected when input is grabbed.
-
-    SDL_SetWindowGrab(TXT_SDLWindow, SDL_TRUE);
-    TXT_SignalConnect(window, "closed", ReleaseGrab, NULL);
 }
 
 static void TXT_KeyInputSizeCalc(TXT_UNCAST_ARG(key_input))

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -890,6 +890,19 @@ void TXT_SetInputMode(txt_input_mode_t mode)
         SDL_StopTextInput();
     }
 
+    // On Windows Mobile handheld devices, the hardware keypresses
+    // are only detected when input is grabbed. In some other
+    // environments, this enables us to get key events for special
+    // keys like "Print Screen"
+    if (mode == TXT_INPUT_RAW)
+    {
+        SDL_SetWindowGrab(TXT_SDLWindow, SDL_TRUE);
+    }
+    else
+    {
+        SDL_SetWindowGrab(TXT_SDLWindow, SDL_FALSE);
+    }
+
     input_mode = mode;
 }
 

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -429,6 +429,9 @@ void TXT_UpdateScreenArea(int x, int y, int w, int h)
 
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
 
+    // to enable catching key events for special keys like Print Screen (GH #765)
+    SDL_SetHint(SDL_HINT_GRAB_KEYBOARD, "1");
+
     // TODO: This is currently creating a new texture every time we render
     // the screen; find a more efficient way to do it.
     screentx = SDL_CreateTextureFromSurface(renderer, screenbuffer);


### PR DESCRIPTION
This enables grabbing they keyboard as well as the mouse when
enabling grabs, preventing other software (e.g. the Window Manager)
from filtering key events such as special keys including Print
Screen.

Enable grabs during the key input dialog in setup.

These two changes mean you can bind Print Screen and use it for
actions in-game.

The special keys only work when the grab is enabled: so in-game,
but not in menus: this is a regression to the SDL 1.2 behaviour.

Fixes #765.