### PR TITLE
Remove the unreliable Software GL check

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1310,30 +1310,6 @@ static void SetVideoMode(void)
     CreateUpscaledTexture(true);
 }
 
-static const char *hw_emu_warning = 
-"===========================================================================\n"
-"WARNING: it looks like you are using a software GL implementation.\n"
-"To improve performance, try setting force_software_renderer in your\n"
-"configuration file.\n"
-"===========================================================================\n";
-
-static void CheckGLVersion(void)
-{
-    const char * version;
-    typedef const GLubyte* (APIENTRY * glStringFn_t)(GLenum);
-    glStringFn_t glfp = (glStringFn_t)SDL_GL_GetProcAddress("glGetString");
-
-    if (glfp)
-    {
-        version = (const char *)glfp(GL_VERSION);
-
-        if (version && strstr(version, "Mesa"))
-        {
-            printf("%s", hw_emu_warning);
-        }
-    }
-}
-
 void I_InitGraphics(void)
 {
     SDL_Event dummy;
@@ -1384,10 +1360,6 @@ void I_InitGraphics(void)
     // on configuration.
     AdjustWindowSize();
     SetVideoMode();
-
-    // We might have poor performance if we are using an emulated
-    // HW accelerator. Check for Mesa and warn if we're using it.
-    CheckGLVersion();
 
     // Start with a clear black screen
     // (screen will be flipped after we set the palette)


### PR DESCRIPTION
This check was designed to warn users if they did not have hardware
acceleration that performance might be poor and to suggest toggling
force_software_renderer. However the check is not reliable: it can't
determine whether hardware acceleration is taking place on Linux, as Mesa
front-ends both hardware and software implementations.

We explored alternatives (checking SDL_GL_ACCELERATED_VISUAL) but these
proved similarly unreliable.

On Linux, GLX offers glxIsDirect, but this is of no use where GLX is not
available, including (I think) Linux framebuffer or Wayland.

Rather than continue to mislead people, delete the test and warning.

Fixes #825.