### PR TITLE
Fix exception thrown by Windows when debugging with GDB

### DIFF
--- a/src/i_timer.c
+++ b/src/i_timer.c
@@ -75,6 +75,9 @@ void I_InitTimer(void)
 {
     // initialize timer
 
+#if SDL_VERSION_ATLEAST(2, 0, 5)
+    SDL_SetHint(SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING, "1");
+#endif
     SDL_Init(SDL_INIT_TIMER);
 }
 


### PR DESCRIPTION
This avoid `In RaiseFailFastException () (C:\Windows\SysWoW64\KernelBase.dll)` or 
`In RaiseException () (C:\WINDOWS\System32\KernelBase.dll` which are exceptions thrown by the Windows kernel and prevent anyone from debugging Chocolate-Doom using GDB on Windows. We are telling SDL2 not to name threads, which on Windows is implemented by triggering a special exception. This hint must be set before calling any SDL2 function for the first time. I don't know if it affected Visual Studio as well, but the bug was reproduced with GDB 4.9 on Windows XP and GDB 7.1 on Windows 10. 

https://wiki.libsdl.org/SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING