### PR TITLE
add a -shorttics command line option

### DIFF
--- a/src/doom/d_net.c
+++ b/src/doom/d_net.c
@@ -152,9 +152,9 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->respawn_monsters = respawnparm;
     settings->timelimit = timelimit;
 
-    settings->lowres_turn = (M_CheckParm("-record") > 0
-                          && M_CheckParm("-longtics") == 0)
-                          || M_CheckParm("-shorttics") > 0;
+    settings->lowres_turn = (M_ParmExists("-record")
+                         && !M_ParmExists("-longtics"))
+                          || M_ParmExists("-shorttics");
 }
 
 static void InitConnectData(net_connect_data_t *connect_data)
@@ -197,9 +197,9 @@ static void InitConnectData(net_connect_data_t *connect_data)
 
     // Are we recording a demo? Possibly set lowres turn mode
 
-    connect_data->lowres_turn = (M_CheckParm("-record") > 0
-                              && M_CheckParm("-longtics") == 0)
-                              || M_CheckParm("-shorttics") > 0;
+    connect_data->lowres_turn = (M_ParmExists("-record")
+                             && !M_ParmExists("-longtics"))
+                              || M_ParmExists("-shorttics");
 
     // Read checksums of our WAD directory and dehacked information
 

--- a/src/doom/d_net.c
+++ b/src/doom/d_net.c
@@ -152,8 +152,9 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     settings->respawn_monsters = respawnparm;
     settings->timelimit = timelimit;
 
-    settings->lowres_turn = M_CheckParm("-record") > 0
-                         && M_CheckParm("-longtics") == 0;
+    settings->lowres_turn = (M_CheckParm("-record") > 0
+                          && M_CheckParm("-longtics") == 0)
+                          || M_CheckParm("-shorttics") > 0;
 }
 
 static void InitConnectData(net_connect_data_t *connect_data)
@@ -196,8 +197,9 @@ static void InitConnectData(net_connect_data_t *connect_data)
 
     // Are we recording a demo? Possibly set lowres turn mode
 
-    connect_data->lowres_turn = M_CheckParm("-record") > 0
-                             && M_CheckParm("-longtics") == 0;
+    connect_data->lowres_turn = (M_CheckParm("-record") > 0
+                              && M_CheckParm("-longtics") == 0)
+                              || M_CheckParm("-shorttics") > 0;
 
     // Read checksums of our WAD directory and dehacked information
 

--- a/src/net_dedicated.c
+++ b/src/net_dedicated.c
@@ -41,7 +41,7 @@ static char *not_dedicated_options[] =
     "-deh", "-iwad", "-cdrom", "-gameversion", "-nomonsters", "-respawn",
     "-fast", "-altdeath", "-deathmatch", "-turbo", "-merge", "-af", "-as",
     "-aa", "-file", "-wart", "-skill", "-episode", "-timer", "-avg", "-warp",
-    "-loadgame", "-longtics", "-extratics", "-dup", NULL,
+    "-loadgame", "-longtics", "-extratics", "-dup", "-shorttics", NULL,
 };
 
 static void CheckForClientOptions(void)


### PR DESCRIPTION
I was really surprised today when ZeroMaster010 told me that he always
has to start Doom with the -record parameter to practice for his
record runs, because there is no other way to enable low-resolution
turning during normal play.

Why is that? I mean, we have a command line switch to enable
full-resolution turning even when recording a demo, so why shouldn't
there be a switch to force low-esolution turning even when not
recording a demo. PrBoom+ already has this switch.