### PR TITLE
Add heretic mouse inventory buttons

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -771,6 +771,59 @@ static void SetJoyButtons(unsigned int buttons_mask)
     }
 }
 
+static boolean InventoryMoveLeft()
+{
+    inventoryTics = 5 * 35;
+    if (!inventory)
+    {
+        inventory = true;
+        return false;
+    }
+    inv_ptr--;
+    if (inv_ptr < 0)
+    {
+        inv_ptr = 0;
+    }
+    else
+    {
+        curpos--;
+        if (curpos < 0)
+        {
+            curpos = 0;
+        }
+    }
+    return true;
+}
+
+static boolean InventoryMoveRight()
+{
+    player_t *plr;
+
+    plr = &players[consoleplayer];
+    inventoryTics = 5 * 35;
+    if (!inventory)
+    {
+        inventory = true;
+        return false;
+    }
+    inv_ptr++;
+    if (inv_ptr >= plr->inventorySlotNum)
+    {
+        inv_ptr--;
+        if (inv_ptr < 0)
+            inv_ptr = 0;
+    }
+    else
+    {
+        curpos++;
+        if (curpos > 6)
+        {
+            curpos = 6;
+        }
+    }
+    return true;
+}
+
 static void SetMouseButtons(unsigned int buttons_mask)
 {
     int i;
@@ -790,6 +843,14 @@ static void SetMouseButtons(unsigned int buttons_mask)
             else if (i == mousebnextweapon)
             {
                 next_weapon = 1;
+            }
+            else if (i == mousebinvleft)
+            {
+                InventoryMoveLeft();
+            }
+            else if (i == mousebinvright)
+            {
+                InventoryMoveRight();
             }
         }
 
@@ -873,51 +934,19 @@ boolean G_Responder(event_t * ev)
         case ev_keydown:
             if (ev->data1 == key_invleft)
             {
-                inventoryTics = 5 * 35;
-                if (!inventory)
+                if (InventoryMoveLeft())
                 {
-                    inventory = true;
-                    break;
+                    return (true);
                 }
-                inv_ptr--;
-                if (inv_ptr < 0)
-                {
-                    inv_ptr = 0;
-                }
-                else
-                {
-                    curpos--;
-                    if (curpos < 0)
-                    {
-                        curpos = 0;
-                    }
-                }
-                return (true);
+                break;
             }
             if (ev->data1 == key_invright)
             {
-                inventoryTics = 5 * 35;
-                if (!inventory)
+                if (InventoryMoveRight())
                 {
-                    inventory = true;
-                    break;
+                    return (true);
                 }
-                inv_ptr++;
-                if (inv_ptr >= plr->inventorySlotNum)
-                {
-                    inv_ptr--;
-                    if (inv_ptr < 0)
-                        inv_ptr = 0;
-                }
-                else
-                {
-                    curpos++;
-                    if (curpos > 6)
-                    {
-                        curpos = 6;
-                    }
-                }
-                return (true);
+                break;
             }
             if (ev->data1 == key_pause && !MenuActive)
             {

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1055,6 +1055,22 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(mouseb_nextweapon),
+    
+    //!
+    // @game heretic
+    //
+    // Mouse button to move to the left in the inventory.
+    //
+
+    CONFIG_VARIABLE_INT(mouseb_invleft),
+
+    //!
+    // @game heretic
+    //
+    // Mouse button to move to the right in the inventory.
+    //
+
+    CONFIG_VARIABLE_INT(mouseb_invright),
 
     //!
     // If non-zero, double-clicking a mouse button acts like pressing

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -116,7 +116,8 @@ int mousebuse = -1;
 
 int mousebprevweapon = -1;
 int mousebnextweapon = -1;
-
+int mousebinvleft = -1;
+int mousebinvright = -1;
 
 int key_message_refresh = KEY_ENTER;
 int key_pause = KEY_PAUSE;
@@ -264,6 +265,9 @@ void M_BindHereticControls(void)
     M_BindIntVariable("key_invleft",        &key_invleft);
     M_BindIntVariable("key_invright",       &key_invright);
     M_BindIntVariable("key_useartifact",    &key_useartifact);
+
+    M_BindIntVariable("mouseb_invleft", &mousebinvleft);
+    M_BindIntVariable("mouseb_invright", &mousebinvright);
 
     M_BindIntVariable("key_arti_quartz",        &key_arti_quartz);
     M_BindIntVariable("key_arti_urn",           &key_arti_urn);

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -145,6 +145,8 @@ extern int mousebuse;
 
 extern int mousebprevweapon;
 extern int mousebnextweapon;
+extern int mousebinvleft;
+extern int mousebinvright;
 
 extern int joybfire;
 extern int joybstrafe;

--- a/src/setup/mouse.c
+++ b/src/setup/mouse.c
@@ -46,7 +46,9 @@ static int *all_mouse_buttons[] = {
     &mousebuse,
     &mousebjump,
     &mousebprevweapon,
-    &mousebnextweapon
+    &mousebnextweapon,
+    &mousebinvleft,
+    &mousebinvright
 };
 
 static void MouseSetCallback(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(variable))
@@ -102,6 +104,12 @@ static void ConfigExtraButtons(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     AddMouseControl(buttons_table, "Previous weapon", &mousebprevweapon);
     AddMouseControl(buttons_table, "Strafe on", &mousebstrafe);
     AddMouseControl(buttons_table, "Next weapon", &mousebnextweapon);
+    
+    if (gamemission == heretic)
+    {
+      AddMouseControl(buttons_table, "Inventory left", &mousebinvleft);
+      AddMouseControl(buttons_table, "Inventory right", &mousebinvright);
+    }
 
     if (gamemission == hexen || gamemission == strife)
     {


### PR DESCRIPTION
Hello :wave: 

This PR adds mouse buttons for moving the inventory cursor in heretic. I find using keys is quite cumbersome, especially when going for speed, whereas the mouse wheel is perfect for this task. Maybe someone else agrees :wink: 

I extracted the inventory left / right code into separate functions so we don't duplicate the code for key and mouse. I tried to follow the general pattern I saw for other mouse buttons, so hopefully the implementation makes sense.

I originally opened this for crispy, but Fabian recommended I open it up for chocolate directly.

Let me know if there are any issues!