### PR TITLE
Fix Math for Loremaster Hook Effect

### DIFF
--- a/src/strife/p_inter.c
+++ b/src/strife/p_inter.c
@@ -1150,17 +1150,14 @@ void P_DamageMobj(mobj_t* target, mobj_t* inflictor, mobj_t* source, int damage)
                 target->momy += FixedMul(finesine[ang],   (12750*FRACUNIT) / target->info->mass);
                 target->reactiontime += 10;
 
-                //themightyheracross- here, temp is assigned a fixed_t value
                 temp = P_AproxDistance(target->x - source->x, target->y - source->y);
                 
-                //Convert mass to fixed point number
-                //Use fixed point math here
+                //Use fixed point math for momentum calculation
                 temp = FixedDiv(temp, ((target->info->mass) << FRACBITS));
 
                 if(temp < 1)
                     temp = 1;
                     
-                //...and here, for correct momz calculation
                 target->momz = FixedDiv((source->z - target->z), temp);
                 break;
 

--- a/src/strife/p_inter.c
+++ b/src/strife/p_inter.c
@@ -1150,13 +1150,18 @@ void P_DamageMobj(mobj_t* target, mobj_t* inflictor, mobj_t* source, int damage)
                 target->momy += FixedMul(finesine[ang],   (12750*FRACUNIT) / target->info->mass);
                 target->reactiontime += 10;
 
+                //themightyheracross- here, temp is assigned a fixed_t value
                 temp = P_AproxDistance(target->x - source->x, target->y - source->y);
-                temp /= target->info->mass;
+                
+                //Convert mass to fixed point number
+                //Use fixed point math here
+                temp = FixedDiv(temp, ((target->info->mass) << FRACBITS));
 
                 if(temp < 1)
                     temp = 1;
-
-                target->momz = (source->z - target->z) / temp;
+                    
+                //...and here, for correct momz calculation
+                target->momz = FixedDiv((source->z - target->z), temp);
                 break;
 
             case MT_POISARROW:


### PR DESCRIPTION
This code change fixes a bug in which the Loremaster's hook, which is meant to throw the player into the air, has nearly no effect on the player's Z momentum. Because of this, the player is not thrown into the air, only moved slightly in the x and y directions- rendering the Loremaster nearly harmless.

The problem was that the "temp" variable was being assigned a fixed point value (which, in this context, almost always works out to a very large integer), then being divided by the target's mass (a normal integer, relatively small in size), yielding a very large, nonsense number. The momz calculation calls for the (fixed point) z distance between the target and source to be divided by the temp value. However, since the (small) z distance is being divided by the (very large) nonsense temp value, the resulting momz is virtually zero almost every time.

This fix converts the player's mass to fixed point in the calculation and replaces "/" operators with proper fixed point math functions, yielding the correct z momentum.

To test the difference, warp to MAP27 to face the Loremaster, or use the GRAPPLE.SEH patch on the SeHackEd Doomworld page, which also uses the hook effect (the hook replaces the electric crossbow). In the vanilla Strife DOS exe and this fork, the player should properly be thrown into the air, while in the master branch as of writing, the player is only moved in the x and y directions.