### PR TITLE
setup: Use proper function signatures for callbacks

### DIFF
--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -27,7 +27,7 @@
 int vanilla_savegame_limit = 1;
 int vanilla_demo_limit = 1;
 
-void CompatibilitySettings(void)
+void CompatibilitySettings(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
 

--- a/src/setup/compatibility.h
+++ b/src/setup/compatibility.h
@@ -15,7 +15,7 @@
 #ifndef SETUP_COMPATIBILITY_H
 #define SETUP_COMPATIBILITY_H
 
-void CompatibilitySettings(void);
+void CompatibilitySettings(void *widget, void *user_data);
 void BindCompatibilityVariables(void);
 
 extern int vanilla_savegame_limit;

--- a/src/setup/display.c
+++ b/src/setup/display.c
@@ -212,7 +212,7 @@ static void AdvancedDisplayConfig(TXT_UNCAST_ARG(widget),
     TXT_SignalConnect(ar_checkbox, "changed", GenerateSizesTable, sizes_table);
 }
 
-void ConfigDisplay(void)
+void ConfigDisplay(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
     txt_table_t *sizes_table;

--- a/src/setup/display.h
+++ b/src/setup/display.h
@@ -15,7 +15,7 @@
 #ifndef SETUP_DISPLAY_H 
 #define SETUP_DISPLAY_H
 
-void ConfigDisplay(void);
+void ConfigDisplay(void *widget, void *user_data);
 void SetDisplayDriver(void);
 void BindDisplayVariables(void);
 

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -986,7 +986,7 @@ static void AddJoystickControl(TXT_UNCAST_ARG(table), char *label, int *var)
                    NULL);
 }
 
-void ConfigJoystick(void)
+void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
 

--- a/src/setup/joystick.h
+++ b/src/setup/joystick.h
@@ -17,7 +17,7 @@
 
 extern int joystick_index;
 
-void ConfigJoystick(void);
+void ConfigJoystick(void *widget, void *user_data);
 void BindJoystickVariables(void);
 
 #endif /* #ifndef SETUP_JOYSTICK_H */

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -358,7 +358,7 @@ static void OtherKeysDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     TXT_AddWidget(window, scrollpane);
 }
 
-void ConfigKeyboard(void)
+void ConfigKeyboard(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
     txt_checkbox_t *run_control;

--- a/src/setup/keyboard.h
+++ b/src/setup/keyboard.h
@@ -15,7 +15,7 @@
 #ifndef SETUP_KEYBOARD_H 
 #define SETUP_KEYBOARD_H 
 
-void ConfigKeyboard(void);
+void ConfigKeyboard(void *widget, void *user_data);
 void BindKeyboardVariables(void);
 
 extern int vanilla_keyboard_mapping;

--- a/src/setup/mouse.c
+++ b/src/setup/mouse.c
@@ -109,7 +109,7 @@ static void ConfigExtraButtons(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     AddMouseControl(buttons_table, "Next weapon", &mousebnextweapon);
 }
 
-void ConfigMouse(void)
+void ConfigMouse(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
 

--- a/src/setup/mouse.h
+++ b/src/setup/mouse.h
@@ -15,7 +15,7 @@
 #ifndef SETUP_MOUSE_H
 #define SETUP_MOUSE_H
 
-void ConfigMouse(void);
+void ConfigMouse(void *widget, void *user_data);
 void BindMouseVariables(void);
 
 extern int novert;

--- a/src/setup/multiplayer.c
+++ b/src/setup/multiplayer.c
@@ -798,12 +798,12 @@ static void StartGameMenu(char *window_title, int multiplayer)
     UpdateWarpButton();
 }
 
-void StartMultiGame(void)
+void StartMultiGame(TXT_UNCAST_ARG(widget), void *user_data)
 {
     StartGameMenu("Start multiplayer game", 1);
 }
 
-void WarpMenu(void)
+void WarpMenu(TXT_UNCAST_ARG(widget), void *user_data)
 {
     StartGameMenu("Level Warp", 0);
 }
@@ -1016,7 +1016,7 @@ static void FindLANServer(TXT_UNCAST_ARG(widget),
     ServerQueryWindow("Find LAN server");
 }
 
-void JoinMultiGame(void)
+void JoinMultiGame(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
     txt_inputbox_t *address_box;
@@ -1121,7 +1121,7 @@ void SetPlayerNameDefault(void)
 #endif
 }
 
-void MultiplayerConfig(void)
+void MultiplayerConfig(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
     txt_label_t *label;

--- a/src/setup/multiplayer.h
+++ b/src/setup/multiplayer.h
@@ -15,10 +15,10 @@
 #ifndef SETUP_MULTIPLAYER_H
 #define SETUP_MULTIPLAYER_H
 
-void StartMultiGame(void);
-void WarpMenu(void);
-void JoinMultiGame(void);
-void MultiplayerConfig(void);
+void StartMultiGame(void *widget, void *user_data);
+void WarpMenu(void *widget, void *user_data);
+void JoinMultiGame(void *widget, void *user_data);
+void MultiplayerConfig(void *widget, void *user_data);
 
 void SetChatMacroDefaults(void);
 void SetPlayerNameDefault(void);

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -113,7 +113,7 @@ static txt_dropdown_list_t *OPLTypeSelector(void)
     return result;
 }
 
-void ConfigSound(void)
+void ConfigSound(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
 

--- a/src/setup/sound.h
+++ b/src/setup/sound.h
@@ -17,7 +17,7 @@
 
 #include "i_sound.h"
 
-void ConfigSound(void);
+void ConfigSound(void *widget, void *user_data);
 void BindSoundVariables(void);
 
 extern char *snd_dmxoption;


### PR DESCRIPTION
This prevents the setup main menu from crashing when the caller does not clean the stack.