### PR TITLE
Doom 1.2 demo support

### DIFF
--- a/src/d_mode.h
+++ b/src/d_mode.h
@@ -56,8 +56,7 @@ typedef enum
 
 typedef enum
 {
-    exe_doom_1_1,    // Doom 1.0/1.1: shareware and registered
-    exe_doom_1_2,    // Doom 1.2: "
+    exe_doom_1_2,    // Doom 1.2: shareware and registered
     exe_doom_1_666,  // Doom 1.666: for shareware, registered and commercial
     exe_doom_1_7,    // Doom 1.7/1.7a: "
     exe_doom_1_8,    // Doom 1.8: "

--- a/src/d_mode.h
+++ b/src/d_mode.h
@@ -56,7 +56,8 @@ typedef enum
 
 typedef enum
 {
-    exe_doom_1_2,    // Doom 1.2: shareware and registered
+    exe_doom_1_1,    // Doom 1.0/1.1: shareware and registered
+    exe_doom_1_2,    // Doom 1.2: "
     exe_doom_1_666,  // Doom 1.666: for shareware, registered and commercial
     exe_doom_1_7,    // Doom 1.7/1.7a: "
     exe_doom_1_8,    // Doom 1.8: "

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -959,6 +959,8 @@ static struct
     const char *cmdline;
     GameVersion_t version;
 } gameversions[] = {
+    {"Doom 1.0/1.1",         "1.1",        exe_doom_1_1},
+    {"Doom 1.2",             "1.2",        exe_doom_1_2},
     {"Doom 1.666",           "1.666",      exe_doom_1_666},
     {"Doom 1.7/1.7a",        "1.7",        exe_doom_1_7},
     {"Doom 1.8",             "1.8",        exe_doom_1_8},
@@ -986,9 +988,9 @@ static void InitGameVersion(void)
     // @arg <version>
     // @category compat
     //
-    // Emulate a specific version of Doom.  Valid values are "1.666",
-    // "1.7", "1.8", "1.9", "ultimate", "final", "final2", "hacx" and
-    // "chex".
+    // Emulate a specific version of Doom.  Valid values are "1.1", "1.2", 
+    // "1.666", "1.7", "1.8", "1.9", "ultimate", "final", "final2", "hacx"
+    // and "chex".
     //
 
     p = M_CheckParmWithArgs("-gameversion", 1);
@@ -1079,6 +1081,12 @@ static void InitGameVersion(void)
                         break;
                     }
                 }
+            }
+
+            // detect v1.0/v1.1 from missing D_INTROA
+            if (gameversion == exe_doom_1_2 && W_CheckNumForName("D_INTROA") < 0)
+            {
+                gameversion = exe_doom_1_1;
             }
         }
         else if (gamemode == retail)

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -959,7 +959,6 @@ static struct
     const char *cmdline;
     GameVersion_t version;
 } gameversions[] = {
-    {"Doom 1.0/1.1",         "1.1",        exe_doom_1_1},
     {"Doom 1.2",             "1.2",        exe_doom_1_2},
     {"Doom 1.666",           "1.666",      exe_doom_1_666},
     {"Doom 1.7/1.7a",        "1.7",        exe_doom_1_7},
@@ -988,9 +987,9 @@ static void InitGameVersion(void)
     // @arg <version>
     // @category compat
     //
-    // Emulate a specific version of Doom.  Valid values are "1.1", "1.2", 
-    // "1.666", "1.7", "1.8", "1.9", "ultimate", "final", "final2", "hacx"
-    // and "chex".
+    // Emulate a specific version of Doom.  Valid values are "1.2", 
+    // "1.666", "1.7", "1.8", "1.9", "ultimate", "final", "final2",
+    // "hacx" and "chex".
     //
 
     p = M_CheckParmWithArgs("-gameversion", 1);
@@ -1082,12 +1081,6 @@ static void InitGameVersion(void)
                     }
                 }
             }
-
-            // detect v1.0/v1.1 from missing D_INTROA
-            if (gameversion == exe_doom_1_2 && W_CheckNumForName("D_INTROA") < 0)
-            {
-                gameversion = exe_doom_1_1;
-            }
         }
         else if (gamemode == retail)
         {
@@ -1103,6 +1096,12 @@ static void InitGameVersion(void)
 
             gameversion = exe_final;
         }
+    }
+
+    // Deathmatch 2.0 did not exist until Doom v1.4
+    if (gameversion <= exe_doom_1_2 && deathmatch == 2)
+    {
+        deathmatch = 1;
     }
     
     // The original exe does not support retail - 4th episode not supported

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1051,6 +1051,13 @@ static void InitGameVersion(void)
                     status = true;
                     switch (demoversion)
                     {
+                        case 0:
+                        case 1:
+                        case 2:
+                        case 3:
+                        case 4:
+                            gameversion = exe_doom_1_2;
+                            break;
                         case 106:
                             gameversion = exe_doom_1_666;
                             break;

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2128,10 +2128,6 @@ static const char *DemoVersionDescription(int version)
 
     switch (version)
     {
-        case 101:
-            return "v1.0/v1.1";
-        case 102:
-            return "v1.2";
         case 104:
             return "v1.4";
         case 105:

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2052,6 +2052,8 @@ int G_VanillaVersionCode(void)
 {
     switch (gameversion)
     {
+        case exe_doom_1_1:
+            return 101;
         case exe_doom_1_2:
             return 102;
         case exe_doom_1_666:
@@ -2088,7 +2090,7 @@ void G_BeginRecording (void)
     {
         *demo_p++ = DOOM_191_VERSION;
     }
-    else if (gameversion != exe_doom_1_2)
+    else if (gameversion > exe_doom_1_2)
     {
         *demo_p++ = G_VanillaVersionCode();
     }
@@ -2096,7 +2098,7 @@ void G_BeginRecording (void)
     *demo_p++ = gameskill; 
     *demo_p++ = gameepisode; 
     *demo_p++ = gamemap; 
-    if (longtics || gameversion != exe_doom_1_2)
+    if (longtics || gameversion > exe_doom_1_2)
     {
         *demo_p++ = deathmatch; 
         *demo_p++ = respawnparm;
@@ -2130,6 +2132,10 @@ static const char *DemoVersionDescription(int version)
 
     switch (version)
     {
+        case 101:
+            return "v1.0/v1.1";
+        case 102:
+            return "v1.2";
         case 104:
             return "v1.4";
         case 105:
@@ -2151,7 +2157,7 @@ static const char *DemoVersionDescription(int version)
     // Unknown version.  Perhaps this is a pre-v1.4 IWAD?  If the version
     // byte is in the range 0-4 then it can be a v1.0-v1.2 demo.
 
-    if (version == 102 || (version >= 0 && version <= 4))
+    if (version >= 0 && version <= 4)
     {
         return "v1.0/v1.1/v1.2";
     }
@@ -2176,9 +2182,11 @@ void G_DoPlayDemo (void)
 
     demoversion = *demo_p++;
 
-    if (demoversion < 102)
+    if (demoversion >= 0 && demoversion <= 4)
     {
-        demoversion = 102;
+        if (gameversion <= exe_doom_1_2)
+            demoversion = G_VanillaVersionCode();
+        
         demo_p--;
     }
 
@@ -2209,7 +2217,7 @@ void G_DoPlayDemo (void)
     skill = *demo_p++; 
     episode = *demo_p++; 
     map = *demo_p++; 
-    if (demoversion != 102)
+    if (demoversion > 102)
     {
         deathmatch = *demo_p++;
         respawnparm = *demo_p++;

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2052,10 +2052,6 @@ int G_VanillaVersionCode(void)
 {
     switch (gameversion)
     {
-        case exe_doom_1_1:
-            return 101;
-        case exe_doom_1_2:
-            return 102;
         case exe_doom_1_666:
             return 106;
         case exe_doom_1_7:
@@ -2174,6 +2170,7 @@ void G_DoPlayDemo (void)
     skill_t skill;
     int i, lumpnum, episode, map;
     int demoversion;
+    boolean olddemo = false;
 
     lumpnum = W_GetNumForName(defdemoname);
     gameaction = ga_nothing;
@@ -2184,9 +2181,7 @@ void G_DoPlayDemo (void)
 
     if (demoversion >= 0 && demoversion <= 4)
     {
-        if (gameversion <= exe_doom_1_2)
-            demoversion = G_VanillaVersionCode();
-        
+        olddemo = true;
         demo_p--;
     }
 
@@ -2199,7 +2194,8 @@ void G_DoPlayDemo (void)
     {
         longtics = true;
     }
-    else if (demoversion != G_VanillaVersionCode())
+    else if (demoversion != G_VanillaVersionCode() &&
+             !(gameversion <= exe_doom_1_2 && olddemo))
     {
         const char *message = "Demo is from a different game version!\n"
                               "(read %i, should be %i)\n"
@@ -2217,7 +2213,7 @@ void G_DoPlayDemo (void)
     skill = *demo_p++; 
     episode = *demo_p++; 
     map = *demo_p++; 
-    if (demoversion > 102)
+    if (!olddemo)
     {
         deathmatch = *demo_p++;
         respawnparm = *demo_p++;

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2053,7 +2053,7 @@ int G_VanillaVersionCode(void)
     switch (gameversion)
     {
         case exe_doom_1_2:
-            I_Error("Doom 1.2 does not have a version code!");
+            return 102;
         case exe_doom_1_666:
             return 106;
         case exe_doom_1_7:
@@ -2088,7 +2088,7 @@ void G_BeginRecording (void)
     {
         *demo_p++ = DOOM_191_VERSION;
     }
-    else
+    else if (gameversion != exe_doom_1_2)
     {
         *demo_p++ = G_VanillaVersionCode();
     }
@@ -2096,11 +2096,14 @@ void G_BeginRecording (void)
     *demo_p++ = gameskill; 
     *demo_p++ = gameepisode; 
     *demo_p++ = gamemap; 
-    *demo_p++ = deathmatch; 
-    *demo_p++ = respawnparm;
-    *demo_p++ = fastparm;
-    *demo_p++ = nomonsters;
-    *demo_p++ = consoleplayer;
+    if (longtics || gameversion != exe_doom_1_2)
+    {
+        *demo_p++ = deathmatch; 
+        *demo_p++ = respawnparm;
+        *demo_p++ = fastparm;
+        *demo_p++ = nomonsters;
+        *demo_p++ = consoleplayer;
+    }
 	 
     for (i=0 ; i<MAXPLAYERS ; i++) 
 	*demo_p++ = playeringame[i]; 		 
@@ -2148,7 +2151,7 @@ static const char *DemoVersionDescription(int version)
     // Unknown version.  Perhaps this is a pre-v1.4 IWAD?  If the version
     // byte is in the range 0-4 then it can be a v1.0-v1.2 demo.
 
-    if (version >= 0 && version <= 4)
+    if (version == 102 || (version >= 0 && version <= 4))
     {
         return "v1.0/v1.1/v1.2";
     }
@@ -2172,6 +2175,12 @@ void G_DoPlayDemo (void)
     demo_p = demobuffer;
 
     demoversion = *demo_p++;
+
+    if (demoversion < 102)
+    {
+        demoversion = 102;
+        demo_p--;
+    }
 
     longtics = false;
 
@@ -2200,12 +2209,24 @@ void G_DoPlayDemo (void)
     skill = *demo_p++; 
     episode = *demo_p++; 
     map = *demo_p++; 
-    deathmatch = *demo_p++;
-    respawnparm = *demo_p++;
-    fastparm = *demo_p++;
-    nomonsters = *demo_p++;
-    consoleplayer = *demo_p++;
-	
+    if (demoversion != 102)
+    {
+        deathmatch = *demo_p++;
+        respawnparm = *demo_p++;
+        fastparm = *demo_p++;
+        nomonsters = *demo_p++;
+        consoleplayer = *demo_p++;
+    }
+    else
+    {
+        deathmatch = 0;
+        respawnparm = 0;
+        fastparm = 0;
+        nomonsters = 0;
+        consoleplayer = 0;
+    }
+    
+        
     for (i=0 ; i<MAXPLAYERS ; i++) 
 	playeringame[i] = *demo_p++; 
 

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -522,7 +522,7 @@ void HU_Ticker(void)
 			    message_counter = HU_MSGTIMEOUT;
 			    if ( gamemode == commercial )
 			      S_StartSound(0, sfx_radio);
-			    else
+			    else if (gameversion > exe_doom_1_2)
 			      S_StartSound(0, sfx_tink);
 			}
 			HUlib_resetIText(&w_inputbuffer[i]);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -2006,7 +2006,7 @@ void M_Drawer (void)
     {
         name = DEH_String(currentMenu->menuitems[i].name);
 
-	if (name[0])
+	if (name[0] && W_CheckNumForName(name) > 0)
 	{
 	    V_DrawPatchDirect (x, y, W_CacheLumpName(name, PU_CACHE));
 	}

--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -168,6 +168,7 @@ boolean P_CheckMeleeRange (mobj_t*	actor)
 {
     mobj_t*	pl;
     fixed_t	dist;
+    fixed_t range;
 	
     if (!actor->target)
 	return false;
@@ -175,8 +176,14 @@ boolean P_CheckMeleeRange (mobj_t*	actor)
     pl = actor->target;
     dist = P_AproxDistance (pl->x-actor->x, pl->y-actor->y);
 
-    if (dist >= MELEERANGE-20*FRACUNIT+pl->info->radius)
-	return false;
+    if (gameversion == exe_doom_1_2)
+        range = MELEERANGE;
+    else
+        range = MELEERANGE-20*FRACUNIT+pl->info->radius;
+
+    if (dist >= range)
+        return false;
+
 	
     if (! P_CheckSight (actor, actor->target) )
 	return false;
@@ -665,8 +672,8 @@ void A_Chase (mobj_t*	actor)
     // modify target threshold
     if  (actor->threshold)
     {
-	if (!actor->target
-	    || actor->target->health <= 0)
+        if (gameversion != exe_doom_1_2 && 
+            (!actor->target || actor->target->health <= 0))
 	{
 	    actor->threshold = 0;
 	}
@@ -925,11 +932,19 @@ void A_SargAttack (mobj_t* actor)
 	return;
 		
     A_FaceTarget (actor);
-    if (P_CheckMeleeRange (actor))
+
+    if (gameversion != exe_doom_1_2)
     {
-	damage = ((P_Random()%10)+1)*4;
-	P_DamageMobj (actor->target, actor, actor, damage);
+        if (!P_CheckMeleeRange (actor))
+            return;
     }
+
+    damage = ((P_Random()%10)+1)*4;
+
+    if (gameversion == exe_doom_1_2)
+        P_LineAttack(actor, actor->angle, MELEERANGE, 0, damage);
+    else
+        P_DamageMobj (actor->target, actor, actor, damage);
 }
 
 void A_HeadAttack (mobj_t* actor)

--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -176,7 +176,7 @@ boolean P_CheckMeleeRange (mobj_t*	actor)
     pl = actor->target;
     dist = P_AproxDistance (pl->x-actor->x, pl->y-actor->y);
 
-    if (gameversion == exe_doom_1_2)
+    if (gameversion <= exe_doom_1_2)
         range = MELEERANGE;
     else
         range = MELEERANGE-20*FRACUNIT+pl->info->radius;
@@ -672,7 +672,7 @@ void A_Chase (mobj_t*	actor)
     // modify target threshold
     if  (actor->threshold)
     {
-        if (gameversion != exe_doom_1_2 && 
+        if (gameversion > exe_doom_1_2 && 
             (!actor->target || actor->target->health <= 0))
 	{
 	    actor->threshold = 0;
@@ -933,7 +933,7 @@ void A_SargAttack (mobj_t* actor)
 		
     A_FaceTarget (actor);
 
-    if (gameversion != exe_doom_1_2)
+    if (gameversion > exe_doom_1_2)
     {
         if (!P_CheckMeleeRange (actor))
             return;
@@ -941,7 +941,7 @@ void A_SargAttack (mobj_t* actor)
 
     damage = ((P_Random()%10)+1)*4;
 
-    if (gameversion == exe_doom_1_2)
+    if (gameversion <= exe_doom_1_2)
         P_LineAttack(actor, actor->angle, MELEERANGE, 0, damage);
     else
         P_DamageMobj (actor->target, actor, actor, damage);

--- a/src/doom/p_floor.c
+++ b/src/doom/p_floor.c
@@ -303,7 +303,8 @@ EV_DoFloor
 	    floor->speed = FLOORSPEED * 4;
 	    floor->floordestheight = 
 		P_FindHighestFloorSurrounding(sec);
-	    if (floor->floordestheight != sec->floorheight)
+	    if (gameversion == exe_doom_1_2 ||
+	        floor->floordestheight != sec->floorheight)
 		floor->floordestheight += 8*FRACUNIT;
 	    break;
 

--- a/src/doom/p_floor.c
+++ b/src/doom/p_floor.c
@@ -303,7 +303,7 @@ EV_DoFloor
 	    floor->speed = FLOORSPEED * 4;
 	    floor->floordestheight = 
 		P_FindHighestFloorSurrounding(sec);
-	    if (gameversion == exe_doom_1_2 ||
+	    if (gameversion <= exe_doom_1_2 ||
 	        floor->floordestheight != sec->floorheight)
 		floor->floordestheight += 8*FRACUNIT;
 	    break;

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -382,7 +382,7 @@ P_TouchSpecialThing
 	
       case SPR_BON2:
 	player->armorpoints++;		// can go over 100%
-	if (player->armorpoints > deh_max_armor)
+	if (player->armorpoints > deh_max_armor && gameversion != exe_doom_1_2)
 	    player->armorpoints = deh_max_armor;
         // deh_green_armor_class only applies to the green armor shirt;
         // for the armor helmets, armortype 1 is always used.
@@ -907,7 +907,7 @@ P_DamageMobj
     target->reactiontime = 0;		// we're awake now...	
 
     if ( (!target->threshold || target->type == MT_VILE)
-	 && source && source != target
+	 && source && (source != target || gameversion == exe_doom_1_2)
 	 && source->type != MT_VILE)
     {
 	// if not intent on another player,

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -397,7 +397,8 @@ P_TouchSpecialThing
 	    player->health = deh_max_soulsphere;
 	player->mo->health = player->health;
 	player->message = DEH_String(GOTSUPER);
-	sound = sfx_getpow;
+	if (gameversion > exe_doom_1_2)
+	    sound = sfx_getpow;
 	break;
 	
       case SPR_MEGA:
@@ -409,7 +410,8 @@ P_TouchSpecialThing
         // affects the MegaArmor.
 	P_GiveArmor (player, 2);
 	player->message = DEH_String(GOTMSPHERE);
-	sound = sfx_getpow;
+	if (gameversion > exe_doom_1_2)
+	    sound = sfx_getpow;
 	break;
 	
 	// cards
@@ -485,7 +487,8 @@ P_TouchSpecialThing
 	if (!P_GivePower (player, pw_invulnerability))
 	    return;
 	player->message = DEH_String(GOTINVUL);
-	sound = sfx_getpow;
+	if (gameversion > exe_doom_1_2)
+	    sound = sfx_getpow;
 	break;
 	
       case SPR_PSTR:
@@ -494,35 +497,40 @@ P_TouchSpecialThing
 	player->message = DEH_String(GOTBERSERK);
 	if (player->readyweapon != wp_fist)
 	    player->pendingweapon = wp_fist;
-	sound = sfx_getpow;
+	if (gameversion > exe_doom_1_2)
+	    sound = sfx_getpow;
 	break;
 	
       case SPR_PINS:
 	if (!P_GivePower (player, pw_invisibility))
 	    return;
 	player->message = DEH_String(GOTINVIS);
-	sound = sfx_getpow;
+	if (gameversion > exe_doom_1_2)
+	    sound = sfx_getpow;
 	break;
 	
       case SPR_SUIT:
 	if (!P_GivePower (player, pw_ironfeet))
 	    return;
 	player->message = DEH_String(GOTSUIT);
-	sound = sfx_getpow;
+	if (gameversion > exe_doom_1_2)
+	    sound = sfx_getpow;
 	break;
 	
       case SPR_PMAP:
 	if (!P_GivePower (player, pw_allmap))
 	    return;
 	player->message = DEH_String(GOTMAP);
-	sound = sfx_getpow;
+	if (gameversion > exe_doom_1_2)
+	    sound = sfx_getpow;
 	break;
 	
       case SPR_PVIS:
 	if (!P_GivePower (player, pw_infrared))
 	    return;
 	player->message = DEH_String(GOTVISOR);
-	sound = sfx_getpow;
+	if (gameversion > exe_doom_1_2)
+	    sound = sfx_getpow;
 	break;
 	
 	// ammo

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -382,7 +382,7 @@ P_TouchSpecialThing
 	
       case SPR_BON2:
 	player->armorpoints++;		// can go over 100%
-	if (player->armorpoints > deh_max_armor && gameversion != exe_doom_1_2)
+	if (player->armorpoints > deh_max_armor && gameversion > exe_doom_1_2)
 	    player->armorpoints = deh_max_armor;
         // deh_green_armor_class only applies to the green armor shirt;
         // for the armor helmets, armortype 1 is always used.
@@ -907,7 +907,7 @@ P_DamageMobj
     target->reactiontime = 0;		// we're awake now...	
 
     if ( (!target->threshold || target->type == MT_VILE)
-	 && source && (source != target || gameversion == exe_doom_1_2)
+	 && source && (source != target || gameversion <= exe_doom_1_2)
 	 && source->type != MT_VILE)
     {
 	// if not intent on another player,

--- a/src/doom/p_map.c
+++ b/src/doom/p_map.c
@@ -1317,7 +1317,7 @@ boolean PIT_ChangeSector (mobj_t*	thing)
     {
 	P_SetMobjState (thing, S_GIBS);
 
-    if (gameversion != exe_doom_1_2)
+    if (gameversion > exe_doom_1_2)
 	    thing->flags &= ~MF_SOLID;
 	thing->height = 0;
 	thing->radius = 0;

--- a/src/doom/p_map.c
+++ b/src/doom/p_map.c
@@ -1317,7 +1317,8 @@ boolean PIT_ChangeSector (mobj_t*	thing)
     {
 	P_SetMobjState (thing, S_GIBS);
 
-	thing->flags &= ~MF_SOLID;
+    if (gameversion != exe_doom_1_2)
+	    thing->flags &= ~MF_SOLID;
 	thing->height = 0;
 	thing->radius = 0;
 

--- a/src/doom/p_sight.c
+++ b/src/doom/p_sight.c
@@ -16,9 +16,10 @@
 //	LineOfSight/Visibility checks, uses REJECT Lookup Table.
 //
 
-
+#include <stdlib.h> // abs()
 
 #include "doomdef.h"
+#include "doomstat.h"
 
 #include "i_system.h"
 #include "p_local.h"
@@ -38,6 +39,44 @@ fixed_t		t2x;
 fixed_t		t2y;
 
 int		sightcounts[2];
+
+
+// PTR_SightTraverse() for Doom 1.2 sight calculations
+// taken from prboom-plus/src/p_sight.c:69-102
+boolean PTR_SightTraverse(intercept_t *in)
+{
+  line_t *li;
+  fixed_t slope;
+
+  li = in->d.line;
+
+  //
+  // crosses a two sided line
+  //
+  P_LineOpening(li);
+
+  if (openbottom >= opentop)  // quick test for totally closed doors
+    return false;  // stop
+
+  if (li->frontsector->floorheight != li->backsector->floorheight)
+  {
+    slope = FixedDiv(openbottom - sightzstart , in->frac);
+    if (slope > bottomslope)
+      bottomslope = slope;
+  }
+
+  if (li->frontsector->ceilingheight != li->backsector->ceilingheight)
+  {
+    slope = FixedDiv(opentop - sightzstart, in->frac);
+    if (slope < topslope)
+      topslope = slope;
+  }
+
+  if (topslope <= bottomslope)
+    return false;  // stop
+
+  return true;  // keep going
+}
 
 
 //
@@ -336,6 +375,12 @@ P_CheckSight
     topslope = (t2->z+t2->height) - sightzstart;
     bottomslope = (t2->z) - sightzstart;
 	
+    if (gameversion == exe_doom_1_2)
+    {
+        return P_PathTraverse(t1->x, t1->y, t2->x, t2->y,
+                              PT_EARLYOUT | PT_ADDLINES, PTR_SightTraverse);
+    }
+
     strace.x = t1->x;
     strace.y = t1->y;
     t2x = t2->x;

--- a/src/doom/p_sight.c
+++ b/src/doom/p_sight.c
@@ -375,7 +375,7 @@ P_CheckSight
     topslope = (t2->z+t2->height) - sightzstart;
     bottomslope = (t2->z) - sightzstart;
 	
-    if (gameversion == exe_doom_1_2)
+    if (gameversion <= exe_doom_1_2)
     {
         return P_PathTraverse(t1->x, t1->y, t2->x, t2->y,
                               PT_EARLYOUT | PT_ADDLINES, PTR_SightTraverse);

--- a/src/doom/p_sight.c
+++ b/src/doom/p_sight.c
@@ -16,7 +16,6 @@
 //	LineOfSight/Visibility checks, uses REJECT Lookup Table.
 //
 
-#include <stdlib.h> // abs()
 
 #include "doomdef.h"
 #include "doomstat.h"
@@ -45,37 +44,37 @@ int		sightcounts[2];
 // taken from prboom-plus/src/p_sight.c:69-102
 boolean PTR_SightTraverse(intercept_t *in)
 {
-  line_t *li;
-  fixed_t slope;
+    line_t *li;
+    fixed_t slope;
 
-  li = in->d.line;
+    li = in->d.line;
 
-  //
-  // crosses a two sided line
-  //
-  P_LineOpening(li);
+    //
+    // crosses a two sided line
+    //
+    P_LineOpening(li);
 
-  if (openbottom >= opentop)  // quick test for totally closed doors
-    return false;  // stop
+    if (openbottom >= opentop) // quick test for totally closed doors
+        return false;          // stop
 
-  if (li->frontsector->floorheight != li->backsector->floorheight)
-  {
-    slope = FixedDiv(openbottom - sightzstart , in->frac);
-    if (slope > bottomslope)
-      bottomslope = slope;
-  }
+    if (li->frontsector->floorheight != li->backsector->floorheight)
+    {
+        slope = FixedDiv(openbottom - sightzstart, in->frac);
+        if (slope > bottomslope)
+            bottomslope = slope;
+    }
 
-  if (li->frontsector->ceilingheight != li->backsector->ceilingheight)
-  {
-    slope = FixedDiv(opentop - sightzstart, in->frac);
-    if (slope < topslope)
-      topslope = slope;
-  }
+    if (li->frontsector->ceilingheight != li->backsector->ceilingheight)
+    {
+        slope = FixedDiv(opentop - sightzstart, in->frac);
+        if (slope < topslope)
+            topslope = slope;
+    }
 
-  if (topslope <= bottomslope)
-    return false;  // stop
+    if (topslope <= bottomslope)
+        return false; // stop
 
-  return true;  // keep going
+    return true; // keep going
 }
 
 

--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -531,7 +531,6 @@ P_CrossSpecialLine
                 case MT_HEADSHOT:
                 case MT_BRUISERSHOT:
                     return;
-                    break;
 
                 default: break;
             }

--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -509,7 +509,7 @@ P_CrossSpecialLine
 
     line = &lines[linenum];
     
-    if (gameversion == exe_doom_1_2)
+    if (gameversion <= exe_doom_1_2)
     {
         if (line->special > 98 && line->special != 104)
         {

--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -509,24 +509,37 @@ P_CrossSpecialLine
 
     line = &lines[linenum];
     
-    //	Triggers that other things can activate
+    if (gameversion == exe_doom_1_2)
+    {
+        if (line->special > 98 && line->special != 104)
+        {
+            return;
+        }
+    }
+    else
+    {
+        //	Triggers that other things can activate
+        if (!thing->player)
+        {
+            // Things that should NOT trigger specials...
+            switch(thing->type)
+            {
+                case MT_ROCKET:
+                case MT_PLASMA:
+                case MT_BFG:
+                case MT_TROOPSHOT:
+                case MT_HEADSHOT:
+                case MT_BRUISERSHOT:
+                    return;
+                    break;
+
+                default: break;
+            }
+        }
+    }
+
     if (!thing->player)
     {
-	// Things that should NOT trigger specials...
-	switch(thing->type)
-	{
-	  case MT_ROCKET:
-	  case MT_PLASMA:
-	  case MT_BFG:
-	  case MT_TROOPSHOT:
-	  case MT_HEADSHOT:
-	  case MT_BRUISERSHOT:
-	    return;
-	    break;
-	    
-	  default: break;
-	}
-		
 	ok = 0;
 	switch(line->special)
 	{

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -446,7 +446,7 @@ void S_StartSound(void *origin_p, int sfx_id)
     }
 
     // substitute missing sounds in Doom 1.2
-    if (gameversion == exe_doom_1_2)
+    if (gameversion <= exe_doom_1_2)
     {
         switch(sfx_id)
         {
@@ -696,7 +696,7 @@ void S_ChangeMusic(int musicnum, int looping)
 
     if (musicnum == mus_intro && (snd_musicdevice == SNDDEVICE_ADLIB
                                || snd_musicdevice == SNDDEVICE_SB)
-        && W_CheckNumForName("D_INTROA") > 0)
+        && gameversion >= exe_doom_1_2)
     {
         musicnum = mus_introa;
     }

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -445,40 +445,6 @@ void S_StartSound(void *origin_p, int sfx_id)
         I_Error("Bad sfx #: %d", sfx_id);
     }
 
-    // substitute missing sounds in Doom 1.2
-    if (gameversion <= exe_doom_1_2)
-    {
-        switch(sfx_id)
-        {
-            case sfx_bdcls:
-                sfx_id = sfx_dorcls;
-                break;
-
-            case sfx_bdopn:
-                sfx_id = sfx_doropn;
-                break;
-
-            case sfx_getpow:
-                sfx_id = sfx_itemup;
-                break;
-
-            case sfx_itmbk:
-                sfx_id = sfx_stnmov;
-                break;
-
-            case sfx_pdiehi:
-                sfx_id = sfx_pldeth;
-                break;
-
-            case sfx_tink:
-                sfx_id = sfx_swtchx;
-                break;
-
-            default:
-                break;
-        }
-    }
-
     sfx = &S_sfx[sfx_id];
 
     // Initialize sound parameters
@@ -696,7 +662,7 @@ void S_ChangeMusic(int musicnum, int looping)
 
     if (musicnum == mus_intro && (snd_musicdevice == SNDDEVICE_ADLIB
                                || snd_musicdevice == SNDDEVICE_SB)
-        && gameversion >= exe_doom_1_2)
+        && W_CheckNumForName("D_INTROA") >= 0)
     {
         musicnum = mus_introa;
     }

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -445,6 +445,40 @@ void S_StartSound(void *origin_p, int sfx_id)
         I_Error("Bad sfx #: %d", sfx_id);
     }
 
+    // substitute missing sounds in Doom 1.2
+    if (gameversion == exe_doom_1_2)
+    {
+        switch(sfx_id)
+        {
+            case sfx_bdcls:
+                sfx_id = sfx_dorcls;
+                break;
+
+            case sfx_bdopn:
+                sfx_id = sfx_doropn;
+                break;
+
+            case sfx_getpow:
+                sfx_id = sfx_itemup;
+                break;
+
+            case sfx_itmbk:
+                sfx_id = sfx_stnmov;
+                break;
+
+            case sfx_pdiehi:
+                sfx_id = sfx_pldeth;
+                break;
+
+            case sfx_tink:
+                sfx_id = sfx_swtchx;
+                break;
+
+            default:
+                break;
+        }
+    }
+
     sfx = &S_sfx[sfx_id];
 
     // Initialize sound parameters
@@ -661,7 +695,8 @@ void S_ChangeMusic(int musicnum, int looping)
     // and d_introa.  The latter is used for OPL playback.
 
     if (musicnum == mus_intro && (snd_musicdevice == SNDDEVICE_ADLIB
-                               || snd_musicdevice == SNDDEVICE_SB))
+                               || snd_musicdevice == SNDDEVICE_SB)
+        && W_CheckNumForName("D_INTROA") > 0)
     {
         musicnum = mus_introa;
     }

--- a/src/doom/st_lib.c
+++ b/src/doom/st_lib.c
@@ -50,7 +50,10 @@ patch_t*		sttminus;
 
 void STlib_init(void)
 {
-    sttminus = (patch_t *) W_CacheLumpName(DEH_String("STTMINUS"), PU_STATIC);
+    if (W_CheckNumForName(DEH_String("STTMINUS")) > 0)
+        sttminus = (patch_t *) W_CacheLumpName(DEH_String("STTMINUS"), PU_STATIC);
+    else
+        sttminus = NULL;
 }
 
 
@@ -136,7 +139,7 @@ STlib_drawNum
     }
 
     // draw a minus sign if necessary
-    if (neg)
+    if (neg && sttminus)
 	V_DrawPatch(x - 8, n->y, sttminus);
 }
 

--- a/src/doom/st_lib.c
+++ b/src/doom/st_lib.c
@@ -50,7 +50,7 @@ patch_t*		sttminus;
 
 void STlib_init(void)
 {
-    if (W_CheckNumForName(DEH_String("STTMINUS")) > 0)
+    if (W_CheckNumForName(DEH_String("STTMINUS")) >= 0)
         sttminus = (patch_t *) W_CacheLumpName(DEH_String("STTMINUS"), PU_STATIC);
     else
         sttminus = NULL;

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -307,6 +307,9 @@ static boolean		st_fragson;
 // main bar left
 static patch_t*		sbar;
 
+// main bar right, for doom 1.0
+static patch_t*		sbarr;
+
 // 0-9, tall numbers
 static patch_t*		tallnum[10];
 
@@ -421,6 +424,10 @@ void ST_refreshBackground(void)
         V_UseBuffer(st_backing_screen);
 
 	V_DrawPatch(ST_X, 0, sbar);
+
+	// draw right side of bar if needed (Doom 1.0)
+	if (sbarr)
+	    V_DrawPatch(ST_ARMSBGX, 0, sbarr);
 
 	if (netgame)
 	    V_DrawPatch(ST_FX, 0, faceback);
@@ -1142,7 +1149,16 @@ static void ST_loadUnloadGraphics(load_callback_t callback)
     callback(namebuf, &faceback);
 
     // status bar background bits
-    callback(DEH_String("STBAR"), &sbar);
+    if (W_CheckNumForName(DEH_String("STBAR")) > 0)
+    {
+        callback(DEH_String("STBAR"), &sbar);
+        sbarr = NULL;
+    }
+    else
+    {
+        callback(DEH_String("STMBARL"), &sbar);
+        callback(DEH_String("STMBARR"), &sbarr);
+    }
 
     // face states
     facenum = 0;

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -1149,7 +1149,7 @@ static void ST_loadUnloadGraphics(load_callback_t callback)
     callback(namebuf, &faceback);
 
     // status bar background bits
-    if (W_CheckNumForName(DEH_String("STBAR")) > 0)
+    if (gameversion >= exe_doom_1_2)
     {
         callback(DEH_String("STBAR"), &sbar);
         sbarr = NULL;

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -1149,7 +1149,7 @@ static void ST_loadUnloadGraphics(load_callback_t callback)
     callback(namebuf, &faceback);
 
     // status bar background bits
-    if (gameversion >= exe_doom_1_2)
+    if (W_CheckNumForName("STBAR") >= 0)
     {
         callback(DEH_String("STBAR"), &sbar);
         sbarr = NULL;

--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -675,7 +675,7 @@ WI_drawNum
     }
 
     // draw a minus sign if necessary
-    if (neg)
+    if (neg && wiminus)
 	V_DrawPatch(x-=8, y, wiminus);
 
     return x;
@@ -1613,7 +1613,10 @@ static void WI_loadUnloadData(load_callback_t callback)
     }
 
     // More hacks on minus sign.
-    callback(DEH_String("WIMINUS"), &wiminus);
+    if (W_CheckNumForName(DEH_String("WIMINUS")) > 0)
+        callback(DEH_String("WIMINUS"), &wiminus);
+    else
+        wiminus = NULL;
 
     for (i=0;i<10;i++)
     {


### PR DESCRIPTION
So @fabiangreffrath asked me to make a pull request here for this patch (previously https://github.com/fabiangreffrath/crispy-doom/pull/478 ), so here it is.

I noticed some easy changes I could grab from Prboom-plus, so I did, and made a patch.

I've tested the three demos in Doom 1.2 shareware and they seem to work. I've also tried recording a quick demo in crispy-doom with the Doom 1.2 shareware wad and it played ok in the original exe under dosbox.

Also included are a few minor changes that get the Doom 0.99 shareware WAD running without immediately crashing, though the demos desynch within seconds and there's an invisible nightmare difficulty setting.