### PR TITLE
Enable the use of SF2 sound fonts

### DIFF
--- a/src/i_sdlsound.c
+++ b/src/i_sdlsound.c
@@ -87,6 +87,9 @@ int use_libsamplerate = 0;
 
 float libsamplerate_scale = 0.65f;
 
+// Sound font file to use for MIDI playback if SDL was linked with FluidSynth.
+char *sdl_sf2_path = "";
+
 // Hook a sound into the linked list at the head.
 
 static void AllocatedSoundLink(allocated_sound_t *snd)
@@ -1105,6 +1108,26 @@ static boolean I_SDL_InitSound(boolean _use_sfx_prefix)
     {
         fprintf(stderr, "Error initialising SDL_mixer: %s\n", Mix_GetError());
         return false;
+    }
+
+    // Maybe load an SF2 sound font.  This is possible only if SDL was linked
+    // with FluidSynth.
+    if (strcmp(sdl_sf2_path,""))
+    {
+        if ((Mix_Init(MIX_INIT_MID) & MIX_INIT_MID) == 0)
+        {
+            fprintf (stderr, "SDL appears to have been built without "
+                     "FluidSynth; cannot use SF2 sound font\n");
+        }
+        else if (Mix_SetSoundFonts(sdl_sf2_path) == 0)
+        {
+            fprintf (stderr, "Mix_SetSoundFonts failed for %s\n",
+                     sdl_sf2_path);
+        }
+        else
+        {
+            printf ("SF2 sound font setup OK: %s\n", sdl_sf2_path);
+        }
     }
 
     ExpandSoundData = ExpandSoundData_SDL;

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -77,6 +77,7 @@ extern int opl_io_port;
 
 extern char *music_pack_path;
 extern char *timidity_cfg_path;
+extern char *sdl_sf2_path;
 
 // DOS-specific options: These are unused but should be maintained
 // so that the config file can be shared between chocolate
@@ -453,6 +454,7 @@ void I_BindSoundVariables(void)
 
     M_BindStringVariable("music_pack_path",      &music_pack_path);
     M_BindStringVariable("timidity_cfg_path",    &timidity_cfg_path);
+    M_BindStringVariable("sdl_sf2_path",         &sdl_sf2_path);
     M_BindStringVariable("gus_patch_path",       &gus_patch_path);
     M_BindIntVariable("gus_ram_kb",              &gus_ram_kb);
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -927,6 +927,13 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_STRING(timidity_cfg_path),
 
     //!
+    // Full path to a SF2 sound font file to use for MIDI playback. This
+    // works only if SDL was built with FluidSynth enabled.
+    //
+
+    CONFIG_VARIABLE_STRING(sdl_sf2_path),
+
+    //!
     // Path to GUS patch files to use when operating in GUS emulation
     // mode.
     //

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -41,6 +41,7 @@ static char *opltype_strings[] =
 };
 
 static char *cfg_extension[] = { "cfg", NULL };
+static char *sf2_extension[] = { "sf2", "SF2", NULL };
 
 // Config file variables:
 
@@ -64,6 +65,7 @@ static float libsamplerate_scale = 0.65;
 
 static char *music_pack_path = NULL;
 static char *timidity_cfg_path = NULL;
+static char *sdl_sf2_path = NULL;
 static char *gus_patch_path = NULL;
 static int gus_ram_kb = 1024;
 
@@ -182,6 +184,12 @@ void ConfigSound(void)
                                     "Select Timidity config file",
                                     cfg_extension),
                 TXT_NewStrut(4, 0),
+                TXT_NewLabel("SF2 sound font file: "),
+                TXT_NewStrut(4, 0),
+                TXT_NewFileSelector(&sdl_sf2_path, 34,
+                                    "Select SF2 file",
+                                    sf2_extension),
+                TXT_NewStrut(4, 0),
                 TXT_NewLabel("Digital music pack directory: "),
                 TXT_NewStrut(4, 0),
                 TXT_NewFileSelector(&music_pack_path, 34,
@@ -208,6 +216,7 @@ void BindSoundVariables(void)
     M_BindStringVariable("gus_patch_path",        &gus_patch_path);
     M_BindStringVariable("music_pack_path",     &music_pack_path);
     M_BindStringVariable("timidity_cfg_path",     &timidity_cfg_path);
+    M_BindStringVariable("sdl_sf2_path",          &sdl_sf2_path);
 
     M_BindIntVariable("snd_sbport",               &snd_sbport);
     M_BindIntVariable("snd_sbirq",                &snd_sbirq);
@@ -231,6 +240,7 @@ void BindSoundVariables(void)
     music_pack_path = M_StringDuplicate("");
     timidity_cfg_path = M_StringDuplicate("");
     gus_patch_path = M_StringDuplicate("");
+    sdl_sf2_path = M_StringDuplicate("");
 
     // All versions of Heretic and Hexen did pitch-shifting.
     // Most versions of Doom did not and Strife never did.


### PR DESCRIPTION
Add the setup option and SDL2 calls necessary to use an SF2 sound font.  Requires that SDL2 was built with FluidSynth enabled.

The previous pull request was polluted with hundreds of intervening commits when I rebased to choc-3, so I have created a new one.
