### PR TITLE
textscreen: Fix ambiguous textscreen CMake line

### DIFF
--- a/textscreen/CMakeLists.txt
+++ b/textscreen/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(textscreen
+add_library(textscreen STATIC
             textscreen.h
             txt_conditional.c   txt_conditional.h
             txt_checkbox.c      txt_checkbox.h


### PR DESCRIPTION
The add_library CMake line for textscreen does not specify the type of
library, thus leaving the build behavior ambiguous. This can cause
problems when certain build systems are configured for dynamic linkage
build mode (e.g. Gentoo Linux defaults to "BUILD_SHARE_LIBS=ON"),
causing the internal textscreen library to be compiled but not linked to
the chocolate-doom executable as would be expected.

This patch fixes the ambiguity by specifying a STATIC type for the
internal textscreen library, thus resolving the build issues experienced
on Gentoo Linux and other similar system environments.