### PR TITLE
allow for loading PWADs and DEHACKED patches by drag-and-drop (take 2)

### DIFF
--- a/src/i_main.c
+++ b/src/i_main.c
@@ -49,6 +49,12 @@ int main(int argc, char **argv)
         exit(0);
     }
 
+#if defined(_WIN32)
+    // Compose a proper command line from loose file names passed as arguments,
+    // this allows for loading PWADs and DEHACKED patches by drag-and-drop.
+    M_AddLooseFiles();
+#endif
+
     M_FindResponseFile();
 
     #ifdef SDL_HINT_NO_SIGNAL_HANDLERS

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -368,12 +368,16 @@ void M_AddLooseFiles(void)
                     newargv[i++] = (*(params[j].list))[k];
                 }
             }
-
-            free(*(params[j].list));
         }
 
         myargc = newargc;
         myargv = newargv;
+    }
+
+    // free allocated memory
+    for (j = 0; j < arrlen(params); j++)
+    {
+        free(*(params[j].list));
     }
 }
 

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -315,9 +315,10 @@ void M_AddLooseFiles(void)
     }
 
     // we will find at most myargc files of a kind
-    wads = malloc(myargc * sizeof(*wads));
-    lmps = malloc(myargc * sizeof(*lmps));
-    dehs = malloc(myargc * sizeof(*dehs));
+    for (j = 0; j < arrlen(params); j++)
+    {
+        *(params[j].list) = malloc(myargc * sizeof(char *));
+    }
 
     // identify loose files on the command line by their extensions
     for (i = 1; i < myargc; i++)

--- a/src/m_argv.h
+++ b/src/m_argv.h
@@ -37,6 +37,7 @@ int M_CheckParm (const char* check);
 int M_CheckParmWithArgs(const char *check, int num_args);
 
 void M_FindResponseFile(void);
+void M_AddLooseFiles(void);
 
 // Parameter has been specified?
 


### PR DESCRIPTION
Compose a proper command line from loose file names passed as
arguments. This allows for loading PWADs and DEHACKED patches by
dragging them onto the game executable in e.g. Windows Explorer.

Implementation loosely based on the one from PrBoom+, but vastly
simplified, since we don't support mixing with regular command line
parameters or response files.

Fixes #1161