### PR TITLE
Fix memory leak related to Steam directories

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -677,6 +677,7 @@ static void AddSteamDirs(void)
     AddIWADPath(steampath, "/Hexen/base");
     AddIWADPath(steampath, "/Hexen Deathkings of the Dark Citadel/base");
     AddIWADPath(steampath, "/Strife");
+    free(steampath);
 }
 #endif // __MACOSX__
 #endif // !_WIN32


### PR DESCRIPTION
Valgrind report (with `--leak-check=full`) before the fix:

```
==30991== 40 bytes in 1 blocks are definitely lost in loss record 70 of 277
==30991==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==30991==    by 0x11B797: M_StringJoin (m_misc.c:575)
==30991==    by 0x11CCC6: AddSteamDirs (d_iwad.c:669)
==30991==    by 0x11CCC6: BuildIWADDirList.part.0 (d_iwad.c:735)
==30991==    by 0x11D032: BuildIWADDirList (d_iwad.c:484)
==30991==    by 0x11D032: D_FindIWAD (d_iwad.c:864)
==30991==    by 0x13840A: D_DoomMain (d_main.c:1415)
==30991==    by 0x11A2FD: main (i_main.c:52)
```