### PR TITLE
Heretic: Fix P_FindNextHighestFloor's behavior

### DIFF
--- a/src/heretic/p_spec.c
+++ b/src/heretic/p_spec.c
@@ -424,6 +424,13 @@ fixed_t P_FindNextHighestFloor(sector_t * sec, int currentheight)
         }
     }
 
+    // Don't return INT_MAX if no higher floor is found.
+
+    if (!h)
+    {
+        return height;
+    }
+
     // Compatibility note, in case of demo desyncs.
 
     if (h > 20)


### PR DESCRIPTION
The floor would raise to INT_MAX if no surrounding sector was higher, which isn't how vanilla Heretic behaves.

This issue has been discussed on Doomworld [here](https://www.doomworld.com/forum/post/1903029).

A map and a savegame are available [here](https://files.fm/f/6x4qz2yg). Pressing the switch in the room on the right will cause the floor in front of the two pillars to raise. The floor bellow each pillar has been accidentally tagged with the same tag has the floor in front of them. The bug causes them to raise through the ceiling, but this doesn't happen in vanilla Heretic or with this fix. 