### PR TITLE
video: Don't enforce an 8:5 ratio when correction is not enabled.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
     loaded.  (thanks Zodomaniac, chungy)
   * Fixed an exception thrown by the Windows kernel when debugging with
     GDB.  (thanks AXDOOMER)
+  * With aspect ratio correction disabled, the game can scale to any
+    arbitrary size and remove all black borders in full screen mode.
+    (thanks chungy)
 
 ### Build systems
   * Microsoft Visual Studio files have been removed due to technical

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -290,7 +290,7 @@ void I_StartFrame (void)
 // ratio consistent with the aspect_ratio_correct variable.
 static void AdjustWindowSize(void)
 {
-    if (aspect_ratio_correct)
+    if (aspect_ratio_correct || integer_scaling)
     {
         if (window_width * actualheight <= window_height * SCREENWIDTH)
         {
@@ -1243,7 +1243,7 @@ static void SetVideoMode(void)
     // time this also defines the aspect ratio that is preserved while scaling
     // and stretching the texture into the window.
 
-    if (aspect_ratio_correct)
+    if (aspect_ratio_correct || integer_scaling)
     {
         SDL_RenderSetLogicalSize(renderer,
                                  SCREENWIDTH,

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -290,15 +290,18 @@ void I_StartFrame (void)
 // ratio consistent with the aspect_ratio_correct variable.
 static void AdjustWindowSize(void)
 {
-    if (window_width * actualheight <= window_height * SCREENWIDTH)
+    if (aspect_ratio_correct)
     {
-        // We round up window_height if the ratio is not exact; this leaves
-        // the result stable.
-        window_height = (window_width * actualheight + SCREENWIDTH - 1) / SCREENWIDTH;
-    }
-    else
-    {
-        window_width = window_height * SCREENWIDTH / actualheight;
+        if (window_width * actualheight <= window_height * SCREENWIDTH)
+        {
+            // We round up window_height if the ratio is not exact; this leaves
+            // the result stable.
+            window_height = (window_width * actualheight + SCREENWIDTH - 1) / SCREENWIDTH;
+        }
+        else
+        {
+            window_width = window_height * SCREENWIDTH / actualheight;
+        }
     }
 }
 
@@ -1240,9 +1243,12 @@ static void SetVideoMode(void)
     // time this also defines the aspect ratio that is preserved while scaling
     // and stretching the texture into the window.
 
-    SDL_RenderSetLogicalSize(renderer,
-                             SCREENWIDTH,
-                             actualheight);
+    if (aspect_ratio_correct)
+    {
+        SDL_RenderSetLogicalSize(renderer,
+                                 SCREENWIDTH,
+                                 actualheight);
+    }
 
     // Force integer scales for resolution-independent rendering.
 

--- a/src/setup/display.c
+++ b/src/setup/display.c
@@ -194,7 +194,7 @@ static void AdvancedDisplayConfig(TXT_UNCAST_ARG(widget),
     TXT_SetColumnWidths(window, 40);
 
     TXT_AddWidgets(window,
-        ar_checkbox = TXT_NewCheckBox("Fix aspect ratio",
+        ar_checkbox = TXT_NewCheckBox("Force correct aspect ratio",
                                       &aspect_ratio_correct),
         TXT_If(gamemission == heretic || gamemission == hexen
             || gamemission == strife,


### PR DESCRIPTION
As outlined in #968, this removes the 8:5 ratio in both fullscreen
and windowed modes, allowing the game screen to scale to any arbitrary
resolution or window size, no black borders visible!