### PR TITLE
tolerate up to 1s delay when opening a file for writing

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -360,6 +360,8 @@ static boolean IsMid(byte *mem, int len)
     return len > 4 && !memcmp(mem, "MThd", 4);
 }
 
+#define WRITE_TIMEOUT 1000 // ms
+
 static boolean ConvertMus(byte *musdata, int len, const char *filename)
 {
     MEMFILE *instream;
@@ -377,7 +379,7 @@ static boolean ConvertMus(byte *musdata, int len, const char *filename)
     {
         mem_get_buf(outstream, &outbuf, &outbuf_len);
 
-        M_WriteFile(filename, outbuf, outbuf_len);
+        M_WriteFileTimeout(filename, outbuf, outbuf_len, WRITE_TIMEOUT);
     }
 
     mem_fclose(instream);
@@ -403,7 +405,7 @@ static void *I_SDL_RegisterSong(void *data, int len)
 
     if (IsMid(data, len) && len < MAXMIDLENGTH)
     {
-        M_WriteFile(filename, data, len);
+        M_WriteFileTimeout(filename, data, len, WRITE_TIMEOUT);
     }
     else
     {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -42,6 +42,7 @@
 
 #include "i_swap.h"
 #include "i_system.h"
+#include "i_timer.h"
 #include "i_video.h"
 #include "m_misc.h"
 #include "v_video.h"
@@ -182,8 +183,16 @@ boolean M_WriteFile(const char *name, const void *source, int length)
 {
     FILE *handle;
     int	count;
+    const int timeout = I_GetTimeMS() + 1000;
 	
     handle = fopen(name, "wb");
+
+    // tolerate up to 1s delay when opening a file for writing
+    while (handle == NULL && I_GetTimeMS() < timeout)
+    {
+        I_Sleep(10);
+        handle = fopen(name, "wb");
+    }
 
     if (handle == NULL)
 	return false;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -183,16 +183,8 @@ boolean M_WriteFile(const char *name, const void *source, int length)
 {
     FILE *handle;
     int	count;
-    const int timeout = I_GetTimeMS() + 1000;
 	
     handle = fopen(name, "wb");
-
-    // tolerate up to 1s delay when opening a file for writing
-    while (handle == NULL && I_GetTimeMS() < timeout)
-    {
-        I_Sleep(10);
-        handle = fopen(name, "wb");
-    }
 
     if (handle == NULL)
 	return false;
@@ -206,6 +198,22 @@ boolean M_WriteFile(const char *name, const void *source, int length)
     return true;
 }
 
+boolean M_WriteFileTimeout(const char *name, const void *source, int length, int delay)
+{
+    boolean res;
+    const int timeout = I_GetTimeMS() + delay;
+
+    res = M_WriteFile(name, source, length);
+
+    // tolerate the given delay when opening a file for writing
+    while (res == false && I_GetTimeMS() < timeout)
+    {
+        I_Sleep(10);
+        res = M_WriteFile(name, source, length);
+    }
+
+    return res;
+}
 
 //
 // M_ReadFile

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -26,6 +26,7 @@
 #include "doomtype.h"
 
 boolean M_WriteFile(const char *name, const void *source, int length);
+boolean M_WriteFileTimeout(const char *name, const void *source, int length, int delay);
 int M_ReadFile(const char *name, byte **buffer);
 void M_MakeDirectory(const char *dir);
 char *M_TempFile(const char *s);


### PR DESCRIPTION
This mitigates a racing condition that may occur when using midiproc
with an advanced audio backend, e.g. fluidsynth with a soundfont for
MIDI rendering.

Before a new song can be played, the main process sends to midiproc
the signal to stop playing the current song. However, it does not
wait for midiproc to succeed with this. Thus, it may happen that the
main process already attempts to override the music lump file on
disc with a new lump, before the previous one has been released by
the music backend. The attempt to open the music file for writing will
fail, but this is actually never checked in the code.

This approach repeatedly tries to open the file for writing for up to
about 1 second, which should be enough time for the music backend to
shut down the previous song and release the file handle.

Reportedly, this fixes #963.

Context: https://github.com/JNechaevsky/russian-doom/issues/127