### PR TITLE
Remove long-opt variant of version

### DIFF
--- a/src/i_main.c
+++ b/src/i_main.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
     //!
     // Print the program version and exit.
     //
-    if (M_ParmExists("-version") || M_ParmExists("--version")) {
+    if (M_ParmExists("-version")) {
         puts(PACKAGE_STRING);
         exit(0);
     }


### PR DESCRIPTION
Let's stick to single-dash delimited arguments, in common with the
existing ones. Double-dash are a GNU convention for "long options",
typically spelled out (so, -v or --version). We don't use the GNU
conventions in this project. Having the second option is out of
place and potentially causes unnecessary complexity in other places
(shell completion, documentation…)