### PR TITLE
Fix printf warnings from cppcheck

### DIFF
--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -714,7 +714,7 @@ static void PadRejectArray(byte *array, unsigned int len)
 
     if (len > sizeof(rejectpad))
     {
-        fprintf(stderr, "PadRejectArray: REJECT lump too short to pad! (%i > %i)\n",
+        fprintf(stderr, "PadRejectArray: REJECT lump too short to pad! (%u > %i)\n",
                         len, (int) sizeof(rejectpad));
 
         // Pad remaining space with 0 (or 0xff, if specified on command line).

--- a/src/gusconf.c
+++ b/src/gusconf.c
@@ -247,7 +247,7 @@ static boolean WriteTimidityConfig(char *path, gus_config_t *config)
         if (config->mapping[i] >= 0 && config->mapping[i] < MAX_INSTRUMENTS
          && config->patch_names[config->mapping[i]] != NULL)
         {
-            fprintf(fstream, "%i %s\n",
+            fprintf(fstream, "%u %s\n",
                     i, config->patch_names[config->mapping[i]]);
         }
     }
@@ -259,7 +259,7 @@ static boolean WriteTimidityConfig(char *path, gus_config_t *config)
         if (config->mapping[i] >= 0 && config->mapping[i] < MAX_INSTRUMENTS
          && config->patch_names[config->mapping[i]] != NULL)
         {
-            fprintf(fstream, "%i %s\n",
+            fprintf(fstream, "%u %s\n",
                     i - 128, config->patch_names[config->mapping[i]]);
         }
     }

--- a/src/i_musicpack.c
+++ b/src/i_musicpack.c
@@ -957,7 +957,7 @@ static void LoadSubstituteConfigs(void)
 
     if (subst_music_len > 0)
     {
-        printf("Loaded %i music substitutions from config files.\n",
+        printf("Loaded %u music substitutions from config files.\n",
                subst_music_len);
     }
 
@@ -973,7 +973,7 @@ static void LoadSubstituteConfigs(void)
 
     if (subst_music_len > old_music_len)
     {
-        printf("Configured %i music substitutions based on filename.\n",
+        printf("Configured %u music substitutions based on filename.\n",
                subst_music_len - old_music_len);
     }
 

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1211,7 +1211,7 @@ static void ControllerEvent(opl_track_data_t *track, midi_event_t *event)
 
         default:
 #ifdef OPL_MIDI_DEBUG
-            fprintf(stderr, "Unknown MIDI controller type: %i\n", controller);
+            fprintf(stderr, "Unknown MIDI controller type: %u\n", controller);
 #endif
             break;
     }
@@ -1304,7 +1304,7 @@ static void MetaEvent(opl_track_data_t *track, midi_event_t *event)
 
         default:
 #ifdef OPL_MIDI_DEBUG
-            fprintf(stderr, "Unknown MIDI meta event type: %i\n",
+            fprintf(stderr, "Unknown MIDI meta event type: %u\n",
                             event->data.meta.type);
 #endif
             break;

--- a/src/memio.c
+++ b/src/memio.c
@@ -189,7 +189,7 @@ int mem_fseek(MEMFILE *stream, signed long position, mem_rel_t whence)
 	}
 	else
 	{
-		printf("Error seeking to %i\n", newpos);
+		printf("Error seeking to %u\n", newpos);
 		return -1;
 	}
 }

--- a/src/midifile.c
+++ b/src/midifile.c
@@ -757,7 +757,7 @@ void PrintTrack(midi_track_t *track)
 
         if (event->delta_time > 0)
         {
-            printf("Delay: %i ticks\n", event->delta_time);
+            printf("Delay: %u ticks\n", event->delta_time);
         }
 
         printf("Event type: %s (%i)\n",
@@ -773,19 +773,19 @@ void PrintTrack(midi_track_t *track)
             case MIDI_EVENT_PROGRAM_CHANGE:
             case MIDI_EVENT_CHAN_AFTERTOUCH:
             case MIDI_EVENT_PITCH_BEND:
-                printf("\tChannel: %i\n", event->data.channel.channel);
-                printf("\tParameter 1: %i\n", event->data.channel.param1);
-                printf("\tParameter 2: %i\n", event->data.channel.param2);
+                printf("\tChannel: %u\n", event->data.channel.channel);
+                printf("\tParameter 1: %u\n", event->data.channel.param1);
+                printf("\tParameter 2: %u\n", event->data.channel.param2);
                 break;
 
             case MIDI_EVENT_SYSEX:
             case MIDI_EVENT_SYSEX_SPLIT:
-                printf("\tLength: %i\n", event->data.sysex.length);
+                printf("\tLength: %u\n", event->data.sysex.length);
                 break;
 
             case MIDI_EVENT_META:
-                printf("\tMeta type: %i\n", event->data.meta.type);
-                printf("\tLength: %i\n", event->data.meta.length);
+                printf("\tMeta type: %u\n", event->data.meta.type);
+                printf("\tLength: %u\n", event->data.meta.length);
                 break;
         }
     }
@@ -812,7 +812,7 @@ int main(int argc, char *argv[])
 
     for (i=0; i<file->num_tracks; ++i)
     {
-        printf("\n== Track %i ==\n\n", i);
+        printf("\n== Track %u ==\n\n", i);
 
         PrintTrack(&file->tracks[i]);
     }

--- a/src/net_gui.c
+++ b/src/net_gui.c
@@ -291,7 +291,7 @@ static void CheckSHA1Sums(void)
     if (!same_freedoom)
     {
         printf("Warning: Mixing Freedoom with non-Freedoom\n");
-        printf("Local: %i  Server: %i\n", 
+        printf("Local: %u  Server: %i\n",
                net_local_is_freedoom, 
                net_client_wait_data.is_freedoom);
     }

--- a/src/strife/p_setup.c
+++ b/src/strife/p_setup.c
@@ -695,7 +695,7 @@ static void PadRejectArray(byte *array, unsigned int len)
     if (len > sizeof(rejectpad))
     {
         fprintf(stderr,
-                "PadRejectArray: REJECT lump too short to pad! (%i > %i)\n",
+                "PadRejectArray: REJECT lump too short to pad! (%u > %i)\n",
                 len, (int) sizeof(rejectpad));
 
         // Pad remaining space with 0 (or 0xff, if specified on command line).


### PR DESCRIPTION
All of these warnings relate to printing an unsigned integer as `%i` instead of `%u`.