### PR TITLE
Fix some const correctness issues in doom-specific code

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -927,7 +927,7 @@ void PrintDehackedBanners(void)
 
     for (i=0; i<arrlen(copyright_banners); ++i)
     {
-        char *deh_s;
+        const char *deh_s;
 
         deh_s = DEH_String(copyright_banners[i]);
 

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -669,7 +669,7 @@ static char *banners[] =
 static char *GetGameName(char *gamename)
 {
     size_t i;
-    char *deh_sub;
+    const char *deh_sub;
     
     for (i=0; i<arrlen(banners); ++i)
     {

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -483,7 +483,7 @@ void D_DoomLoop (void)
 //
 int             demosequence;
 int             pagetic;
-char                    *pagename;
+const char                    *pagename;
 
 
 //

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -331,7 +331,7 @@ void D_Display (void)
 
 static void EnableLoadingDisk(void)
 {
-    char *disk_lump_name;
+    const char *disk_lump_name;
 
     if (show_diskicon)
     {

--- a/src/doom/d_player.h
+++ b/src/doom/d_player.h
@@ -132,7 +132,7 @@ typedef struct player_s
     int			secretcount;
 
     // Hint messages.
-    char*		message;	
+    const char		*message;
     
     // For screen flashing (red or bright).
     int			damagecount;

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2115,7 +2115,7 @@ void G_BeginRecording (void)
 
 static const char *defdemoname;
  
-void G_DeferedPlayDemo (char* name) 
+void G_DeferedPlayDemo(const char *name)
 { 
     defdemoname = name; 
     gameaction = ga_playdemo; 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2113,7 +2113,7 @@ void G_BeginRecording (void)
 // G_PlayDemo 
 //
 
-char*	defdemoname; 
+const char *defdemoname;
  
 void G_DeferedPlayDemo (char* name) 
 { 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2113,7 +2113,7 @@ void G_BeginRecording (void)
 // G_PlayDemo 
 //
 
-const char *defdemoname;
+static const char *defdemoname;
  
 void G_DeferedPlayDemo (char* name) 
 { 

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -37,7 +37,7 @@ void G_InitNew (skill_t skill, int episode, int map);
 // but a warp test can start elsewhere
 void G_DeferedInitNew (skill_t skill, int episode, int map);
 
-void G_DeferedPlayDemo (char* demo);
+void G_DeferedPlayDemo (const char* demo);
 
 // Can be called by the startup code or M_Responder,
 // calls P_SetupLevel or W_EnterWorld.

--- a/src/doom/p_saveg.c
+++ b/src/doom/p_saveg.c
@@ -184,7 +184,7 @@ static void *saveg_readp(void)
     return (void *) (intptr_t) saveg_read32();
 }
 
-static void saveg_writep(void *p)
+static void saveg_writep(const void *p)
 {
     saveg_write32((intptr_t) p);
 }


### PR DESCRIPTION
Mostly trivial but I noticed something wrong when fixing `p_saveg.c`

`saveg_writep` writes raw pointers to file and `saveg_readp` reads them back. This might have worked in DOS but can't possibly work on modern OSes. Is there something hackish going on which fixes the pointers afterwards or it is working just because of luck? In the latter case every call to `saveg_readp` needs to be rethough and rewritten.

@fragglet It looks like you wrote this code originally, @fabiangreffrath you added a cast to `intptr_t` (which is wrong too, it's immediately cast to 32-bit which truncates the pointer on 64-bit).