### PR TITLE
Additional CMake ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,12 @@ DOOM*.pcx
 HTIC*.pcx
 HEXEN*.pcx
 STRIFE*.pcx
+
+# CMake-specific ignores
+/.vs
 /build*
+/CMakeSettings.json
+/out
 
 # These are the default patterns globally ignored by Subversion:
 *.o


### PR DESCRIPTION
Visual Studio 2019 supports CMake natively when opening a project
folder, and these files and folders are created by VS on first open.