### PR TITLE
Hexen: Call W_GenerateHashTable()

### DIFF
--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -424,6 +424,9 @@ void D_DoomMain(void)
 
     HandleArgs();
 
+    // Generate the WAD hash table.  Speed things up a bit.
+    W_GenerateHashTable();
+
     I_PrintStartupBanner(gamedescription);
 
     ST_Message("MN_Init: Init menu system.\n");


### PR DESCRIPTION
Since [this has been done for Heretic](https://github.com/chocolate-doom/chocolate-doom/pull/1094), do it for Hexen. 

This fixes https://github.com/chocolate-doom/chocolate-doom/issues/976. I call W_GenerateHashTable() once the main WAD functions have been called and the command line args have been parsed, following the way it's done for other games. 