### PR TITLE
Doom: don't divide by zero, but call I_Error instead.

### DIFF
--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -1909,6 +1909,10 @@ void A_BrainSpit (mobj_t*	mo)
 		
     // shoot a cube at current target
     targ = braintargets[braintargeton];
+    if (numbraintargets == 0) {
+        I_Error("A_BrainSpit: numbraintargets was 0 (vanilla crashes here)");
+        return;
+    }
     braintargeton = (braintargeton+1)%numbraintargets;
 
     // spawn brain missile

--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -1909,9 +1909,9 @@ void A_BrainSpit (mobj_t*	mo)
 		
     // shoot a cube at current target
     targ = braintargets[braintargeton];
-    if (numbraintargets == 0) {
+    if (numbraintargets == 0)
+    {
         I_Error("A_BrainSpit: numbraintargets was 0 (vanilla crashes here)");
-        return;
     }
     braintargeton = (braintargeton+1)%numbraintargets;
 


### PR DESCRIPTION
When loading from a save game, vanilla Doom forgets to initialize some
variables related to the final boss/Romero's head. In particular, a
count of the number of spawn points can end up being set to zero. Later,
when selecting a spawn target, a division by zero can occur. Vanilla
will simply crash. In Chocolate Doom, we should exit out gracefully
instead.