### PR TITLE
Gracefully handle realloc failures

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -470,9 +470,16 @@ static char *GetSubstituteMusicFile(void *data, size_t data_len)
 
 static void AddSubstituteMusic(subst_music_t *subst)
 {
+    subst_music_t *new_subst_music;
+
     ++subst_music_len;
-    subst_music =
+    new_subst_music =
         realloc(subst_music, sizeof(subst_music_t) * subst_music_len);
+    if (!new_subst_music)
+    {
+        I_Error("Out of memory");
+    }
+    subst_music = new_subst_music;
     memcpy(&subst_music[subst_music_len - 1], subst, sizeof(subst_music_t));
 }
 

--- a/src/net_query.c
+++ b/src/net_query.c
@@ -187,6 +187,7 @@ static void NET_Query_SendMasterQuery(net_addr_t *addr)
 static query_target_t *GetTargetForAddr(net_addr_t *addr, boolean create)
 {
     query_target_t *target;
+    query_target_t *new_targets;
     int i;
 
     for (i=0; i<num_targets; ++i)
@@ -202,7 +203,12 @@ static query_target_t *GetTargetForAddr(net_addr_t *addr, boolean create)
         return NULL;
     }
 
-    targets = realloc(targets, sizeof(query_target_t) * (num_targets + 1));
+    new_targets = realloc(targets, sizeof(query_target_t) * (num_targets + 1));
+    if (!new_targets)
+    {
+        I_Error("Out of memory");
+    }
+    targets = new_targets;
 
     target = &targets[num_targets];
     target->type = QUERY_TARGET_SERVER;

--- a/src/w_checksum.c
+++ b/src/w_checksum.c
@@ -32,6 +32,7 @@ static int GetFileNumber(wad_file_t *handle)
 {
     int i;
     int result;
+    wad_file_t **new_open_wadfiles;
 
     for (i = 0; i < num_open_wadfiles; ++i)
     {
@@ -44,8 +45,13 @@ static int GetFileNumber(wad_file_t *handle)
     // Not found in list.  This is a new file we haven't seen yet.
     // Allocate another slot for this file.
 
-    open_wadfiles = realloc(open_wadfiles,
+    new_open_wadfiles = realloc(open_wadfiles,
                             sizeof(wad_file_t *) * (num_open_wadfiles + 1));
+    if (!new_open_wadfiles)
+    {
+        I_Error("Out of memory");
+    }
+    open_wadfiles = new_open_wadfiles;
     open_wadfiles[num_open_wadfiles] = handle;
 
     result = num_open_wadfiles;


### PR DESCRIPTION
Quit when realloc fails and make sure the original pointer is not lost. The pointers still leak because there are no atexit handlers for them.

I've only tested the first one of these.