### PR TITLE
move common "enum gamestate_t" to the d_mode.h header

### DIFF
--- a/src/d_mode.h
+++ b/src/d_mode.h
@@ -22,6 +22,20 @@
 
 #include "doomtype.h"
 
+// The current state of the game: whether we are
+// playing, gazing at the intermission screen,
+// the game final animation, or a demo.
+
+typedef enum
+{
+    GS_LEVEL,
+    GS_INTERMISSION,
+    GS_FINALE,
+    GS_DEMOSCREEN,
+} gamestate_t;
+
+#define GS_UNKNOWN GS_INTERMISSION // STRIFE-TODO: rename?
+
 // The "mission" controls what game we are playing.
 
 typedef enum

--- a/src/doom/doomdef.h
+++ b/src/doom/doomdef.h
@@ -44,17 +44,6 @@
 // The maximum number of players, multiplayer/networking.
 #define MAXPLAYERS 4
 
-// The current state of the game: whether we are
-// playing, gazing at the intermission screen,
-// the game final animation, or a demo. 
-typedef enum
-{
-    GS_LEVEL,
-    GS_INTERMISSION,
-    GS_FINALE,
-    GS_DEMOSCREEN,
-} gamestate_t;
-
 typedef enum
 {
     ga_nothing,

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -88,14 +88,6 @@
 
 typedef enum
 {
-    GS_LEVEL,
-    GS_INTERMISSION,
-    GS_FINALE,
-    GS_DEMOSCREEN
-} gamestate_t;
-
-typedef enum
-{
     ga_nothing,
     ga_loadlevel,
     ga_newgame,

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -117,14 +117,6 @@
 
 typedef enum
 {
-    GS_LEVEL,
-    GS_INTERMISSION,
-    GS_FINALE,
-    GS_DEMOSCREEN
-} gamestate_t;
-
-typedef enum
-{
     ga_nothing,
     ga_loadlevel,
     ga_initnew,

--- a/src/strife/doomdef.h
+++ b/src/strife/doomdef.h
@@ -46,17 +46,6 @@
 // most parameter validation debugging code will not be compiled
 #define RANGECHECK
 
-// The current state of the game: whether we are
-// playing, gazing at the intermission screen,
-// the game final animation, or a demo. 
-typedef enum
-{
-    GS_LEVEL,
-    GS_UNKNOWN,
-    GS_FINALE,
-    GS_DEMOSCREEN,
-} gamestate_t;
-
 typedef enum
 {
     ga_nothing,


### PR DESCRIPTION
This makes no difference for Choco, but for derivatives it might be
interesting for the renderer to know the current gamestate in order
to decide whether to render e.g. with an uncapped framerate or not.