### PR TITLE
Add GCC printf-like attribute to some functions

### DIFF
--- a/src/deh_io.h
+++ b/src/deh_io.h
@@ -26,7 +26,7 @@ void DEH_CloseFile(deh_context_t *context);
 int DEH_GetChar(deh_context_t *context);
 char *DEH_ReadLine(deh_context_t *context, boolean extended);
 void DEH_Error(deh_context_t *context, char *msg, ...) PRINTF_ATTR(2, 3);
-void DEH_Warning(deh_context_t *context, char *msg, ...);
+void DEH_Warning(deh_context_t *context, char *msg, ...) PRINTF_ATTR(2, 3);
 boolean DEH_HadError(deh_context_t *context);
 
 #endif /* #ifndef DEH_IO_H */

--- a/src/deh_io.h
+++ b/src/deh_io.h
@@ -25,7 +25,7 @@ deh_context_t *DEH_OpenLump(int lumpnum);
 void DEH_CloseFile(deh_context_t *context);
 int DEH_GetChar(deh_context_t *context);
 char *DEH_ReadLine(deh_context_t *context, boolean extended);
-void DEH_Error(deh_context_t *context, char *msg, ...);
+void DEH_Error(deh_context_t *context, char *msg, ...) PRINTF_ATTR(2, 3);
 void DEH_Warning(deh_context_t *context, char *msg, ...);
 boolean DEH_HadError(deh_context_t *context);
 

--- a/src/deh_str.h
+++ b/src/deh_str.h
@@ -26,7 +26,7 @@
 
 char *DEH_String(char *s);
 void DEH_printf(char *fmt, ...) PRINTF_ATTR(1, 2);
-void DEH_fprintf(FILE *fstream, char *fmt, ...);
+void DEH_fprintf(FILE *fstream, char *fmt, ...) PRINTF_ATTR(2, 3);
 void DEH_snprintf(char *buffer, size_t len, char *fmt, ...);
 void DEH_AddStringReplacement(char *from_text, char *to_text);
 

--- a/src/deh_str.h
+++ b/src/deh_str.h
@@ -20,10 +20,12 @@
 
 #include <stdio.h>
 
+#include "doomtype.h"
+
 // Used to do dehacked text substitutions throughout the program
 
 char *DEH_String(char *s);
-void DEH_printf(char *fmt, ...);
+void DEH_printf(char *fmt, ...) PRINTF_ATTR(1, 2);
 void DEH_fprintf(FILE *fstream, char *fmt, ...);
 void DEH_snprintf(char *buffer, size_t len, char *fmt, ...);
 void DEH_AddStringReplacement(char *from_text, char *to_text);

--- a/src/deh_str.h
+++ b/src/deh_str.h
@@ -27,7 +27,7 @@
 char *DEH_String(char *s);
 void DEH_printf(char *fmt, ...) PRINTF_ATTR(1, 2);
 void DEH_fprintf(FILE *fstream, char *fmt, ...) PRINTF_ATTR(2, 3);
-void DEH_snprintf(char *buffer, size_t len, char *fmt, ...);
+void DEH_snprintf(char *buffer, size_t len, char *fmt, ...) PRINTF_ATTR(3, 4);
 void DEH_AddStringReplacement(char *from_text, char *to_text);
 
 

--- a/src/deh_str.h
+++ b/src/deh_str.h
@@ -24,7 +24,7 @@
 
 // Used to do dehacked text substitutions throughout the program
 
-char *DEH_String(char *s);
+char *DEH_String(char *s) PRINTF_ARG_ATTR(1);
 void DEH_printf(char *fmt, ...) PRINTF_ATTR(1, 2);
 void DEH_fprintf(FILE *fstream, char *fmt, ...) PRINTF_ATTR(2, 3);
 void DEH_snprintf(char *buffer, size_t len, char *fmt, ...) PRINTF_ATTR(3, 4);

--- a/src/doom/r_plane.c
+++ b/src/doom/r_plane.c
@@ -368,15 +368,15 @@ void R_DrawPlanes (void)
 				
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
-	I_Error ("R_DrawPlanes: drawsegs overflow (%i)",
+	I_Error ("R_DrawPlanes: drawsegs overflow (%" PRIiPTR ")",
 		 ds_p - drawsegs);
     
     if (lastvisplane - visplanes > MAXVISPLANES)
-	I_Error ("R_DrawPlanes: visplane overflow (%i)",
+	I_Error ("R_DrawPlanes: visplane overflow (%" PRIiPTR ")",
 		 lastvisplane - visplanes);
     
     if (lastopening - openings > MAXOPENINGS)
-	I_Error ("R_DrawPlanes: opening overflow (%i)",
+	I_Error ("R_DrawPlanes: opening overflow (%" PRIiPTR ")",
 		 lastopening - openings);
 #endif
 

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -66,10 +66,12 @@
 #endif
 
 #define PRINTF_ATTR(fmt, first) __attribute__((format(printf, fmt, first)))
+#define PRINTF_ARG_ATTR(x) __attribute__((format_arg(x)))
 
 #else
 #define PACKEDATTR
 #define PRINTF_ATTR(fmt, first)
+#define PRINTF_ARG_ATTR(x)
 #endif
 
 #ifdef __WATCOMC__

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -65,8 +65,11 @@
 #define PACKEDATTR __attribute__((packed))
 #endif
 
+#define PRINTF_ATTR(fmt, first) __attribute__((format(printf, fmt, first)))
+
 #else
 #define PACKEDATTR
+#define PRINTF_ATTR(fmt, first)
 #endif
 
 #ifdef __WATCOMC__

--- a/src/heretic/r_plane.c
+++ b/src/heretic/r_plane.c
@@ -386,12 +386,13 @@ void R_DrawPlanes(void)
 
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
-        I_Error("R_DrawPlanes: drawsegs overflow (%i)", ds_p - drawsegs);
+        I_Error("R_DrawPlanes: drawsegs overflow (%" PRIiPTR ")",
+                ds_p - drawsegs);
     if (lastvisplane - visplanes > MAXVISPLANES)
-        I_Error("R_DrawPlanes: visplane overflow (%i)",
+        I_Error("R_DrawPlanes: visplane overflow (%" PRIiPTR ")",
                 lastvisplane - visplanes);
     if (lastopening - openings > MAXOPENINGS)
-        I_Error("R_DrawPlanes: opening overflow (%i)",
+        I_Error("R_DrawPlanes: opening overflow (%" PRIiPTR ")",
                 lastopening - openings);
 #endif
 

--- a/src/hexen/r_plane.c
+++ b/src/hexen/r_plane.c
@@ -390,16 +390,17 @@ void R_DrawPlanes(void)
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
     {
-        I_Error("R_DrawPlanes: drawsegs overflow (%i)", ds_p - drawsegs);
+        I_Error("R_DrawPlanes: drawsegs overflow (%" PRIiPTR ")",
+                ds_p - drawsegs);
     }
     if (lastvisplane - visplanes > MAXVISPLANES)
     {
-        I_Error("R_DrawPlanes: visplane overflow (%i)",
+        I_Error("R_DrawPlanes: visplane overflow (%" PRIiPTR ")",
                 lastvisplane - visplanes);
     }
     if (lastopening - openings > MAXOPENINGS)
     {
-        I_Error("R_DrawPlanes: opening overflow (%i)",
+        I_Error("R_DrawPlanes: opening overflow (%" PRIiPTR ")",
                 lastopening - openings);
     }
 #endif

--- a/src/hexen/st_start.h
+++ b/src/hexen/st_start.h
@@ -17,6 +17,8 @@
 #ifndef STSTART_H
 #define STSTART_H
 
+#include "doomtype.h"
+
 // HEADER FILES ------------------------------------------------------------
 
 // MACROS ------------------------------------------------------------------
@@ -26,7 +28,7 @@
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
 extern void ST_Init(void);
 extern void ST_Done(void);
-extern void ST_Message(char *message, ...);
+extern void ST_Message(char *message, ...) PRINTF_ATTR(1, 2);
 extern void ST_RealMessage(char *message, ...);
 extern void ST_Progress(void);
 extern void ST_NetProgress(void);

--- a/src/hexen/st_start.h
+++ b/src/hexen/st_start.h
@@ -29,7 +29,7 @@
 extern void ST_Init(void);
 extern void ST_Done(void);
 extern void ST_Message(char *message, ...) PRINTF_ATTR(1, 2);
-extern void ST_RealMessage(char *message, ...);
+extern void ST_RealMessage(char *message, ...) PRINTF_ATTR(1, 2);
 extern void ST_Progress(void);
 extern void ST_NetProgress(void);
 extern void ST_NetDone(void);

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -335,7 +335,7 @@ void *I_Realloc(void *ptr, size_t size)
 
     if (size != 0 && new_ptr == NULL)
     {
-        I_Error ("I_Realloc: failed on reallocation of %i bytes", size);
+        I_Error ("I_Realloc: failed on reallocation of %" PRIuPTR " bytes", size);
     }
 
     return new_ptr;

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -52,7 +52,7 @@ ticcmd_t* I_BaseTiccmd (void);
 // Clean exit, displays sell blurb.
 void I_Quit (void);
 
-void I_Error (char *error, ...);
+void I_Error (char *error, ...) PRINTF_ATTR(1, 2);
 
 void I_Tactile (int on, int off, int total);
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -384,7 +384,7 @@ char *M_StringDuplicate(const char *orig)
 
     if (result == NULL)
     {
-        I_Error("Failed to duplicate string (length %i)\n",
+        I_Error("Failed to duplicate string (length %" PRIuPTR ")\n",
                 strlen(orig));
     }
 

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -46,7 +46,7 @@ char *M_StringJoin(const char *s, ...);
 boolean M_StringStartsWith(const char *s, const char *prefix);
 boolean M_StringEndsWith(const char *s, const char *suffix);
 int M_vsnprintf(char *buf, size_t buf_len, const char *s, va_list args);
-int M_snprintf(char *buf, size_t buf_len, const char *s, ...);
+int M_snprintf(char *buf, size_t buf_len, const char *s, ...) PRINTF_ATTR(3, 4);
 char *M_OEMToUTF8(const char *ansi);
 
 #endif

--- a/src/net_query.c
+++ b/src/net_query.c
@@ -642,6 +642,7 @@ int NET_StartMasterQuery(void)
 
 // -----------------------------------------------------------------------
 
+static void formatted_printf(int wide, char *s, ...) PRINTF_ATTR(2, 3);
 static void formatted_printf(int wide, char *s, ...)
 {
     va_list args;

--- a/src/setup/execute.h
+++ b/src/setup/execute.h
@@ -15,6 +15,7 @@
 #ifndef TESTCONFIG_H
 #define TESTCONFIG_H
 
+#include "doomtype.h"
 #include "textscreen.h"
 
 typedef struct execute_context_s execute_context_t;
@@ -27,7 +28,7 @@ typedef struct execute_context_s execute_context_t;
 #define IWAD_CHEX     (1 << 5)       /* chex.wad */
 
 execute_context_t *NewExecuteContext(void);
-void AddCmdLineParameter(execute_context_t *context, char *s, ...);
+void AddCmdLineParameter(execute_context_t *context, char *s, ...) PRINTF_ATTR(2, 3);
 void PassThroughArguments(execute_context_t *context);
 int ExecuteDoom(execute_context_t *context);
 int FindInstalledIWADs(void);

--- a/src/setup/multiplayer.c
+++ b/src/setup/multiplayer.c
@@ -189,7 +189,7 @@ static void AddExtraParameters(execute_context_t *exec)
     {
         if (extra_params[i] != NULL && strlen(extra_params[i]) > 0)
         {
-            AddCmdLineParameter(exec, extra_params[i]);
+            AddCmdLineParameter(exec, "%s", extra_params[i]);
         }
     }
 }

--- a/src/setup/multiplayer.c
+++ b/src/setup/multiplayer.c
@@ -421,7 +421,8 @@ static void LevelSelectDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(user_data))
                     continue;
                 }
 
-                M_snprintf(buf, sizeof(buf), " E%iM%i ", x, y);
+                M_snprintf(buf, sizeof(buf),
+                           " E%" PRIiPTR "M%" PRIiPTR " ", x, y);
                 button = TXT_NewButton(buf);
                 TXT_SignalConnect(button, "pressed",
                                   SetExMyWarp, (void *) (x * 10 + y));
@@ -453,7 +454,7 @@ static void LevelSelectDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(user_data))
                 continue;
             }
 
-            M_snprintf(buf, sizeof(buf), " MAP%02i ", l);
+            M_snprintf(buf, sizeof(buf), " MAP%02" PRIiPTR " ", l);
             button = TXT_NewButton(buf);
             TXT_SignalConnect(button, "pressed", 
                               SetMAPxyWarp, (void *) l);

--- a/src/strife/r_plane.c
+++ b/src/strife/r_plane.c
@@ -369,15 +369,15 @@ void R_DrawPlanes (void)
 				
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
-	I_Error ("R_DrawPlanes: drawsegs overflow (%i)",
+	I_Error ("R_DrawPlanes: drawsegs overflow (%" PRIiPTR ")",
 		 ds_p - drawsegs);
     
     if (lastvisplane - visplanes > MAXVISPLANES)
-	I_Error ("R_DrawPlanes: visplane overflow (%i)",
+	I_Error ("R_DrawPlanes: visplane overflow (%" PRIiPTR ")",
 		 lastvisplane - visplanes);
     
     if (lastopening - openings > MAXOPENINGS)
-	I_Error ("R_DrawPlanes: opening overflow (%i)",
+	I_Error ("R_DrawPlanes: opening overflow (%" PRIiPTR ")",
 		 lastopening - openings);
 #endif
 

--- a/textscreen/txt_main.h
+++ b/textscreen/txt_main.h
@@ -122,6 +122,17 @@ typedef enum
     TXT_INPUT_TEXT,
 } txt_input_mode_t;
 
+
+#ifdef __GNUC__
+
+#define PRINTF_ATTR(fmt, first) __attribute__((format(printf, fmt, first)))
+
+#else  // __GNUC__
+
+#define PRINTF_ATTR(fmt, first)
+
+#endif  // __GNUC__
+
 // Initialize the screen
 // Returns 1 if successful, 0 if failed.
 int TXT_Init(void);
@@ -181,7 +192,7 @@ void TXT_StringConcat(char *dest, const char *src, size_t dest_len);
 int TXT_vsnprintf(char *buf, size_t buf_len, const char *s, va_list args);
 
 // Safe version of snprintf().
-int TXT_snprintf(char *buf, size_t buf_len, const char *s, ...);
+int TXT_snprintf(char *buf, size_t buf_len, const char *s, ...) PRINTF_ATTR(3, 4);
 
 #endif /* #ifndef TXT_MAIN_H */
 


### PR DESCRIPTION
Mark some functions with GCC format attribute to make GCC check their parameters.

There are several others which could be marked but aren't, mostly because they expose some real warnings. Should I open separate issues about those or discuss them here?
