### PR TITLE
doom: revert erroneous part of code

### DIFF
--- a/src/doom/wi_stuff.c
+++ b/src/doom/wi_stuff.c
@@ -1474,12 +1474,7 @@ void WI_drawStats(void)
     if (wbs->epsd < 3)
     {
         V_DrawPatch(SCREENWIDTH/2 + SP_TIMEX, SP_TIMEY, par);
-
-        // Emulation: don't draw partime value if map33
-        if (gamemode != commercial || wbs->last != NUMCMAPS)
-        {
-            WI_drawTime(SCREENWIDTH - SP_TIMEX, SP_TIMEY, cnt_par);
-        }
+        WI_drawTime(SCREENWIDTH - SP_TIMEX, SP_TIMEY, cnt_par);
     }
 
 }


### PR DESCRIPTION
That is, remove the part that checks if the map just finished is MAP33
to omit drawing the par time if this is the case.

While it is true that no par time for MAP33 is drawn in Vanilla Doom,
this isn't because there is a condition that checks for it, but
because the par time for MAP33 is read from beyond the cpars[] array
and the four bytes following it are interpreted as a negative 32-bit
integer. The WI_drawTime() function, however, returns early if the
time it is supposed to draw is negative.

This can be easily checked by using DEHACKED to change the GAMMALVL0
string so that its first four bytes are interpreted as a positive
32-bit integer, e.g. by replacing it with "   " (four spaces). Then,
even Vanilla Doom (e.g. DOOM2.EXE) will start to draw a par time when
MAP33 is finished but will eventually end up drawing the "SUCKS!"
patch.

This may be regarded as the second part of commit 00d2024fe, it reverts
another part of commit e1f113aec.