### PR TITLE
doom: correctly determine the par time for MAP33

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -38,6 +38,7 @@
 #include "i_system.h"
 #include "i_timer.h"
 #include "i_input.h"
+#include "i_swap.h"
 #include "i_video.h"
 
 #include "p_setup.h"
@@ -1460,10 +1461,15 @@ void G_DoCompleted (void)
     // statcheck regression testing.
     if (gamemode == commercial)
     {
-        // map33 has no official time: initialize to zero
+        // map33 reads its par time from beyond the cpars[] array
         if (gamemap == 33)
         {
-            wminfo.partime = 0;
+            int cpars32;
+
+            memcpy(&cpars32, DEH_String(GAMMALVL0), sizeof(int));
+            cpars32 = LONG(cpars32);
+
+            wminfo.partime = TICRATE*cpars32;
         }
         else
         {

--- a/src/doom/statdump.c
+++ b/src/doom/statdump.c
@@ -268,7 +268,7 @@ static void PrintLevelName(FILE *stream, int episode, int level)
 
 static void PrintStats(FILE *stream, wbstartstruct_t *stats)
 {
-    int leveltime, partime;
+    short leveltime, partime;
     int i;
 
     PrintLevelName(stream, stats->epsd, stats->last);


### PR DESCRIPTION
The par time for MAP33 is read from beyond the cpars[] array and
corresponds to the first four bytes ("Gamm") of the GAMMALVL0 string
literal interpreted as a 32-bit integer. This has been checked and
proven for the three regular DOOM.EXEs (i.e. 1.9, Ultimate, Final).

Fixes #1209.

Thanks @turol for the pointer to use memcpy() instead of pointer
casting.

While at it, change the data type for leveltime and partime to type
short in the statdump code to match the output of the DOS executable.