### PR TITLE
doom: use separate pointers and buffers for demo recording and playback

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -454,9 +454,6 @@ void D_DoomLoop (void)
                " may cause demos and network games to get out of sync.\n");
     }
 
-    if (demorecording)
-	G_BeginRecording ();
-
     main_loop_started = true;
 
     I_SetWindowTitle(gamedescription);

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -134,8 +134,10 @@ boolean         longtics;               // cph's doom 1.91 longtics hack
 boolean         lowres_turn;            // low resolution turning for longtics
 boolean         demoplayback; 
 boolean		netdemo; 
-byte*		demobuffer;
-byte*		demo_p;
+byte*		demo_in_buffer;
+byte*		demo_out_buffer;
+byte*		demo_in_p;
+byte*		demo_out_p = NULL;
 byte*		demoend; 
 boolean         singledemo;            	// quit after playing a demo from cmdline 
  
@@ -1910,28 +1912,28 @@ G_InitNew
 
 void G_ReadDemoTiccmd (ticcmd_t* cmd) 
 { 
-    if (*demo_p == DEMOMARKER) 
+    if (*demo_in_p == DEMOMARKER)
     {
-	// end of demo data stream 
-	G_CheckDemoStatus (); 
-	return; 
-    } 
-    cmd->forwardmove = ((signed char)*demo_p++); 
-    cmd->sidemove = ((signed char)*demo_p++); 
+	// end of demo data stream
+	G_CheckDemoStatus ();
+	return;
+    }
+    cmd->forwardmove = ((signed char)*demo_in_p++);
+    cmd->sidemove = ((signed char)*demo_in_p++);
 
     // If this is a longtics demo, read back in higher resolution
 
     if (longtics)
     {
-        cmd->angleturn = *demo_p++;
-        cmd->angleturn |= (*demo_p++) << 8;
+        cmd->angleturn = *demo_in_p++;
+        cmd->angleturn |= (*demo_in_p++) << 8;
     }
     else
     {
-        cmd->angleturn = ((unsigned char) *demo_p++)<<8; 
+        cmd->angleturn = ((unsigned char) *demo_in_p++)<<8;
     }
 
-    cmd->buttons = (unsigned char)*demo_p++; 
+    cmd->buttons = (unsigned char)*demo_in_p++;
 } 
 
 // Increase the size of the demo buffer to allow unlimited demos
@@ -1945,57 +1947,62 @@ static void IncreaseDemoBuffer(void)
 
     // Find the current size
 
-    current_length = demoend - demobuffer;
+    current_length = demoend - demo_out_buffer;
     
     // Generate a new buffer twice the size
     new_length = current_length * 2;
     
     new_demobuffer = Z_Malloc(new_length, PU_STATIC, 0);
-    new_demop = new_demobuffer + (demo_p - demobuffer);
+    new_demop = new_demobuffer + (demo_out_p - demo_out_buffer);
 
     // Copy over the old data
 
-    memcpy(new_demobuffer, demobuffer, current_length);
+    memcpy(new_demobuffer, demo_out_buffer, current_length);
 
     // Free the old buffer and point the demo pointers at the new buffer.
 
-    Z_Free(demobuffer);
+    Z_Free(demo_out_buffer);
 
-    demobuffer = new_demobuffer;
-    demo_p = new_demop;
-    demoend = demobuffer + new_length;
+    demo_out_buffer = new_demobuffer;
+    demo_out_p = new_demop;
+    demoend = demo_out_buffer + new_length;
 }
 
 void G_WriteDemoTiccmd (ticcmd_t* cmd) 
-{ 
+{
     byte *demo_start;
 
-    if (gamekeydown[key_demo_quit])           // press q to end demo recording 
-	G_CheckDemoStatus (); 
+    if (demo_out_p == NULL)
+    {
+        G_BeginRecording();
+    }
 
-    demo_start = demo_p;
+    if (gamekeydown[key_demo_quit])           // press q to end demo recording
+	G_CheckDemoStatus ();
 
-    *demo_p++ = cmd->forwardmove; 
-    *demo_p++ = cmd->sidemove; 
+    demo_start = demo_out_p;
+
+    *demo_out_p++ = cmd->forwardmove;
+    *demo_out_p++ = cmd->sidemove;
 
     // If this is a longtics demo, record in higher resolution
  
     if (longtics)
     {
-        *demo_p++ = (cmd->angleturn & 0xff);
-        *demo_p++ = (cmd->angleturn >> 8) & 0xff;
+        *demo_out_p++ = (cmd->angleturn & 0xff);
+        *demo_out_p++ = (cmd->angleturn >> 8) & 0xff;
     }
     else
     {
-        *demo_p++ = cmd->angleturn >> 8; 
+        *demo_out_p++ = cmd->angleturn >> 8;
     }
 
-    *demo_p++ = cmd->buttons; 
+    *demo_out_p++ = cmd->buttons;
 
     // reset demo pointer back
-    demo_p = demo_start;
+    demo_out_p = demo_start;
 
-    if (demo_p > demoend - 16)
+    if (demo_out_p > demoend - 16)
     {
         if (vanilla_demo_limit)
         {
@@ -2043,8 +2050,8 @@ void G_RecordDemo (char *name)
     i = M_CheckParmWithArgs("-maxdemo", 1);
     if (i)
 	maxsize = atoi(myargv[i+1])*1024;
-    demobuffer = Z_Malloc (maxsize,PU_STATIC,NULL); 
-    demoend = demobuffer + maxsize;
+    demo_out_buffer = Z_Malloc (maxsize,PU_STATIC,NULL);
+    demoend = demo_out_buffer + maxsize;
 	
     demorecording = true; 
 } 
@@ -2072,7 +2079,7 @@ void G_BeginRecording (void)
 { 
     int             i; 
 
-    demo_p = demobuffer;
+    demo_out_p = demo_out_buffer;
 
     //!
     // @category demo
@@ -2088,24 +2095,24 @@ void G_BeginRecording (void)
 
     if (longtics)
     {
-        *demo_p++ = DOOM_191_VERSION;
+        *demo_out_p++ = DOOM_191_VERSION;
     }
     else
     {
-        *demo_p++ = G_VanillaVersionCode();
+        *demo_out_p++ = G_VanillaVersionCode();
     }
 
-    *demo_p++ = gameskill; 
-    *demo_p++ = gameepisode; 
-    *demo_p++ = gamemap; 
-    *demo_p++ = deathmatch; 
-    *demo_p++ = respawnparm;
-    *demo_p++ = fastparm;
-    *demo_p++ = nomonsters;
-    *demo_p++ = consoleplayer;
-	 
+    *demo_out_p++ = gameskill;
+    *demo_out_p++ = gameepisode;
+    *demo_out_p++ = gamemap;
+    *demo_out_p++ = deathmatch;
+    *demo_out_p++ = respawnparm;
+    *demo_out_p++ = fastparm;
+    *demo_out_p++ = nomonsters;
+    *demo_out_p++ = consoleplayer;
+
     for (i=0 ; i<MAXPLAYERS ; i++) 
-	*demo_p++ = playeringame[i]; 		 
+	*demo_out_p++ = playeringame[i];
 } 
  
 
@@ -2170,10 +2177,10 @@ void G_DoPlayDemo (void)
 
     lumpnum = W_GetNumForName(defdemoname);
     gameaction = ga_nothing;
-    demobuffer = W_CacheLumpNum(lumpnum, PU_STATIC);
-    demo_p = demobuffer;
+    demo_in_buffer = W_CacheLumpNum(lumpnum, PU_STATIC);
+    demo_in_p = demo_in_buffer;
 
-    demoversion = *demo_p++;
+    demoversion = *demo_in_p++;
 
     longtics = false;
 
@@ -2199,17 +2206,17 @@ void G_DoPlayDemo (void)
                          DemoVersionDescription(demoversion));
     }
 
-    skill = *demo_p++; 
-    episode = *demo_p++; 
-    map = *demo_p++; 
-    deathmatch = *demo_p++;
-    respawnparm = *demo_p++;
-    fastparm = *demo_p++;
-    nomonsters = *demo_p++;
-    consoleplayer = *demo_p++;
+    skill = *demo_in_p++;
+    episode = *demo_in_p++;
+    map = *demo_in_p++;
+    deathmatch = *demo_in_p++;
+    respawnparm = *demo_in_p++;
+    fastparm = *demo_in_p++;
+    nomonsters = *demo_in_p++;
+    consoleplayer = *demo_in_p++;
 	
     for (i=0 ; i<MAXPLAYERS ; i++) 
-	playeringame[i] = *demo_p++; 
+	playeringame[i] = *demo_in_p++;
 
     if (playeringame[1] || M_CheckParm("-solo-net") > 0
                         || M_CheckParm("-netdemo") > 0)
@@ -2304,9 +2311,9 @@ boolean G_CheckDemoStatus (void)
  
     if (demorecording) 
     { 
-	*demo_p++ = DEMOMARKER; 
-	M_WriteFile (demoname, demobuffer, demo_p - demobuffer); 
-	Z_Free (demobuffer); 
+	*demo_out_p++ = DEMOMARKER;
+	M_WriteFile (demoname, demo_out_buffer, demo_out_p - demo_out_buffer);
+	Z_Free (demo_out_buffer);
 	demorecording = false; 
 	I_Error ("Demo %s recorded",demoname); 
     } 


### PR DESCRIPTION
This makes no difference for Chocolate Doom but acts as a preparation
for a continue-recording feature that @fragglet proposed for Crispy Doom in

https://github.com/fabiangreffrath/crispy-doom/pull/376

It helps maintaining a reasonably small interdiff between both ports.