### PR TITLE
Don't read mouse movement events in inactive game window

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -477,7 +477,7 @@ void I_StartTic (void)
 
     I_GetEvent();
 
-    if (usemouse && !nomouse)
+    if (usemouse && !nomouse && window_focused)
     {
         I_ReadMouse();
     }


### PR DESCRIPTION
By the request of @fabiangreffrath.

This will prevent mouse looking / turning in inactive game window by moving mouse cursor above it. See https://github.com/JNechaevsky/russian-doom/commit/7763003e5724f6bda595171cf34c8913b1fa7573#commitcomment-28957384 for more details.
