### PR TITLE
Report number of scrollers when there are too many

### DIFF
--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -1369,6 +1369,19 @@ int EV_DoDonut(line_t*	line)
 short		numlinespecials;
 line_t*		linespeciallist[MAXLINEANIMS];
 
+static unsigned int NumScrollers()
+{
+    unsigned int i, scrollers = 0;
+
+    for (i = 0; i < numlines; i++)
+    {
+        if (48 == lines[i].special)
+        {
+            scrollers++;
+        }
+    }
+    return scrollers;
+}
 
 // Parses command line parameters.
 void P_SpawnSpecials (void)
@@ -1463,8 +1476,8 @@ void P_SpawnSpecials (void)
 	  case 48:
             if (numlinespecials >= MAXLINEANIMS)
             {
-                I_Error("Too many scrolling wall linedefs! "
-                        "(Vanilla limit is 64)");
+                I_Error("Too many scrolling wall linedefs (%d)! "
+                        "(Vanilla limit is 64)", NumScrollers());
             }
 	    // EFFECT FIRSTCOL SCROLL+
 	    linespeciallist[numlinespecials] = &lines[i];


### PR DESCRIPTION
When bailing out after the vanilla scrolling wall limit is reached,
report the number of scrolling walls in the current map as part of
the error message. This aids mappers who are working as close to
the limit as possible.