### PR TITLE
Read whole music substition config file at once

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -632,31 +632,37 @@ static char *ParseSubstituteLine(char *filename, char *line)
 
 static boolean ReadSubstituteConfig(char *filename)
 {
-    char line[128];
-    FILE *fs;
-    char *error;
+    char *buffer;
+    char *line;
     int linenum = 1;
-//    int old_subst_music_len;
 
-    fs = fopen(filename, "r");
-
-    if (fs == NULL)
+    // This unnecessarily opens the file twice...
+    if (!M_FileExists(filename))
     {
         return false;
     }
 
-//    old_subst_music_len = subst_music_len;
+    M_ReadFile(filename, (byte **) &buffer);
 
-    while (!feof(fs))
+    line = buffer;
+
+    while (line != NULL)
     {
-        char *retval;
-        M_StringCopy(line, "", sizeof(line));
-        retval = fgets(line, sizeof(line), fs);
+        char *error;
+        char *next;
 
-        if (retval == NULL)
+        // find end of line
+        char *eol = strchr(line, '\n');
+        if (eol != NULL)
         {
-            fprintf(stderr, "%s:%i: Unexpected end of file\n", filename, linenum);
-            break;
+            // change the newline into NUL
+            *eol = '\0';
+            next = eol + 1;
+        }
+        else
+        {
+            // end of buffer
+            next = NULL;
         }
 
         error = ParseSubstituteLine(filename, line);
@@ -667,9 +673,10 @@ static boolean ReadSubstituteConfig(char *filename)
         }
 
         ++linenum;
+        line = next;
     }
 
-    fclose(fs);
+    Z_Free(buffer);
 
     return true;
 }

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -217,13 +217,14 @@ int M_ReadFile(const char *name, byte **buffer)
 
     length = M_FileLength(handle);
     
-    buf = Z_Malloc (length, PU_STATIC, NULL);
+    buf = Z_Malloc (length + 1, PU_STATIC, NULL);
     count = fread(buf, 1, length, handle);
     fclose (handle);
 	
     if (count < length)
 	I_Error ("Couldn't read file %s", name);
 		
+    buf[length] = '\0';
     *buffer = buf;
     return length;
 }


### PR DESCRIPTION
As a followup #974 this cleans up `i_sdlmusic.c`. It reads the whole file at once, removes the redundant exit conditions from the parsing loop and gets rid of the "Unexpected end of file" warnings introduced previously.