### PR TITLE
Add cppcheck static analysis to travis build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+./autogen.sh
+make
+make install DESTDIR=/tmp/whatever
+make dist

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
-./autogen.sh
-make
-make install DESTDIR=/tmp/whatever
-make dist
+if [ "$ANALYZE" = "true" ] ; then
+	cppcheck --error-exitcode=1 -j2 -UTESTING -Iopl -Isrc -Isrc/setup opl pcsound src textscreen > /dev/null
+else
+	./autogen.sh
+	make
+	make install DESTDIR=/tmp/whatever
+	make dist
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,14 @@ compiler: gcc
 sudo: required
 dist: trusty
 
+env:
+    - ANALYZE=false
+    - ANALYZE=true
+
 addons:
     apt:
         packages:
+        - cppcheck
         - libsdl2-dev
         - libsdl2-mixer-dev
         - libsdl2-net-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
         - libsdl2-image-dev
         - libsamplerate0-dev
 
-script: ./autogen.sh && make && make install DESTDIR=/tmp/whatever && make dist
+script: ./.travis.sh
 
 branches:
     only:


### PR DESCRIPTION
This runs cppcheck static analysis as part of travis build. If any warnings are found it should fail the check.

Currently I expect this to fail since there are some potential array out-of-bounds errors. Some of them are probably false positives. Someone who knows the code better should look at them and we need to discuss the best way to silence them. DON'T MERGE until that is done.

Side note: I'm using two cores (-j2) for cppcheck. Should we also enable this for normal builds?