### PR TITLE
Write out aspect-corrected PCX or PNG screenshots based on game display settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ DOOM*.png
 HTIC*.png
 HEXEN*.png
 STRIFE*.png
+DOOM*.pcx
+HTIC*.pcx
+HEXEN*.pcx
+STRIFE*.pcx
 
 # These are the default patterns globally ignored by Subversion:
 *.o

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -659,49 +659,84 @@ void WritePCXfile(char *filename, byte *data,
                   int width, int height,
                   byte *palette)
 {
-    int		i;
+    int		i, j, k;
     int		length;
     pcx_t*	pcx;
     byte*	pack;
-	
-    pcx = Z_Malloc (width*height*2+1000, PU_STATIC, NULL);
+
+    if (aspect_ratio_correct)
+    {
+        pcx = Z_Malloc (width * 5 * height * 6 * 2, PU_STATIC, NULL);
+    }
+    else
+    {
+        pcx = Z_Malloc (width * height * 2 + 1000, PU_STATIC, NULL);
+    }
 
     pcx->manufacturer = 0x0a;		// PCX id
     pcx->version = 5;			// 256 color
-    pcx->encoding = 1;			// uncompressed
+    pcx->encoding = 1;
     pcx->bits_per_pixel = 8;		// 256 color
     pcx->xmin = 0;
     pcx->ymin = 0;
-    pcx->xmax = SHORT(width-1);
-    pcx->ymax = SHORT(height-1);
+    pcx->xmax = SHORT((aspect_ratio_correct ? width * 5 : width) - 1);
+    pcx->ymax = SHORT((aspect_ratio_correct ? height * 6 : height) - 1);
     pcx->hres = SHORT(1);
     pcx->vres = SHORT(1);
     memset (pcx->palette,0,sizeof(pcx->palette));
     pcx->reserved = 0;                  // PCX spec: reserved byte must be zero
     pcx->color_planes = 1;		// chunky image
-    pcx->bytes_per_line = SHORT(width);
+    pcx->bytes_per_line = SHORT((aspect_ratio_correct ? width * 5 : width));
     pcx->palette_type = SHORT(2);	// not a grey scale
     memset (pcx->filler,0,sizeof(pcx->filler));
 
     // pack the image
     pack = &pcx->data;
-	
-    for (i=0 ; i<width*height ; i++)
+
+    if (aspect_ratio_correct)
     {
-	if ( (*data & 0xc0) != 0xc0)
-	    *pack++ = *data++;
-	else
-	{
-	    *pack++ = 0xc1;
-	    *pack++ = *data++;
-	}
+        for (i = 0; i < SCREENHEIGHT; i++)
+        {
+            // write the row 6×
+            for (j = 0; j < 6; j++)
+            {
+                byte *row;
+                row = data;
+                for (k = 0; k < width; k++)
+                {
+                    // Use the RLE encoding to repeat every pixel five
+                    // times.
+
+                    *pack++ = 0xc5;
+                    *pack++ = *row++;
+                }
+            }
+            data += width;
+        }
     }
-    
+    else
+    {
+        for (i = 0; i < width*height; i++)
+        {
+            // PCX uses the upper two bits for the start of its RLE
+            // encoding.  Instead of being clever, we just escape any
+            // such bytes with 0xc1 to tell decoders to "repeat once"
+
+            if ((*data & 0xc0) != 0xc0)
+                *pack++ = *data++;
+            else
+            {
+                *pack++ = 0xc1;
+                *pack++ = *data++;
+            }
+        }
+    }
+
     // write the palette
     *pack++ = 0x0c;	// palette ID byte
     for (i=0 ; i<768 ; i++)
-	*pack++ = *palette++;
-    
+        *pack++ = *palette++;
+
     // write output file
     length = pack - (byte *)pcx;
     M_WriteFile (filename, pcx, length);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -736,9 +736,17 @@ void WritePNGfile(char *filename, byte *data,
     int width, height;
     byte *rowbuf;
 
-    // scale up to accommodate aspect ratio correction
-    width = inwidth * 5;
-    height = inheight * 6;
+    if (aspect_ratio_correct)
+    {
+        // scale up to accommodate aspect ratio correction
+        width = inwidth * 5;
+        height = inheight * 6;
+    }
+    else
+    {
+        width = inwidth;
+        height = inheight;
+    }
 
     handle = fopen(filename, "wb");
     if (!handle)
@@ -789,17 +797,32 @@ void WritePNGfile(char *filename, byte *data,
 
     if (rowbuf)
     {
-        for (i = 0; i < SCREENHEIGHT; i++)
+        if (aspect_ratio_correct)
         {
-            // expand the row 5x
-            for (j = 0; j < SCREENWIDTH; j++)
+            for (i = 0; i < SCREENHEIGHT; i++)
             {
-                memset(rowbuf + j * 5, *(data + i*SCREENWIDTH + j), 5);
-            }
+                // expand the row 5x
+                for (j = 0; j < SCREENWIDTH; j++)
+                {
+                    memset(rowbuf + j * 5, *(data + i*SCREENWIDTH + j), 5);
+                }
 
-            // write the row 6 times
-            for (j = 0; j < 6; j++)
+                // write the row 6 times
+                for (j = 0; j < 6; j++)
+                {
+                    png_write_row(ppng, rowbuf);
+                }
+            }
+        }
+        else
+        {
+            for (i = 0; i < SCREENHEIGHT; i++)
             {
+                for (j = 0; j < SCREENWIDTH; j++)
+                {
+                    memset(rowbuf + j, *(data + i*SCREENWIDTH + j), 1);
+                }
+
                 png_write_row(ppng, rowbuf);
             }
         }

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -674,8 +674,8 @@ void WritePCXfile(char *filename, byte *data,
     pcx->ymin = 0;
     pcx->xmax = SHORT(width-1);
     pcx->ymax = SHORT(height-1);
-    pcx->hres = SHORT(width);
-    pcx->vres = SHORT(height);
+    pcx->hres = SHORT(1);
+    pcx->vres = SHORT(1);
     memset (pcx->palette,0,sizeof(pcx->palette));
     pcx->reserved = 0;                  // PCX spec: reserved byte must be zero
     pcx->color_planes = 1;		// chunky image


### PR DESCRIPTION
This is my proposed resolution to #920, decoupling the issue of aspect-corrected screenshots from the file format being used, adding the capability for 320×200 PNGs and 1600×1200 PCXs.