### PR TITLE
Fix i_glob.c compilation under MSVC (and CMake)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,9 +95,14 @@ set(GAME_SOURCE_FILES
     w_merge.c           w_merge.h
     z_zone.c            z_zone.h)
 
+set(GAME_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../")
+
 if(MSVC)
     list(APPEND GAME_SOURCE_FILES
          "../win32/win_opendir.c" "../win32/win_opendir.h")
+
+    list(APPEND GAME_INCLUDE_DIRS
+         "${PROJECT_SOURCE_DIR}/win32/")
 endif()
 
 set(DEHACKED_SOURCE_FILES
@@ -126,8 +131,7 @@ else()
     add_executable("${PROGRAM_PREFIX}doom" ${SOURCE_FILES_WITH_DEH})
 endif()
 
-target_include_directories("${PROGRAM_PREFIX}doom"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../" "${PROJECT_SOURCE_DIR}/win32/")
+target_include_directories("${PROGRAM_PREFIX}doom" PRIVATE ${GAME_INCLUDE_DIRS})
 target_link_libraries("${PROGRAM_PREFIX}doom" doom ${EXTRA_LIBS})
 
 if(MSVC)
@@ -141,8 +145,7 @@ else()
     add_executable("${PROGRAM_PREFIX}heretic" ${SOURCE_FILES_WITH_DEH})
 endif()
 
-target_include_directories("${PROGRAM_PREFIX}heretic"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../" "${PROJECT_SOURCE_DIR}/win32/")
+target_include_directories("${PROGRAM_PREFIX}heretic" PRIVATE ${GAME_INCLUDE_DIRS})
 target_link_libraries("${PROGRAM_PREFIX}heretic" heretic ${EXTRA_LIBS})
 
 if(MSVC)
@@ -156,8 +159,7 @@ else()
     add_executable("${PROGRAM_PREFIX}hexen" ${SOURCE_FILES})
 endif()
 
-target_include_directories("${PROGRAM_PREFIX}hexen"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../" "${PROJECT_SOURCE_DIR}/win32/")
+target_include_directories("${PROGRAM_PREFIX}hexen" PRIVATE ${GAME_INCLUDE_DIRS})
 target_link_libraries("${PROGRAM_PREFIX}hexen" hexen ${EXTRA_LIBS})
 
 if(MSVC)
@@ -171,8 +173,7 @@ else()
     add_executable("${PROGRAM_PREFIX}strife" ${SOURCE_FILES_WITH_DEH})
 endif()
 
-target_include_directories("${PROGRAM_PREFIX}strife"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../" "${PROJECT_SOURCE_DIR}/win32/")
+target_include_directories("${PROGRAM_PREFIX}strife" PRIVATE ${GAME_INCLUDE_DIRS})
 target_link_libraries("${PROGRAM_PREFIX}strife" strife ${EXTRA_LIBS})
 
 if(MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,7 +127,7 @@ else()
 endif()
 
 target_include_directories("${PROGRAM_PREFIX}doom"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
+                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../" "${PROJECT_SOURCE_DIR}/win32/")
 target_link_libraries("${PROGRAM_PREFIX}doom" doom ${EXTRA_LIBS})
 
 if(MSVC)
@@ -142,7 +142,7 @@ else()
 endif()
 
 target_include_directories("${PROGRAM_PREFIX}heretic"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
+                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../" "${PROJECT_SOURCE_DIR}/win32/")
 target_link_libraries("${PROGRAM_PREFIX}heretic" heretic ${EXTRA_LIBS})
 
 if(MSVC)
@@ -157,7 +157,7 @@ else()
 endif()
 
 target_include_directories("${PROGRAM_PREFIX}hexen"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
+                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../" "${PROJECT_SOURCE_DIR}/win32/")
 target_link_libraries("${PROGRAM_PREFIX}hexen" hexen ${EXTRA_LIBS})
 
 if(MSVC)
@@ -172,7 +172,7 @@ else()
 endif()
 
 target_include_directories("${PROGRAM_PREFIX}strife"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
+                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../" "${PROJECT_SOURCE_DIR}/win32/")
 target_link_libraries("${PROGRAM_PREFIX}strife" strife ${EXTRA_LIBS})
 
 if(MSVC)

--- a/src/i_glob.c
+++ b/src/i_glob.c
@@ -27,6 +27,8 @@
 #if defined(_MSC_VER)
 // For Visual C++, we need to include the win_opendir module.
 #include <win_opendir.h>
+#include <sys/stat.h>
+#define S_ISDIR(m)      (((m)& S_IFMT) == S_IFDIR)
 #elif defined(HAVE_DIRENT_H)
 #include <dirent.h>
 #include <sys/stat.h>


### PR DESCRIPTION
This fixes issue #1109, which I have commented on. The changes to i_glob.c are minimal (defining `S_ISDIR` and including `sys/stat.h`). The CMake changes impact the chocolate-(doom|heretic|hexen|strife) projects. Hopefully everything is fine, but I'm good to make whatever changes are necessary.