### PR TITLE
video: if renderer creation failed, try again without acceleration

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1246,6 +1246,23 @@ static void SetVideoMode(void)
 
     renderer = SDL_CreateRenderer(screen, -1, renderer_flags);
 
+    // If we could not find a matching render driver,
+    // try again without hardware acceleration.
+
+    if (renderer == NULL && !force_software_renderer)
+    {
+        renderer_flags |= SDL_RENDERER_SOFTWARE;
+        renderer_flags &= ~SDL_RENDERER_PRESENTVSYNC;
+
+        renderer = SDL_CreateRenderer(screen, -1, renderer_flags);
+
+        // If this helped, save the setting for later.
+        if (renderer != NULL)
+        {
+            force_software_renderer = 1;
+        }
+    }
+
     if (renderer == NULL)
     {
         I_Error("Error creating renderer for screen window: %s",


### PR DESCRIPTION
Currently, we enable hardware acceleration by default. If SDL fails to
create a matching renderer for that, e.g. because the graphic hardware
or driver do not properly support hardware acceleration, we show an
error message and quit. At this point users do either complain or turn
their back on our software and never come back. Whenever users complain,
we recommend them to enable the force_software_renderer option and
try again.

However, we can do better and try again ourselves without hardware
acceleration if the renderer creation failed with the default flags.
If it still fails even then, we know for sure that something is
really wrong.