### PR TITLE
Fix segmentation fault when running on rgb565 screen

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1149,7 +1149,7 @@ static void SetVideoMode(void)
     int w, h;
     int x, y;
     unsigned int rmask, gmask, bmask, amask;
-    int unused_bpp;
+    int bpp;
     int window_flags = 0, renderer_flags = 0;
     SDL_DisplayMode mode;
 
@@ -1321,10 +1321,10 @@ static void SetVideoMode(void)
 
     if (argbbuffer == NULL)
     {
-        SDL_PixelFormatEnumToMasks(pixel_format, &unused_bpp,
+        SDL_PixelFormatEnumToMasks(pixel_format, &bpp,
                                    &rmask, &gmask, &bmask, &amask);
         argbbuffer = SDL_CreateRGBSurface(0,
-                                          SCREENWIDTH, SCREENHEIGHT, 32,
+                                          SCREENWIDTH, SCREENHEIGHT, bpp,
                                           rmask, gmask, bmask, amask);
         SDL_FillRect(argbbuffer, NULL, 0);
     }


### PR DESCRIPTION
Pixel depth of rgb565 format is 16, instead of 32.
Using fixed value of 32 causes Segmentation fault when run
the statement:
SDL_LowerBlit(screenbuffer, &blit_rect, rgbabuffer, &blit_rect)