### PR TITLE
Remove redundant demoextend definition

### DIFF
--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -131,7 +131,6 @@ boolean MenuActive;
 int InfoType;
 int messageson = true;
 boolean mn_SuicideConsole;
-boolean demoextend; // from h2def.h
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 


### PR DESCRIPTION
GCC 10 enables -fno-common by default, which causes the linker to fail when
there are multple definitions of a global variable.

See https://gcc.gnu.org/gcc-10/porting_to.html

This is causing a build failure in the upcoming Fedora 32: https://bugzilla.redhat.com/show_bug.cgi?id=1799222