### PR TITLE
Properly resume music playing in G_DoLoadLevel

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -605,6 +605,12 @@ void G_DoLoadLevel (void)
 { 
     int             i; 
 
+    if (paused)
+    {
+	paused = false;
+	S_ResumeSound ();
+    }
+
     // Set the sky map.
     // First thing, we have a dummy sky texture name,
     //  a flat. The data is in the WAD only because

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -671,6 +671,12 @@ void G_DoLoadLevel(void)
 {
     int i;
 
+    if (paused)
+    {
+        paused = false;
+        S_ResumeSound();
+    }
+
     levelstarttic = gametic;    // for time calculation
     gamestate = GS_LEVEL;
     for (i = 0; i < MAXPLAYERS; i++)

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -681,6 +681,12 @@ void G_DoLoadLevel(void)
 {
     int i;
 
+    if (paused)
+    {
+        paused = false;
+        S_ResumeSound();
+    }
+
     levelstarttic = gametic;    // for time calculation 
     gamestate = GS_LEVEL;
     for (i = 0; i < maxplayers; i++)

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -671,6 +671,12 @@ void G_DoLoadLevel (void)
 { 
     int             i; 
 
+    if (paused) 
+    { 
+        paused = false; 
+        S_ResumeSound (); 
+    } 
+
     // haleyjd 10/03/10: [STRIFE] This is not done here.
     //skyflatnum = R_FlatNumForName(DEH_String(SKYFLATNAME));
 


### PR DESCRIPTION
By the request of @fabiangreffrath.

This will fix a pretty serious bug of Chocolate Doom on Windows, that we have investigated with **Fabian** (see https://github.com/JNechaevsky/russian-doom/issues/69). If there is no `chocolate-midiproc.exe` executable present, it is possible to lock up music playing by pausing intermission screen. This is happening only with OPL synth.

In case of using Native MIDI as musical playback on WIndows 7 (still without midiproc executable), the situation will be even worse: music may lock up completely. Sorry, I can't properly reproduce it now, since I have switched back to Windows 10 LTSB.

About the code: it's just copied over from `G_InitNew` func of every game, style (tabs/spaces/placement) is preserved. It seems to a safer approach.

Games are affected for sure are Doom and Heretic. Hexen and Strife does not have intermission screen, but maybe it's still worth to apply with fix, just for sure.

Video demonstration:
- Chocolate Doom: https://youtu.be/jzLXqN52zQQ
- Vanilla Doom: https://youtu.be/rvTVrk8ZaDo

Please also note: there are also few different ways/bugs to lock up music in Heretic and Hexen, but it's a vanilla behavior and not suggested to be fixed.