### PR TITLE
sound: Initialize SDL_Mixer for digital/MIDI music playback

### DIFF
--- a/src/i_musicpack.c
+++ b/src/i_musicpack.c
@@ -1148,6 +1148,9 @@ static boolean I_MP_InitMusic(void)
         music_initialized = true;
     }
 
+    // Initialize SDL_Mixer for digital music playback
+    Mix_Init(MIX_INIT_FLAC | MIX_INIT_OGG | MIX_INIT_MP3);
+
     // Register an effect function to track the music position.
     Mix_RegisterEffect(MIX_CHANNEL_POST, TrackPositionCallback, NULL, NULL);
 

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -195,6 +195,9 @@ static boolean I_SDL_InitMusic(void)
     }
 
     // Initialize SDL_Mixer for MIDI music playback
+#ifndef MIX_INIT_MID
+#define MIX_INIT_MID 0
+#endif
     Mix_Init(MIX_INIT_MID);
 
     // Once initialization is complete, the temporary Timidity config

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -194,6 +194,9 @@ static boolean I_SDL_InitMusic(void)
         }
     }
 
+    // Initialize SDL_Mixer for MIDI music playback
+    Mix_Init(MIX_INIT_MID);
+
     // Once initialization is complete, the temporary Timidity config
     // file can be removed.
 

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -194,11 +194,10 @@ static boolean I_SDL_InitMusic(void)
         }
     }
 
+#ifdef MIX_INIT_MID
     // Initialize SDL_Mixer for MIDI music playback
-#ifndef MIX_INIT_MID
-#define MIX_INIT_MID 0
-#endif
     Mix_Init(MIX_INIT_MID);
+#endif
 
     // Once initialization is complete, the temporary Timidity config
     // file can be removed.


### PR DESCRIPTION
This will lead to Mix_GetMusicDecoder() actually returning the
avaiable music backends and thus get midiproc back to working again.

Fixes #1147