### PR TITLE
Permit binding of joystick axes to look up/down

### DIFF
--- a/src/d_event.h
+++ b/src/d_event.h
@@ -72,7 +72,7 @@ typedef struct
     evtype_t type;
 
     // Event-specific data; see the descriptions given above.
-    int data1, data2, data3, data4;
+    int data1, data2, data3, data4, data5;
 } event_t;
 
  

--- a/src/d_event.h
+++ b/src/d_event.h
@@ -59,6 +59,7 @@ typedef enum
     //    data2: X axis mouse movement (turn).
     //    data3: Y axis mouse movement (forward/backward).
     //    data4: Third axis mouse movement (strafe).
+    //    data5: Fourth axis mouse movement (look)
     ev_joystick,
 
     // Quit event. Triggered when the user clicks the "close" button

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -193,6 +193,7 @@ int dclicktime2, dclickstate2, dclicks2;
 
 int joyxmove, joyymove;         // joystick values are repeated
 int joystrafemove;
+int joylook;
 boolean joyarray[MAX_JOY_BUTTONS + 1];
 boolean *joybuttons = &joyarray[1];     // allow [-1]
 
@@ -386,11 +387,11 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         side -= sidemove[speed];
 
     // Look up/down/center keys
-    if (gamekeydown[key_lookup])
+    if (gamekeydown[key_lookup] || joylook < 0)
     {
         look = lspeed;
     }
-    if (gamekeydown[key_lookdown])
+    if (gamekeydown[key_lookdown] || joylook > 0)
     {
         look = -lspeed;
     }
@@ -689,7 +690,7 @@ void G_DoLoadLevel(void)
 //
 
     memset(gamekeydown, 0, sizeof(gamekeydown));
-    joyxmove = joyymove = joystrafemove = 0;
+    joyxmove = joyymove = joystrafemove = joylook = 0;
     mousex = mousey = 0;
     sendpause = sendsave = paused = false;
     memset(mousearray, 0, sizeof(mousearray));
@@ -906,6 +907,7 @@ boolean G_Responder(event_t * ev)
             joyxmove = ev->data2;
             joyymove = ev->data3;
             joystrafemove = ev->data4;
+            joylook = ev->data5;
             return (true);      // eat events
 
         default:

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -160,6 +160,7 @@ int dclicktime2, dclickstate2, dclicks2;
 
 int joyxmove, joyymove;         // joystick values are repeated
 int joystrafemove;
+int joylook;
 boolean joyarray[MAX_JOY_BUTTONS + 1];
 boolean *joybuttons = &joyarray[1];     // allow [-1]
 
@@ -325,11 +326,11 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     }
 
     // Look up/down/center keys
-    if (gamekeydown[key_lookup])
+    if (gamekeydown[key_lookup] || joylook < 0)
     {
         look = lspeed;
     }
-    if (gamekeydown[key_lookdown])
+    if (gamekeydown[key_lookdown] || joylook > 0)
     {
         look = -lspeed;
     }
@@ -700,7 +701,7 @@ void G_DoLoadLevel(void)
 // 
 
     memset(gamekeydown, 0, sizeof(gamekeydown));
-    joyxmove = joyymove = joystrafemove = 0;
+    joyxmove = joyymove = joystrafemove = joylook = 0;
     mousex = mousey = 0;
     sendpause = sendsave = paused = false;
     memset(mousearray, 0, sizeof(mousearray));
@@ -918,6 +919,7 @@ boolean G_Responder(event_t * ev)
             joyxmove = ev->data2;
             joyymove = ev->data3;
             joystrafemove = ev->data4;
+            joylook = ev->data5;
             return (true);      // eat events
 
         default:

--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -65,6 +65,11 @@ static int joystick_y_invert = 0;
 static int joystick_strafe_axis = -1;
 static int joystick_strafe_invert = 0;
 
+// Which joystick axis to use for looking?
+
+static int joystick_look_axis = -1;
+static int joystick_look_invert = 0;
+
 // Virtual to physical button joystick button mapping. By default this
 // is a straight mapping.
 static int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
@@ -177,7 +182,8 @@ void I_InitJoystick(void)
 
     if (!IsValidAxis(joystick_x_axis)
      || !IsValidAxis(joystick_y_axis)
-     || !IsValidAxis(joystick_strafe_axis))
+     || !IsValidAxis(joystick_strafe_axis)
+     || !IsValidAxis(joystick_look_axis))
     {
         printf("I_InitJoystick: Invalid joystick axis for configured joystick "
                "(run joystick setup again)\n");
@@ -218,6 +224,14 @@ static boolean IsAxisButton(int physbutton)
     {
         if (physbutton == BUTTON_AXIS_NEG(joystick_strafe_axis)
          || physbutton == BUTTON_AXIS_POS(joystick_strafe_axis))
+        {
+            return true;
+        }
+    }
+    if (IS_BUTTON_AXIS(joystick_look_axis))
+    {
+        if (physbutton == BUTTON_AXIS_NEG(joystick_look_axis)
+         || physbutton == BUTTON_AXIS_POS(joystick_look_axis))
         {
             return true;
         }
@@ -357,6 +371,7 @@ void I_UpdateJoystick(void)
         ev.data2 = GetAxisState(joystick_x_axis, joystick_x_invert);
         ev.data3 = GetAxisState(joystick_y_axis, joystick_y_invert);
         ev.data4 = GetAxisState(joystick_strafe_axis, joystick_strafe_invert);
+        ev.data5 = GetAxisState(joystick_look_axis, joystick_look_invert);
 
         D_PostEvent(&ev);
     }
@@ -375,6 +390,8 @@ void I_BindJoystickVariables(void)
     M_BindIntVariable("joystick_x_invert",     &joystick_x_invert);
     M_BindIntVariable("joystick_y_invert",     &joystick_y_invert);
     M_BindIntVariable("joystick_strafe_invert",&joystick_strafe_invert);
+    M_BindIntVariable("joystick_look_axis",    &joystick_look_axis);
+    M_BindIntVariable("joystick_look_invert",  &joystick_look_invert);
 
     for (i = 0; i < NUM_VIRTUAL_BUTTONS; ++i)
     {

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1105,6 +1105,19 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(joystick_strafe_invert),
 
     //!
+    // Joystick axis to use to for looking up and down.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_look_axis),
+
+    //!
+    // If non-zero, movement on the joystick axis used for looking
+    // is inverted.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_look_invert),
+
+    //!
     // The physical joystick button that corresponds to joystick
     // virtual button #0.
     //

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1044,9 +1044,7 @@ void ConfigJoystick(void)
                    NULL);
     }
 
-    TXT_AddWidgets(window,
-               TXT_NewSeparator("Buttons"),
-               NULL);
+    TXT_AddWidget(window, TXT_NewSeparator("Buttons"));
 
     AddJoystickControl(window, "Fire/Attack", &joybfire);
     AddJoystickControl(window, "Strafe Left", &joybstrafeleft);

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -80,6 +80,11 @@ static int joystick_y_invert = 0;
 static int joystick_strafe_axis = -1;
 static int joystick_strafe_invert = 0;
 
+// Look axis.
+
+static int joystick_look_axis = -1;
+static int joystick_look_invert = 0;
+
 // Virtual to physical mapping.
 int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
@@ -133,6 +138,8 @@ static const joystick_config_t empty_defaults[] =
     {"joystick_y_invert",          0},
     {"joystick_strafe_axis",       -1},
     {"joystick_strafe_invert",     0},
+    {"joystick_look_axis",         -1},
+    {"joystick_look_invert",       0},
     {"joyb_fire",                  -1},
     {"joyb_use",                   -1},
     {"joyb_strafe",                -1},
@@ -1021,9 +1028,25 @@ void ConfigJoystick(void)
                    TXT_TABLE_OVERFLOW_RIGHT,
                    TXT_TABLE_EMPTY,
                    TXT_TABLE_EMPTY,
-
-                   TXT_NewSeparator("Buttons"),
                    NULL);
+
+    if (gamemission >= heretic) // heretic, hexen, strife
+    {
+        TXT_AddWidgets(window,
+                   TXT_NewLabel("Look up/down"),
+                   TXT_NewJoystickAxis(&joystick_look_axis,
+                                       &joystick_look_invert,
+                                        JOYSTICK_AXIS_VERTICAL),
+                   TXT_TABLE_OVERFLOW_RIGHT,
+                   TXT_TABLE_OVERFLOW_RIGHT,
+                   TXT_TABLE_EMPTY,
+                   TXT_TABLE_EMPTY,
+                   NULL);
+    }
+
+    TXT_AddWidgets(window,
+               TXT_NewSeparator("Buttons"),
+               NULL);
 
     AddJoystickControl(window, "Fire/Attack", &joybfire);
     AddJoystickControl(window, "Strafe Left", &joybstrafeleft);
@@ -1076,6 +1099,8 @@ void BindJoystickVariables(void)
     M_BindIntVariable("joystick_x_invert",      &joystick_x_invert);
     M_BindIntVariable("joystick_y_invert",      &joystick_y_invert);
     M_BindIntVariable("joystick_strafe_invert", &joystick_strafe_invert);
+    M_BindIntVariable("joystick_look_axis",   &joystick_look_axis);
+    M_BindIntVariable("joystick_look_invert", &joystick_look_invert);
 
     for (i = 0; i < NUM_VIRTUAL_BUTTONS; ++i)
     {

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1030,7 +1030,7 @@ void ConfigJoystick(void)
                    TXT_TABLE_EMPTY,
                    NULL);
 
-    if (gamemission >= heretic) // heretic, hexen, strife
+    if (gamemission == heretic || gamemission == hexen || gamemission == strife)
     {
         TXT_AddWidgets(window,
                    TXT_NewLabel("Look up/down"),

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -219,6 +219,7 @@ static int      dclicks2;
 static int      joyxmove;
 static int      joyymove;
 static int      joystrafemove;
+static int      joylook;
 static boolean  joyarray[MAX_JOY_BUTTONS + 1]; 
 static boolean *joybuttons = &joyarray[1];		// allow [-1] 
  
@@ -343,11 +344,11 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         consistancy[consoleplayer][maketic%BACKUPTICS]; 
 
     // villsa [STRIFE] look up key
-    if(gamekeydown[key_lookup])
+    if(gamekeydown[key_lookup] || joylook < 0)
         cmd->buttons2 |= BT2_LOOKUP;
 
     // villsa [STRIFE] look down key
-    if(gamekeydown[key_lookdown])
+    if(gamekeydown[key_lookdown] || joylook > 0)
         cmd->buttons2 |= BT2_LOOKDOWN;
 
     // villsa [STRIFE] inventory use key
@@ -699,7 +700,7 @@ void G_DoLoadLevel (void)
     // clear cmd building stuff
 
     memset (gamekeydown, 0, sizeof(gamekeydown));
-    joyxmove = joyymove = joystrafemove = 0;
+    joyxmove = joyymove = joystrafemove = joylook = 0;
     mousex = mousey = 0;
     sendpause = sendsave = paused = false;
     memset(mousearray, 0, sizeof(mousearray));
@@ -880,6 +881,7 @@ boolean G_Responder (event_t* ev)
         joyxmove = ev->data2; 
         joyymove = ev->data3; 
         joystrafemove = ev->data4;
+        joylook = ev->data5;
         return true;    // eat events 
 
     default: 


### PR DESCRIPTION
In games which support a look/down action (Heretic, Hexen, Strife)
permit binding a joystick axis to those actions.

Altazimuth was asking me some questions on IRC about how we handle
mouse wheel actions and that got me thinking about some of the
input stuff (specifically joystick stuff) that we hadn't finished
off.