### PR TITLE
fix two compiler warnings on x64 build

### DIFF
--- a/src/heretic/p_saveg.c
+++ b/src/heretic/p_saveg.c
@@ -123,7 +123,7 @@ void SV_WriteLong(unsigned int val)
 
 void SV_WritePtr(void *ptr)
 {
-    long val = (long) ptr;
+    long val = (long)(intptr_t) ptr;
 
     SV_WriteLong(val & 0xffffffff);
 }

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -3452,6 +3452,6 @@ static void SV_WritePtr(void *val)
     // nowadays they might be larger. Whatever value we write here isn't
     // going to be much use when we reload the game.
 
-    ptr = (long) val;
+    ptr = (long)(intptr_t) val;
     SV_WriteLong((unsigned int) (ptr & 0xffffffff));
 }


### PR DESCRIPTION
By the method and recommendation of @fabiangreffrath.

This fixes two compiler warnings on x64 build (gcc.exe (Rev2, Built by MSYS2 project) 7.3.0, x64):

**Heretic:**
```

p_saveg.c: In function 'SV_WritePtr':
p_saveg.c:126:16: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
     long val = (long) ptr;
                ^
```

**Hexen:**
```
sv_save.c: In function 'SV_WritePtr':
sv_save.c:3455:11: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
     ptr = (long) val;
           ^
```

For more details, see: https://github.com/JNechaevsky/russian-doom/commit/7a202471d6a9cd350befab9193aca9db53680fff