### PR TITLE
always precache sounds

### DIFF
--- a/src/i_sdlsound.c
+++ b/src/i_sdlsound.c
@@ -808,21 +808,12 @@ static void GetSfxLumpName(sfxinfo_t *sfx, char *buf, size_t buf_len)
     }
 }
 
-#ifdef HAVE_LIBSAMPLERATE
-
 // Preload all the sound effects - stops nasty ingame freezes
 
 static void I_SDL_PrecacheSounds(sfxinfo_t *sounds, int num_sounds)
 {
     char namebuf[9];
     int i;
-
-    // Don't need to precache the sounds unless we are using libsamplerate.
-
-    if (use_libsamplerate == 0)
-    {
-	return;
-    }
 
     printf("I_SDL_PrecacheSounds: Precaching all sound effects..");
 
@@ -846,15 +837,6 @@ static void I_SDL_PrecacheSounds(sfxinfo_t *sounds, int num_sounds)
 
     printf("\n");
 }
-
-#else
-
-static void I_SDL_PrecacheSounds(sfxinfo_t *sounds, int num_sounds)
-{
-    // no-op
-}
-
-#endif
 
 // Load a SFX chunk into memory and ensure that it is locked.
 


### PR DESCRIPTION
Currently, sound effects are only precached if Choco has been built
with libsamplerate support and if this is enabled at run-time.

However, I don't see a reason why we would not want to precache all
sounds if libsamplerate is either not available or disabled.
Precaching sounds only takes a second more at start-up but prevents
nasty hick-ups during playing if sounds are loaded and have their
samplerates converted over and over again.

This is inspired by the following bug report by @vanfanel:
https://github.com/fabiangreffrath/crispy-doom/issues/508#issuecomment-573915583