### PR TITLE
Use inherited handles to communicate with midiproc

### DIFF
--- a/midiproc/main.c
+++ b/midiproc/main.c
@@ -378,28 +378,12 @@ boolean InitSDL()
 //
 // Ensure that we can communicate.
 //
-boolean InitPipes()
+void InitPipes(HANDLE in, HANDLE out)
 {
-    midi_process_in = GetStdHandle(STD_INPUT_HANDLE);
-    if (midi_process_in == INVALID_HANDLE_VALUE)
-    {
-        goto fail;
-    }
-
-    midi_process_out = GetStdHandle(STD_OUTPUT_HANDLE);
-    if (midi_process_out == INVALID_HANDLE_VALUE)
-    {
-        goto fail;
-    }
+    midi_process_in = in;
+    midi_process_out = out;
 
     atexit(FreePipes);
-
-    return true;
-
-fail:
-    FreePipes();
-
-    return false;
 }
 
 //
@@ -410,7 +394,7 @@ fail:
 int main(int argc, char *argv[])
 {
     // Make sure we're not launching this process by itself.
-    if (argc < 3)
+    if (argc < 5)
     {
         MessageBox(NULL, TEXT("This program is tasked with playing Native ")
                    TEXT("MIDI music, and is intended to be launched by ")
@@ -446,10 +430,20 @@ int main(int argc, char *argv[])
         snd_samplerate = 44100;
     }
 
-    if (!InitPipes())
+    // Parse out our handle ids.
+    HANDLE in = strtol(argv[3], NULL, 10);
+    if (in == 0)
     {
         return EXIT_FAILURE;
     }
+
+    HANDLE out = strtol(argv[4], NULL, 10);
+    if (out == 0)
+    {
+        return EXIT_FAILURE;
+    }
+
+    InitPipes(in, out);
 
     if (!InitSDL())
     {

--- a/src/i_midipipe.c
+++ b/src/i_midipipe.c
@@ -414,7 +414,7 @@ boolean I_MidiPipe_InitServer()
     DWORD dirname_len;
     char *module = NULL;
     char *cmdline = NULL;
-    char snd_samplerate_buf[8];
+    char params_buf[128];
     SECURITY_ATTRIBUTES sec_attrs;
     PROCESS_INFORMATION proc_info;
     STARTUPINFO startup_info;
@@ -438,13 +438,6 @@ boolean I_MidiPipe_InitServer()
 
     // Define the module.
     module = PROGRAM_PREFIX "midiproc.exe";
-
-    // Define the command line.  Version and Sample Rate follow the
-    // executable name.
-    M_snprintf(snd_samplerate_buf, sizeof(snd_samplerate_buf),
-               "%d", snd_samplerate);
-    cmdline = M_StringJoin(module, " \"" PACKAGE_STRING "\"", " ",
-                           snd_samplerate_buf, NULL);
 
     // Set up pipes
     memset(&sec_attrs, 0, sizeof(SECURITY_ATTRIBUTES));
@@ -476,13 +469,16 @@ boolean I_MidiPipe_InitServer()
         return false;
     }
 
+    // Define the command line.  Version, Sample Rate, and handles follow
+    // the executable name.
+    M_snprintf(params_buf, sizeof(params_buf), "%d %Iu %Iu",
+        snd_samplerate, midi_process_in_reader, midi_process_out_writer);
+    cmdline = M_StringJoin(module, " \"" PACKAGE_STRING "\"", " ", params_buf, NULL);
+
     // Launch the subprocess
     memset(&proc_info, 0, sizeof(proc_info));
     memset(&startup_info, 0, sizeof(startup_info));
     startup_info.cb = sizeof(startup_info);
-    startup_info.hStdInput = midi_process_in_reader;
-    startup_info.hStdOutput = midi_process_out_writer;
-    startup_info.dwFlags = STARTF_USESTDHANDLES;
 
     ok = CreateProcess(TEXT(module), TEXT(cmdline), NULL, NULL, TRUE,
                        0, NULL, dirname, &startup_info, &proc_info);


### PR DESCRIPTION
Hopefully this prevents libraries that print error messages to standard
streams from disrupting communication with the subprocess.