### PR TITLE
Fix use of uninitialized memory in heretic and hexen

### DIFF
--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -713,6 +713,7 @@ void R_DrawPSprite(pspdef_t * psp)
     vis = &avis;
     vis->mobjflags = 0;
     vis->psprite = true;
+    vis->footclip = 0;
     vis->texturemid =
         (BASEYCENTER << FRACBITS) + FRACUNIT / 2 - (psp->sy -
                                                     spritetopoffset[lump]);

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -727,6 +727,7 @@ void R_DrawPSprite(pspdef_t * psp)
     vis->mobjflags = 0;
     vis->class = 0;
     vis->psprite = true;
+    vis->floorclip = 0;
     vis->texturemid = (BASEYCENTER << FRACBITS) + FRACUNIT / 2
         - (psp->sy - spritetopoffset[lump]);
     if (viewheight == SCREENHEIGHT)


### PR DESCRIPTION
Fix use of uninitialized memory in heretic and hexen.

As seen in #1117 

@mfrancis95 Does this close all of it?