### PR TITLE
More const correctness

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -773,7 +773,7 @@ char *D_FindWADByName(const char *name)
 //
 // D_TryWADByName
 //
-// Searches for a WAD by its filename, or passes through the filename
+// Searches for a WAD by its filename, or returns a copy of the filename
 // if not found.
 //
 
@@ -789,7 +789,7 @@ char *D_TryFindWADByName(char *filename)
     }
     else
     {
-        return filename;
+        return M_StringDuplicate(filename);
     }
 }
 

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -777,7 +777,7 @@ char *D_FindWADByName(const char *name)
 // if not found.
 //
 
-char *D_TryFindWADByName(char *filename)
+char *D_TryFindWADByName(const char *filename)
 {
     char *result;
 

--- a/src/d_iwad.h
+++ b/src/d_iwad.h
@@ -40,7 +40,7 @@ typedef struct
 } iwad_t;
 
 char *D_FindWADByName(const char *filename);
-char *D_TryFindWADByName(char *filename);
+char *D_TryFindWADByName(const char *filename);
 char *D_FindIWAD(int mask, GameMission_t *mission);
 const iwad_t **D_FindAllIWADs(int mask);
 const char *D_SaveGameIWADName(GameMission_t gamemission);

--- a/src/deh_main.c
+++ b/src/deh_main.c
@@ -483,6 +483,7 @@ void DEH_ParseCommandLine(void)
         {
             filename = D_TryFindWADByName(myargv[p]);
             DEH_LoadFile(filename);
+            free(filename);
             ++p;
         }
     }

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -621,7 +621,7 @@ void D_StartTitle (void)
 // These are from the original source: some of them are perhaps
 // not used in any dehacked patches
 
-static char *banners[] =
+static const char *banners[] =
 {
     // doom2.wad
     "                         "

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -900,7 +900,7 @@ static boolean D_AddFile(char *filename)
 // Some dehacked mods replace these.  These are only displayed if they are 
 // replaced by dehacked.
 
-static char *copyright_banners[] =
+static const char *copyright_banners[] =
 {
     "===========================================================================\n"
     "ATTENTION:  This version of DOOM has been modified.  If you would like to\n"

--- a/src/doom/dstrings.c
+++ b/src/doom/dstrings.c
@@ -20,7 +20,7 @@
 
 #include "dstrings.h"
 
-char *doom1_endmsg[] =
+const char *doom1_endmsg[] =
 {
   "are you sure you want to\nquit this great game?",
   "please don't leave, there's more\ndemons to toast!",
@@ -32,7 +32,7 @@ char *doom1_endmsg[] =
   "go ahead and leave. see if i care.",
 };
 
-char *doom2_endmsg[] =
+const char *doom2_endmsg[] =
 {
   // QuitDOOM II messages
   "are you sure you want to\nquit this great game?",

--- a/src/doom/dstrings.h
+++ b/src/doom/dstrings.h
@@ -34,8 +34,8 @@
 // 8 per each game type
 #define NUM_QUITMESSAGES   8
 
-extern char *doom1_endmsg[];
-extern char *doom2_endmsg[];
+extern const char *doom1_endmsg[];
+extern const char *doom2_endmsg[];
 
 
 #endif

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1089,7 +1089,7 @@ void M_QuitResponse(int key)
 }
 
 
-static char *M_SelectEndMessage(void)
+static const char *M_SelectEndMessage(void)
 {
     char **endmsg;
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1091,7 +1091,7 @@ void M_QuitResponse(int key)
 
 static const char *M_SelectEndMessage(void)
 {
-    char **endmsg;
+    const char **endmsg;
 
     if (logical_gamemission == doom)
     {

--- a/src/w_file.c
+++ b/src/w_file.c
@@ -46,7 +46,7 @@ static wad_file_class_t *wad_file_classes[] =
     &stdc_wad_file,
 };
 
-wad_file_t *W_OpenFile(char *path)
+wad_file_t *W_OpenFile(const char *path)
 {
     wad_file_t *result;
     int i;

--- a/src/w_file.h
+++ b/src/w_file.h
@@ -28,7 +28,7 @@ typedef struct _wad_file_s wad_file_t;
 typedef struct
 {
     // Open a file for reading.
-    wad_file_t *(*OpenFile)(char *path);
+    wad_file_t *(*OpenFile)(const char *path);
 
     // Close the specified file.
     void (*CloseFile)(wad_file_t *file);

--- a/src/w_file.h
+++ b/src/w_file.h
@@ -58,7 +58,7 @@ struct _wad_file_s
 // Open the specified file. Returns a pointer to a new wad_file_t 
 // handle for the WAD file, or NULL if it could not be opened.
 
-wad_file_t *W_OpenFile(char *path);
+wad_file_t *W_OpenFile(const char *path);
 
 // Close the specified WAD file.
 

--- a/src/w_file_posix.c
+++ b/src/w_file_posix.c
@@ -74,7 +74,7 @@ unsigned int GetFileLength(int handle)
     return lseek(handle, 0, SEEK_END);
 }
    
-static wad_file_t *W_POSIX_OpenFile(char *path)
+static wad_file_t *W_POSIX_OpenFile(const char *path)
 {
     posix_wad_file_t *result;
     int handle;

--- a/src/w_file_posix.c
+++ b/src/w_file_posix.c
@@ -38,7 +38,7 @@ typedef struct
 
 extern wad_file_class_t posix_wad_file;
 
-static void MapFile(posix_wad_file_t *wad, char *filename)
+static void MapFile(posix_wad_file_t *wad, const char *filename)
 {
     void *result;
     int protection;

--- a/src/w_file_stdc.c
+++ b/src/w_file_stdc.c
@@ -30,7 +30,7 @@ typedef struct
 
 extern wad_file_class_t stdc_wad_file;
 
-static wad_file_t *W_StdC_OpenFile(char *path)
+static wad_file_t *W_StdC_OpenFile(const char *path)
 {
     stdc_wad_file_t *result;
     FILE *fstream;

--- a/src/w_file_win32.c
+++ b/src/w_file_win32.c
@@ -86,7 +86,7 @@ unsigned int GetFileLength(HANDLE handle)
     return result;
 }
    
-static wad_file_t *W_Win32_OpenFile(char *path)
+static wad_file_t *W_Win32_OpenFile(const char *path)
 {
     win32_wad_file_t *result;
     wchar_t wpath[MAX_PATH + 1];

--- a/src/w_main.c
+++ b/src/w_main.c
@@ -16,6 +16,8 @@
 //     Common code to parse command line, identifying WAD files to load.
 //
 
+#include <stdlib.h>
+
 #include "config.h"
 #include "d_iwad.h"
 #include "i_system.h"
@@ -57,6 +59,7 @@ boolean W_ParseCommandLine(void)
 
             printf(" merging %s\n", filename);
             W_MergeFile(filename);
+            free(filename);
         }
     }
 
@@ -85,6 +88,7 @@ boolean W_ParseCommandLine(void)
 
             printf(" performing NWT-style merge of %s\n", filename);
             W_NWTDashMerge(filename);
+            free(filename);
         }
     }
     
@@ -112,6 +116,7 @@ boolean W_ParseCommandLine(void)
 
             printf(" merging flats from %s\n", filename);
             W_NWTMergeFile(filename, W_NWT_MERGE_FLATS);
+            free(filename);
         }
     }
 
@@ -136,6 +141,7 @@ boolean W_ParseCommandLine(void)
 
             printf(" merging sprites from %s\n", filename);
             W_NWTMergeFile(filename, W_NWT_MERGE_SPRITES);
+            free(filename);
         }
     }
 
@@ -160,6 +166,7 @@ boolean W_ParseCommandLine(void)
 
             printf(" merging sprites and flats from %s\n", filename);
             W_NWTMergeFile(filename, W_NWT_MERGE_SPRITES | W_NWT_MERGE_FLATS);
+            free(filename);
         }
     }
 
@@ -184,6 +191,7 @@ boolean W_ParseCommandLine(void)
 
             printf(" adding %s\n", filename);
 	    W_AddFile(filename);
+            free(filename);
         }
     }
 

--- a/src/w_merge.c
+++ b/src/w_merge.c
@@ -624,7 +624,7 @@ static void W_NWTAddLumps(searchlist_t *list)
 // Merge sprites and flats in the way NWT does with its -af and -as
 // command-line options.
 
-void W_NWTMergeFile(char *filename, int flags)
+void W_NWTMergeFile(const char *filename, int flags)
 {
     int old_numlumps;
 

--- a/src/w_merge.c
+++ b/src/w_merge.c
@@ -670,7 +670,7 @@ void W_NWTMergeFile(char *filename, int flags)
 // a PWAD, then search the IWAD sprites, removing any sprite lumps that also
 // exist in the PWAD.
 
-void W_NWTDashMerge(char *filename)
+void W_NWTDashMerge(const char *filename)
 {
     wad_file_t *wad_file;
     int old_numlumps;

--- a/src/w_merge.c
+++ b/src/w_merge.c
@@ -567,7 +567,7 @@ void W_PrintDirectory(void)
 
 // Merge in a file by name
 
-void W_MergeFile(char *filename)
+void W_MergeFile(const char *filename)
 {
     int old_numlumps;
 

--- a/src/w_merge.h
+++ b/src/w_merge.h
@@ -26,7 +26,7 @@
 
 // Add a new WAD and merge it into the main directory
 
-void W_MergeFile(char *filename);
+void W_MergeFile(const char *filename);
 
 // NWT-style merging
 

--- a/src/w_merge.h
+++ b/src/w_merge.h
@@ -30,7 +30,7 @@ void W_MergeFile(const char *filename);
 
 // NWT-style merging
 
-void W_NWTMergeFile(char *filename, int flags);
+void W_NWTMergeFile(const char *filename, int flags);
 
 // Acts the same as NWT's "-merge" option.
 

--- a/src/w_merge.h
+++ b/src/w_merge.h
@@ -34,7 +34,7 @@ void W_NWTMergeFile(char *filename, int flags);
 
 // Acts the same as NWT's "-merge" option.
 
-void W_NWTDashMerge(char *filename);
+void W_NWTDashMerge(const char *filename);
 
 // Debug function that prints the WAD directory.
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -100,7 +100,7 @@ unsigned int W_LumpNameHash(const char *s)
 // Other files are single lumps with the base filename
 //  for the lump name.
 
-wad_file_t *W_AddFile (char *filename)
+wad_file_t *W_AddFile (const char *filename)
 {
     wadinfo_t header;
     lumpindex_t i;

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -53,7 +53,7 @@ struct lumpinfo_s
 extern lumpinfo_t **lumpinfo;
 extern unsigned int numlumps;
 
-wad_file_t *W_AddFile(char *filename);
+wad_file_t *W_AddFile(const char *filename);
 void W_Reload(void);
 
 lumpindex_t W_CheckNumForName(const char *name);


### PR DESCRIPTION
Also fixes some potential memory leaks in WAD code.

You should compile-test on Windows before merge, this touches some Windows-specific code and I have not tested that.

Also I think warnings caused by `-Wcast-qual` can't be fixed easily because for some reason `SDL_CreateRGBSurfaceFrom` first parameter is not const.
