### PR TITLE
Make TXT_SelectFile extensions parameter const

### DIFF
--- a/src/setup/multiplayer.c
+++ b/src/setup/multiplayer.c
@@ -69,7 +69,7 @@ static int found_iwad_selected = -1;
 
 static char *iwadfile;
 
-static char *wad_extensions[] = { "wad", "lmp", "deh", NULL };
+static const char *wad_extensions[] = { "wad", "lmp", "deh", NULL };
 
 static char *doom_skills[] =
 {

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -40,7 +40,7 @@ static char *opltype_strings[] =
     "OPL3"
 };
 
-static char *cfg_extension[] = { "cfg", NULL };
+static const char *cfg_extension[] = { "cfg", NULL };
 
 // Config file variables:
 

--- a/textscreen/examples/guitest.c
+++ b/textscreen/examples/guitest.c
@@ -32,7 +32,7 @@ enum
 };
 
 // also put some crazy extensions to test the escape function. a"b"c"""dd
-char *extensions[] = { "wad", "lmp", "txt", "a\"b\"c\"\"\"dd", "",
+const char *extensions[] = { "wad", "lmp", "txt", "a\"b\"c\"\"\"dd", "",
      "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"", NULL };
 char *radio_values[] = { "Badger", "Mushroom", "Snake" };
 char *textbox_value = NULL;

--- a/textscreen/txt_fileselect.c
+++ b/textscreen/txt_fileselect.c
@@ -33,12 +33,12 @@ struct txt_fileselect_s {
     txt_inputbox_t *inputbox;
     int size;
     char *prompt;
-    char **extensions;
+    const char **extensions;
 };
 
 // Dummy value to select a directory.
 
-char *TXT_DIRECTORY[] = { "__directory__", NULL };
+const char *TXT_DIRECTORY[] = { "__directory__", NULL };
 
 #ifndef _WIN32
 
@@ -155,7 +155,7 @@ int TXT_CanSelectFiles(void)
     return 0;
 }
 
-char *TXT_SelectFile(const char *window_title, char **extensions)
+char *TXT_SelectFile(const char *window_title, const char **extensions)
 {
     return NULL;
 }
@@ -210,7 +210,7 @@ static int InitLibraries(void)
 
 // Generate the "filter" string from the list of extensions.
 
-static char *GenerateFilterString(char **extensions)
+static char *GenerateFilterString(const char **extensions)
 {
     unsigned int result_len = 1;
     unsigned int i;
@@ -282,7 +282,7 @@ static char *SelectDirectory(char *window_title)
     return result;
 }
 
-char *TXT_SelectFile(const char *window_title, char **extensions)
+char *TXT_SelectFile(const char *window_title, const char **extensions)
 {
     OPENFILENAME fm;
     char selected[MAX_PATH] = "";
@@ -374,7 +374,7 @@ static char *CreateEscapedString(const char *original)
 
 // Build list of extensions, like: {"wad","lmp","txt"}
 
-static char *CreateExtensionsList(char **extensions)
+static char *CreateExtensionsList(const char **extensions)
 {
     char *result, *escaped;
     unsigned int result_len;
@@ -420,7 +420,7 @@ static char *CreateExtensionsList(char **extensions)
     return result;
 }
 
-static char *GenerateSelector(const char *const window_title, char **extensions)
+static char *GenerateSelector(const char *const window_title, const char **extensions)
 {
     const char *chooser;
     char *ext_list = NULL;
@@ -486,7 +486,7 @@ static char *GenerateSelector(const char *const window_title, char **extensions)
     return result;
 }
 
-static char *GenerateAppleScript(const char *window_title, char **extensions)
+static char *GenerateAppleScript(const char *window_title, const char **extensions)
 {
     char *selector, *result;
     size_t result_len;
@@ -516,7 +516,7 @@ int TXT_CanSelectFiles(void)
     return 1;
 }
 
-char *TXT_SelectFile(const char *window_title, char **extensions)
+char *TXT_SelectFile(const char *window_title, const char **extensions)
 {
     char *argv[4];
     char *result, *applescript;
@@ -546,7 +546,7 @@ char *TXT_SelectFile(const char *window_title, char **extensions)
 
 #define ZENITY_BINARY "/usr/bin/zenity"
 
-static unsigned int NumExtensions(char **extensions)
+static unsigned int NumExtensions(const char **extensions)
 {
     unsigned int result = 0;
 
@@ -607,7 +607,7 @@ static char *ExpandExtension(const char *orig)
     return newext;
 }
 
-char *TXT_SelectFile(const char *window_title, char **extensions)
+char *TXT_SelectFile(const char *window_title, const char **extensions)
 {
     unsigned int i;
     size_t len;
@@ -808,7 +808,7 @@ static void InputBoxChanged(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(fileselect))
 }
 
 txt_fileselect_t *TXT_NewFileSelector(char **variable, int size,
-                                      char *prompt, char **extensions)
+                                      char *prompt, const char **extensions)
 {
     txt_fileselect_t *fileselect;
 

--- a/textscreen/txt_fileselect.h
+++ b/textscreen/txt_fileselect.h
@@ -50,7 +50,7 @@ int TXT_CanSelectFiles(void);
  *                    to select directories.
  */
 
-char *TXT_SelectFile(const char *prompt, char **extensions);
+char *TXT_SelectFile(const char *prompt, const char **extensions);
 
 /**
  * Create a new txt_fileselect_t widget.
@@ -66,14 +66,14 @@ char *TXT_SelectFile(const char *prompt, char **extensions);
  */
 
 txt_fileselect_t *TXT_NewFileSelector(char **variable, int size,
-                                      char *prompt, char **extensions);
+                                      char *prompt, const char **extensions);
 
 /**
  * Special value to use for 'extensions' that selects a directory
  * instead of a file.
  */
 
-extern char *TXT_DIRECTORY[];
+extern const char *TXT_DIRECTORY[];
 
 #endif /* #ifndef TXT_FILESELECT_H */
 


### PR DESCRIPTION
This is complicated because we must fix all the callers at the same time. @chungy @ioan-chera Please test this on windows/macOs before merge. I tried to fix all the variants but I can't compile-test it myself.