### PR TITLE
Chocolate: cmake + autotools updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ configure_file(src/resource.rc.in src/resource.rc)
 configure_file(src/setup-res.rc.in src/setup-res.rc)
 configure_file(src/setup/setup-manifest.xml.in src/setup/setup-manifest.xml)
 
+set(Python_ADDITIONAL_VERSIONS 3 2)
+find_package(PythonInterp)
+
+set(PROJECT_DATADIR "${PROJECT_SOURCE_DIR}/data")
+add_subdirectory(data)
+
 add_subdirectory(textscreen)
 add_subdirectory(midiproc)
 add_subdirectory(opl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,44 +1,40 @@
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(ParseAutoconfigure)
 
 cmake_minimum_required(VERSION 3.7.2)
-project("Chocolate Doom" VERSION 3.0.0 LANGUAGES C)
-
-# Autotools variables
-set(top_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
-set(top_builddir ${CMAKE_CURRENT_BINARY_DIR})
-
-# AC_INIT variables
-set(PACKAGE_NAME "${PROJECT_NAME}")
-set(PACKAGE_TARNAME "chocolate-doom")
-set(PACKAGE_VERSION "${PROJECT_VERSION}")
-set(PACKAGE_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
-set(PACKAGE_BUGREPORT "chocolate-doom-dev-list@chocolate-doom.org")
-
-string(REGEX REPLACE " Doom$" "" PACKAGE_SHORTNAME "${PACKAGE_NAME}")
-set(PACKAGE_COPYRIGHT "Copyright (C) 1993-2017")
-set(PACKAGE_LICENSE "GNU General Public License, version 2")
+project("${PACKAGE_NAME}"
+    VERSION "${PACKAGE_VERSION}"
+    DESCRIPTION "${PACKAGE_SHORTDESC}"
+    HOMEPAGE_URL "${PACKAGE_URL}"
+    LANGUAGES C
+)
 
 # Any settings that should apply to all targets in this directory and all
 # subdirectories should go here.  Use judiciously.
 if(MSVC)
-    add_definitions("/D_CRT_SECURE_NO_WARNINGS" "/D_CRT_SECURE_NO_DEPRECATE"
-                    "/D_CRT_NONSTDC_NO_DEPRECATE")
+    add_definitions(
+        _CRT_SECURE_NO_WARNINGS
+        _CRT_SECURE_NO_DEPRECATE
+        _CRT_NONSTDC_NO_DEPRECATE
+    )
 else()
-    add_compile_options("-Wall" "-Wdeclaration-after-statement"
-                        "-Wredundant-decls")
+    add_compile_options(
+        -Wall
+        $<$<COMPILE_LANGUAGE:C>:-Wdeclaration-after-statement>
+        -Wredundant-decls
+    )
 endif()
 
-find_package(SDL2 2.0.1)
-find_package(SDL2_mixer 2.0.0)
-find_package(SDL2_net 2.0.0)
+find_package(SDL2 2.0.1 REQUIRED)
+find_package(SDL2_mixer 2.0.0 REQUIRED)
+find_package(SDL2_net 2.0.0 REQUIRED)
 
-# Check for libsamplerate.
 find_package(samplerate)
 if(SAMPLERATE_FOUND)
     set(HAVE_LIBSAMPLERATE TRUE)
 endif()
 
-# Check for libpng.
 find_package(PNG)
 if(PNG_FOUND)
     set(HAVE_LIBPNG TRUE)
@@ -55,18 +51,14 @@ check_include_file("dirent.h" HAVE_DIRENT_H)
 string(CONCAT WINDOWS_RC_VERSION "${PROJECT_VERSION_MAJOR}, "
     "${PROJECT_VERSION_MINOR}, ${PROJECT_VERSION_PATCH}, 0")
 
-# Without a hyphen. This is used for the bash-completion scripts.
-string(TOLOWER "${PACKAGE_SHORTNAME}" PROGRAM_SPREFIX)
-
-# With a hyphen, used almost everywhere else.
-set(PROGRAM_PREFIX "${PROGRAM_SPREFIX}-")
-
 configure_file(cmake/config.h.cin config.h)
 
 configure_file(src/resource.rc.in src/resource.rc)
 configure_file(src/setup-res.rc.in src/setup-res.rc)
 configure_file(src/setup/setup-manifest.xml.in src/setup/setup-manifest.xml)
 
-foreach(SUBDIR textscreen midiproc opl pcsound src)
-    add_subdirectory("${SUBDIR}")
-endforeach()
+add_subdirectory(textscreen)
+add_subdirectory(midiproc)
+add_subdirectory(opl)
+add_subdirectory(pcsound)
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,23 @@ project("${PACKAGE_NAME}"
     LANGUAGES C
 )
 
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(DOOM_MAIN_PROJECT ON)
+endif()
+
+option(DOOM_INSTALL "Enable Doom installation" "${DOOM_MAIN_PROJECT}")
+
+set(CMAKE_INSTALL_DOCDIR "share/doc" CACHE FILEPATH "Where to install docs")
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_DESKTOPDIR "${CMAKE_INSTALL_DATAROOTDIR}/applications" CACHE FILEPATH "Where to install desktop files")
+set(CMAKE_INSTALL_COMPLETIONDIR "${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions" CACHE FILEPATH "Where to install bash completions")
+
+function(doom_install)
+    if(DOOM_INSTALL)
+        install(${ARGN})
+    endif()
+endfunction()
+
 # Any settings that should apply to all targets in this directory and all
 # subdirectories should go here.  Use judiciously.
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,3 +68,5 @@ add_subdirectory(midiproc)
 add_subdirectory(opl)
 add_subdirectory(pcsound)
 add_subdirectory(src)
+
+add_subdirectory(man)

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,8 @@ CMAKE_FILES=                                   \
         cmake/FindSDL2_net.cmake               \
         cmake/Findm.cmake                      \
         cmake/Findsamplerate.cmake             \
-        cmake/config.h.cin
+        cmake/config.h.cin                     \
+        cmake/ParseAutoconfigure.cmake
 
 DOC_FILES=                              \
         COPYING.md                      \

--- a/cmake/ParseAutoconfigure.cmake
+++ b/cmake/ParseAutoconfigure.cmake
@@ -1,0 +1,49 @@
+# Set variables set by configure.ac
+
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGURE_AC_CONTENTS)
+string(REGEX MATCH "AC_INIT\\(([a-zA-Z ]+),[ \t\r\n]*([a-zA-Z0-9.]+),[ \t\r\n]*([a-zA-Z0-9@.-]+),[ \t\r\n]*([a-zA-Z0-9@-]+)\\)" AUTOCONF_REGEX "${CONFIGURE_AC_CONTENTS}")
+if(NOT AUTOCONF_REGEX)
+    message(FATAL_ERROR "Cannot parse version from configure.ac")
+endif()
+set(PACKAGE_NAME "${CMAKE_MATCH_1}")
+set(PACKAGE_VERSION "${CMAKE_MATCH_2}")
+set(PACKAGE_EMAIL "${CMAKE_MATCH_3}")
+set(PACKAGE_TARNAME "${CMAKE_MATCH_4}")
+set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+
+set(PACKAGE_SHORTNAME "${PACKAGE_NAME} Doom")
+
+foreach(package_var
+    PACKAGE_SHORTDESC
+    PACKAGE_COPYRIGHT
+    PACKAGE_LICENSE
+    PACKAGE_MAINTAINER
+    PACKAGE_URL
+    PACKAGE_RDNS
+    PACKAGE_ISSUES
+)
+    string(REGEX MATCH "${package_var}[ \t\r\n]*=[ \t\r\n]*\"([a-zA-Z0-9 _/():,.-]+)\"" AUTOCONF_REGEX "${CONFIGURE_AC_CONTENTS}")
+    if(NOT AUTOCONF_REGEX)
+        message(FATAL_ERROR "Cannot parse ${package_var} from configure.ac")
+    endif()
+    set("${package_var}" "${CMAKE_MATCH_1}")
+endforeach()
+
+string(REGEX REPLACE " Doom$" "" PACKAGE_SHORTNAME "${PACKAGE_NAME}")
+
+# Without a hyphen. This is used for the bash-completion scripts.
+string(TOLOWER "${PACKAGE_SHORTNAME}" PROGRAM_SPREFIX)
+
+# With a hyphen, used almost everywhere else.
+set(PROGRAM_PREFIX "${PROGRAM_SPREFIX}-" CACHE STRING "Program prefix")
+
+string(REGEX MATCH "([a-zA-Z0-9.]+)-?.*" WINDOWS_RE_VERSION_REGEX "${PACKAGE_VERSION}")
+if(NOT WINDOWS_RE_VERSION_REGEX)
+    message(FATAL_ERROR "Cannot create WINDOWS_RC_VERSION from PACKAGE_VERSION")
+endif()
+
+string(REPLACE "." ", " WINDOWS_RC_VERSION "${CMAKE_MATCH_1}")
+set(WINDOWS_RC_VERSION "${WINDOWS_RC_VERSION}, 0")
+
+set(top_srcdir "${PROJECT_SOURCE_DIR}")
+set(top_builddir "${PROJECT_BINARY_DIR}")

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,0 +1,13 @@
+function(convert_icon PNG SRC)
+    set(ACC_EXTRA)
+    cmake_parse_arguments(ACC "" "COPY" "" ${ARGN})
+    if(ACC_COPY)
+        list(APPEND ACC_EXTRA COMMAND "${CMAKE_COMMAND}" -E copy "${SRC}" "${ACC_COPY}")
+    endif()
+    if(PYTHON_EXECUTABLE)
+        add_custom_command(OUTPUT "${SRC}"
+            COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_DATADIR}/convert-icon" "${PNG}" "${SRC}"
+            ${ACC_EXTRA}
+        )
+    endif()
+endfunction()

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -11,3 +11,15 @@ function(convert_icon PNG SRC)
         )
     endif()
 endfunction()
+
+doom_install(
+    FILES doom.png
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps"
+    RENAME "${PROGRAM_PREFIX}doom.png"
+)
+
+doom_install(
+    FILES setup.png
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps"
+    RENAME "${PROGRAM_PREFIX}setup.png"
+)

--- a/man/.gitignore
+++ b/man/.gitignore
@@ -1,5 +1,6 @@
 CMDLINE.doom
 CMDLINE.doom.md
+CMDLINE.doom.wikitext
 CMDLINE.heretic
 CMDLINE.heretic.md
 CMDLINE.hexen

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -138,6 +138,26 @@ function(generate_man)
     )
     list(APPEND GENERATED_DOCS "${CMAKE_CURRENT_BINARY_DIR}/INSTALL.${AD_GAME_NAME}")
 
+    doom_install(FILES ${GENERATED_MAN5}
+        DESTINATION "${CMAKE_INSTALL_MANDIR}/man5"
+    )
+
+    doom_install(FILES ${GENERATED_MAN6}
+        DESTINATION "${CMAKE_INSTALL_MANDIR}/man6"
+    )
+
+    doom_install(
+        FILES
+            ${GENERATED_DOCS}
+            "${PROJECT_SOURCE_DIR}/ChangeLog"
+            "${PROJECT_SOURCE_DIR}/COPYING.md"
+            "${PROJECT_SOURCE_DIR}/NEWS.md"
+            "${PROJECT_SOURCE_DIR}/PHILOSOPHY.md"
+            "${PROJECT_SOURCE_DIR}/README.md"
+            "${PROJECT_SOURCE_DIR}/README.Music.md"
+        DESTINATION "${CMAKE_INSTALL_DOCDIR}/${PROGRAM_PREFIX}${AD_GAME_NAME}"
+    )
+
     add_custom_target("mans_${AD_GAME_NAME}"
         DEPENDS ${GENERATED_DOCS} ${GENERATED_MAN5} ${GENERATED_MAN6}
     )
@@ -156,6 +176,9 @@ if(DOOM_BUILD_SERVER)
         EXTRA
             "${PROJECT_SOURCE_DIR}/src"
     )
+    doom_install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROGRAM_PREFIX}server.6"
+        DESTINATION "${CMAKE_INSTALL_MANDIR}/man6"
+    )
     add_custom_target(mans_server
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${PROGRAM_PREFIX}server.6"
     )
@@ -165,6 +188,9 @@ endif()
 if(DOOM_BUILD_DOOM)
     generate_man(GAME_NAME doom DEFAULT_CFG_NAME default)
     list(APPEND DOOM_INSTALL_DEFINES doom)
+    doom_install(FILES "${PROJECT_SOURCE_DIR}/NOT-BUGS.md"
+        DESTINATION "${CMAKE_INSTALL_DOCDIR}/${PROGRAM_PREFIX}doom"
+    )
 endif()
 
 if(DOOM_BUILD_HERETIC)
@@ -180,6 +206,9 @@ endif()
 if(DOOM_BUILD_STRIFE)
     generate_man(GAME_NAME strife)
     list(APPEND DOOM_INSTALL_DEFINES strife)
+    doom_install(FILES "${PROJECT_SOURCE_DIR}/README.Strife.md"
+        DESTINATION "${CMAKE_INSTALL_DOCDIR}/${PROGRAM_PREFIX}strife"
+    )
 endif()
 
 set(EXTRA_MANS)
@@ -197,6 +226,10 @@ simplecpp(INSTALL INSTALL.template
     EXTRA "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/src/doom"
 )
 #list(APPEND EXTRA_MANS "${CMAKE_CURRENT_BINARY_DIR}/INSTALL")
+
+doom_install(FILES "${EXTRA_MANS}"
+    DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+)
 
 add_custom_target(mans_extra
     DEPENDS ${EXTRA_MANS}

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,0 +1,207 @@
+if(NOT PYTHON_EXECUTABLE)
+    message("Python not available. Building mans disabled.")
+    return()
+endif()
+
+set(PROJECT_MANDIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL "mandir")
+
+function(add_docgen OUT)
+    cmake_parse_arguments(MAN "WIKI_OUTPUT" "GAME;MANPAGE_TEMPLATE;MARKDOWN_TEMPLATE;PLAINTEXT_TEMPLATE;COMPLETION_TEMPLATE;CONFIG_FILE" "EXTRA" ${ARGN})
+    set(DOCGEN_ARGS -n "${PROGRAM_SPREFIX}" -s "${PACKAGE_NAME}" -z "${PACKAGE_SHORTNAME}")
+    set(DEPENDS)
+    if(MAN_WIKI_OUTPUT)
+        list(APPEND DOCGEN_ARGS -w)
+    endif()
+    if(MAN_GAME)
+        list(APPEND DOCGEN_ARGS -g "${MAN_GAME}")
+    endif()
+    if(MAN_MANPAGE_TEMPLATE)
+        list(APPEND DOCGEN_ARGS -m "${MAN_MANPAGE_TEMPLATE}")
+        list(APPEND DEPENDS "${MAN_MANPAGE_TEMPLATE}")
+    endif()
+    if(MAN_MARKDOWN_TEMPLATE)
+        list(APPEND DOCGEN_ARGS -M "${MAN_MARKDOWN_TEMPLATE}")
+        list(APPEND DEPENDS "${MAN_MARKDOWN_TEMPLATE}")
+    endif()
+    if(MAN_PLAINTEXT_TEMPLATE)
+        list(APPEND DOCGEN_ARGS -p "${MAN_PLAINTEXT_TEMPLATE}")
+        list(APPEND DEPENDS "${MAN_PLAINTEXT_TEMPLATE}")
+    endif()
+    if(MAN_COMPLETION_TEMPLATE)
+        list(APPEND DOCGEN_ARGS -b "${MAN_COMPLETION_TEMPLATE}")
+        list(APPEND DEPENDS "${MAN_COMPLETION_TEMPLATE}")
+    endif()
+    if(MAN_CONFIG_FILE)
+        list(APPEND DOCGEN_ARGS -c "${MAN_CONFIG_FILE}")
+    endif()
+    list(APPEND DOCGEN_ARGS ${MAN_EXTRA})
+    if(NOT IS_ABSOLUTE "${OUT}")
+        set(OUT "${CMAKE_CURRENT_BINARY_DIR}/${OUT}")
+    endif()
+    add_custom_command(
+        OUTPUT "${OUT}"
+        COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_MANDIR}/docgen" ${DOCGEN_ARGS} > "${OUT}"
+        DEPENDS "${DEPENDS}" "${PROJECT_MANDIR}/docgen"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        VERBATIM
+    )
+endfunction()
+
+function(simplecpp OUT IN)
+    cmake_parse_arguments(SPP "" "" "DEFINES" ${ARGN})
+    set(SIMPLEPP_ARGS)
+    if(WIN32)
+        list(APPEND SPP_DEFINES _WIN32)
+    endif()
+    foreach(SPP_ARG ${SPP_DEFINES})
+        list(APPEND SIMPLEPP_ARGS "-D${SPP_ARG}")
+    endforeach()
+    if(NOT IS_ABSOLUTE "${OUT}")
+        set(OUT "${CMAKE_CURRENT_BINARY_DIR}/${OUT}")
+    endif()
+    add_custom_command(
+        OUTPUT "${OUT}"
+        COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_MANDIR}/simplecpp" ${SIMPLEPP_ARGS} > "${OUT}" < "${IN}"
+        DEPENDS "${IN}" "${PROJECT_MANDIR}/simplecpp"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        VERBATIM
+    )
+endfunction()
+
+function(generate_man)
+    cmake_parse_arguments(AD "" "GAME_NAME;DEFAULT_CFG_NAME" "" ${ARGV})
+
+    if(NOT AD_DEFAULT_CFG_NAME)
+        set(AD_DEFAULT_CFG_NAME "${AD_GAME_NAME}")
+    endif()
+
+    set(GENERATED_DOCS)
+    set(GENERATED_MAN5)
+    set(GENERATED_MAN6)
+
+    add_docgen("${PROGRAM_PREFIX}${AD_GAME_NAME}.6"
+        GAME "${AD_GAME_NAME}"
+        MANPAGE_TEMPLATE "${AD_GAME_NAME}.template"
+        EXTRA
+            "${PROJECT_SOURCE_DIR}/src"
+            "${PROJECT_SOURCE_DIR}/src/${AD_GAME_NAME}"
+    )
+    list(APPEND GENERATED_MAN6 "${CMAKE_CURRENT_BINARY_DIR}/${PROGRAM_PREFIX}${AD_GAME_NAME}.6")
+
+    add_docgen("${AD_DEFAULT_CFG_NAME}.cfg.5"
+        GAME "${AD_GAME_NAME}"
+        MANPAGE_TEMPLATE default.cfg.template
+        CONFIG_FILE default
+        EXTRA "${PROJECT_SOURCE_DIR}/src/m_config.c"
+    )
+    list(APPEND GENERATED_MAN5 "${CMAKE_CURRENT_BINARY_DIR}/${AD_DEFAULT_CFG_NAME}.cfg.5")
+
+    add_docgen("${PROGRAM_PREFIX}${AD_GAME_NAME}.cfg.5"
+        GAME "${AD_GAME_NAME}"
+        MANPAGE_TEMPLATE extra.cfg.template
+        CONFIG_FILE extended
+        EXTRA "${PROJECT_SOURCE_DIR}/src/m_config.c"
+    )
+    list(APPEND GENERATED_MAN5 "${CMAKE_CURRENT_BINARY_DIR}/${PROGRAM_PREFIX}${AD_GAME_NAME}.cfg.5")
+
+    add_docgen("CMDLINE.${AD_GAME_NAME}"
+        PLAINTEXT_TEMPLATE CMDLINE.template
+        EXTRA "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/src/${AD_GAME_NAME}"
+    )
+    list(APPEND GENERATED_DOCS "${CMAKE_CURRENT_BINARY_DIR}/CMDLINE.${AD_GAME_NAME}")
+
+    add_docgen("${PROGRAM_PREFIX}${AD_GAME_NAME}-setup.6"
+        GAME "${AD_GAME_NAME}"
+        MANPAGE_TEMPLATE setup.template
+        EXTRA "${PROJECT_SOURCE_DIR}/src"
+    )
+    list(APPEND GENERATED_MAN6 "${CMAKE_CURRENT_BINARY_DIR}/${PROGRAM_PREFIX}${AD_GAME_NAME}-setup.6")
+
+    add_docgen("CMDLINE.${AD_GAME_NAME}.md"
+        MARKDOWN_TEMPLATE CMDLINE.template.md
+        EXTRA "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/src/${AD_GAME_NAME}"
+    )
+    #list(APPEND GENERATED_DOCS "${CMAKE_CURRENT_BINARY_DIR}/CMDLINE.${AD_GAME_NAME}.md")
+
+    string(SUBSTRING "${AD_GAME_NAME}" 0 1  GAME_NAME_FIRST_LETTER)
+    string(TOUPPER "${GAME_NAME_FIRST_LETTER}" GAME_NAME_FIRST_LETTER)
+    string(SUBSTRING "${AD_GAME_NAME}" 1 -1 GAME_NAME_REST)
+    set(GAME_NAME_CAPITALIZED "${GAME_NAME_FIRST_LETTER}${GAME_NAME_REST}")
+
+    string(TOUPPER "${AD_GAME_NAME}" NAME_UPPER)
+    simplecpp("INSTALL.${AD_GAME_NAME}" "INSTALL.template"
+        DEFINES
+            "${NAME_UPPER}"
+            "LONG_GAME_NAME=${PACKAGE_SHORTNAME} ${GAME_NAME_CAPITALIZED}"
+            "LONG_EXE_NAME=$<TARGET_PROPERTY:${AD_GAME_NAME},OUTPUT_NAME>"
+            PRECOMPILED
+    )
+    list(APPEND GENERATED_DOCS "${CMAKE_CURRENT_BINARY_DIR}/INSTALL.${AD_GAME_NAME}")
+
+    add_custom_target("mans_${AD_GAME_NAME}"
+        DEPENDS ${GENERATED_DOCS} ${GENERATED_MAN5} ${GENERATED_MAN6}
+    )
+
+    add_dependencies(mans "mans_${AD_GAME_NAME}")
+endfunction()
+
+set(DOOM_INSTALL_DEFINES)
+
+add_custom_target(mans ALL)
+
+if(DOOM_BUILD_SERVER)
+    add_docgen("${PROGRAM_PREFIX}server.6"
+        GAME server
+        MANPAGE_TEMPLATE server.template
+        EXTRA
+            "${PROJECT_SOURCE_DIR}/src"
+    )
+    add_custom_target(mans_server
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${PROGRAM_PREFIX}server.6"
+    )
+    add_dependencies(mans mans_server)
+endif()
+
+if(DOOM_BUILD_DOOM)
+    generate_man(GAME_NAME doom DEFAULT_CFG_NAME default)
+    list(APPEND DOOM_INSTALL_DEFINES doom)
+endif()
+
+if(DOOM_BUILD_HERETIC)
+    generate_man(GAME_NAME heretic)
+    list(APPEND DOOM_INSTALL_DEFINES heretic)
+endif()
+
+if(DOOM_BUILD_HEXEN)
+    generate_man(GAME_NAME hexen)
+    list(APPEND DOOM_INSTALL_DEFINES hexen)
+endif()
+
+if(DOOM_BUILD_STRIFE)
+    generate_man(GAME_NAME strife)
+    list(APPEND DOOM_INSTALL_DEFINES strife)
+endif()
+
+set(EXTRA_MANS)
+add_docgen(CMDLINE.doom.wiki
+    WIKI_OUTPUT
+    EXTRA "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/src/doom"
+)
+#list(APPEND EXTRA_MANS "${CMAKE_CURRENT_BINARY_DIR}/CMDLINE.doom.wiki")
+
+simplecpp(INSTALL INSTALL.template
+    DEFINES
+        ${DOOM_INSTALL_DEFINES}
+        "LONG_EXE_NAME=${PROGRAM_PREFIX}doom"
+        PRECOMPILED
+    EXTRA "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/src/doom"
+)
+#list(APPEND EXTRA_MANS "${CMAKE_CURRENT_BINARY_DIR}/INSTALL")
+
+add_custom_target(mans_extra
+    DEPENDS ${EXTRA_MANS}
+)
+
+add_dependencies(mans mans_extra)
+
+add_subdirectory(bash-completion)

--- a/man/bash-completion/CMakeLists.txt
+++ b/man/bash-completion/CMakeLists.txt
@@ -8,6 +8,10 @@ function(add_completion NAME)
             "${PROJECT_SOURCE_DIR}/src/${NAME}"
     )
 
+    doom_install(FILES "${OUT}"
+        DESTINATION "${CMAKE_INSTALL_COMPLETIONDIR}"
+    )
+
     add_custom_target("completion_${NAME}"
         DEPENDS "${OUT}"
     )

--- a/man/bash-completion/CMakeLists.txt
+++ b/man/bash-completion/CMakeLists.txt
@@ -1,0 +1,40 @@
+function(add_completion NAME)
+    set(OUT "${CMAKE_CURRENT_BINARY_DIR}/${PROGRAM_PREFIX}${NAME}")
+    add_docgen("${OUT}"
+        GAME doom
+        COMPLETION_TEMPLATE "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.template"
+        EXTRA
+            "${PROJECT_SOURCE_DIR}/src"
+            "${PROJECT_SOURCE_DIR}/src/${NAME}"
+    )
+
+    add_custom_target("completion_${NAME}"
+        DEPENDS "${OUT}"
+    )
+
+    add_dependencies(completions "completion_${NAME}")
+endfunction()
+
+foreach(GAME doom heretic hexen strife)
+    configure_file("${GAME}.template.in" "${GAME}.template" @ONLY)
+endforeach()
+
+set(BASH_SOURCES)
+
+add_custom_target(completions ALL)
+
+if(DOOM_BUILD_DOOM)
+    add_completion(doom)
+endif()
+
+if(DOOM_BUILD_HERETIC)
+    add_completion(heretic)
+endif()
+
+if(DOOM_BUILD_HEXEN)
+    add_completion(hexen)
+endif()
+
+if(DOOM_BUILD_STRIFE)
+    add_completion(strife)
+endif()

--- a/midiproc/CMakeLists.txt
+++ b/midiproc/CMakeLists.txt
@@ -1,6 +1,20 @@
 if(WIN32)
-    add_executable("${PROGRAM_PREFIX}midiproc" WIN32 buffer.c buffer.h main.c proto.h)
-    target_include_directories("${PROGRAM_PREFIX}midiproc"
-                               PRIVATE "../src/" "${CMAKE_CURRENT_BINARY_DIR}/../")
-    target_link_libraries("${PROGRAM_PREFIX}midiproc" SDL2::SDL2main SDL2::mixer)
+    add_executable(midiproc WIN32
+        buffer.c        buffer.h
+        main.c
+        proto.h
+    )
+
+    target_include_directories(midiproc PRIVATE
+        "${PROJECT_BINARY_DIR}"
+        "${PROJECT_SOURCE_DIR}/src"
+    )
+
+    target_link_libraries(midiproc PUBLIC
+        SDL2::mixer
+    )
+
+    set_target_properties(midiproc PROPERTIES
+        OUTPUT_NAME "${PROGRAM_PREFIX}midiproc"
+    )
 endif()

--- a/opl/CMakeLists.txt
+++ b/opl/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(opl STATIC
+add_library(opl STATIC EXCLUDE_FROM_ALL
             opl_internal.h
             opl.c           opl.h
             opl_linux.c
@@ -8,8 +8,14 @@ add_library(opl STATIC
             opl_timer.c     opl_timer.h
             opl_win32.c
             ioperm_sys.c    ioperm_sys.h
-            opl3.c          opl3.h)
+            opl3.c          opl3.h
+)
+
 target_include_directories(opl
-                           INTERFACE "."
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
-target_link_libraries(opl SDL2::mixer)
+    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}"
+    PRIVATE "${PROJECT_BINARY_DIR}"
+)
+
+target_link_libraries(opl PUBLIC
+    SDL2::mixer
+)

--- a/pcsound/CMakeLists.txt
+++ b/pcsound/CMakeLists.txt
@@ -1,11 +1,17 @@
-add_library(pcsound STATIC
+add_library(pcsound STATIC EXCLUDE_FROM_ALL
             pcsound.c       pcsound.h
             pcsound_bsd.c
             pcsound_sdl.c
             pcsound_linux.c
             pcsound_win32.c
-                            pcsound_internal.h)
+                            pcsound_internal.h
+)
+
 target_include_directories(pcsound
-                           INTERFACE "."
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
-target_link_libraries(pcsound SDL2::mixer)
+    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}"
+    PUBLIC "${PROJECT_BINARY_DIR}"
+)
+
+target_link_libraries(pcsound PUBLIC
+    SDL2::mixer
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Common source files used by absolutely everything:
+set(DOOM_SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL "Doom srcdir")
 
 add_library(common STATIC EXCLUDE_FROM_ALL
     i_main.c
@@ -47,6 +47,8 @@ if(DOOM_BUILD_SERVER)
         PROPERTIES
             OUTPUT_NAME "${PROGRAM_PREFIX}server"
     )
+
+    doom_install(TARGETS server)
 endif()
 
 # Source files used by the game binaries (chocolate-doom, etc.)
@@ -115,6 +117,34 @@ add_library(gamecommon STATIC EXCLUDE_FROM_ALL
     z_zone.c            z_zone.h
 )
 convert_icon("${PROJECT_DATADIR}/doom.png" "icon.c" COPY "${CMAKE_CURRENT_SOURCE_DIR}/icon.c")
+
+function(generate_install_desktop NAME_CAP)
+    cmake_parse_arguments(GID "" "SRCDIR;INSTALL_SUBDIR" "" ${ARGV})
+
+    set(SRCDIR "${DOOM_SRCDIR}")
+    if(GID_SRCDIR)
+        set(SRCDIR "${GID_SRCDIR}")
+    endif()
+    set(OUT "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_RDNS}.${NAME_CAP}.desktop")
+    configure_file("${SRCDIR}/${NAME_CAP}.desktop.in" "${OUT}" @ONLY)
+    doom_install(FILES "${OUT}"
+        DESTINATION "${CMAKE_INSTALL_DESKTOPDIR}/${GID_INSTALL_SUBDIR}"
+    )
+endfunction()
+
+function(generate_install_metainfo NAME_CAP)
+    cmake_parse_arguments(GIM "" "SRCDIR" "" ${ARGV})
+
+    set(SRCDIR "${DOOM_SRCDIR}")
+    if(GIM_SRCDIR)
+        set(SRCDIR "${GIM_SRCDIR}")
+    endif()
+    set(OUT "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_RDNS}.${NAME_CAP}.metainfo.xml")
+    configure_file("${SRCDIR}/${NAME_CAP}.metainfo.xml.in" "${OUT}" @ONLY)
+    doom_install(FILES "${OUT}"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo"
+    )
+endfunction()
 
 if(MSVC)
     target_sources(gamecommon PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(gamecommon STATIC EXCLUDE_FROM_ALL
     i_pcsound.c
     i_sdlmusic.c
     i_sdlsound.c
+    icon.c
     i_sound.c           i_sound.h
     i_timer.c           i_timer.h
     i_video.c           i_video.h
@@ -113,6 +114,7 @@ add_library(gamecommon STATIC EXCLUDE_FROM_ALL
     w_merge.c           w_merge.h
     z_zone.c            z_zone.h
 )
+convert_icon("${PROJECT_DATADIR}/doom.png" "icon.c" COPY "${CMAKE_CURRENT_SOURCE_DIR}/icon.c")
 
 if(MSVC)
     target_sources(gamecommon PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,26 @@
-foreach(SUBDIR doom heretic hexen strife setup)
-    add_subdirectory("${SUBDIR}")
-endforeach()
-
 # Common source files used by absolutely everything:
 
-set(COMMON_SOURCE_FILES
+add_library(common STATIC EXCLUDE_FROM_ALL
     i_main.c
     i_system.c           i_system.h
     m_argv.c             m_argv.h
-    m_misc.c             m_misc.h)
+    m_misc.c             m_misc.h
+)
+
+target_include_directories(common PUBLIC
+    "${PROJECT_BINARY_DIR}"
+    "${PROJECT_SOURCE_DIR}/utils"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+target_link_libraries(common PUBLIC
+    SDL2::SDL2
+)
 
 # Dedicated server (chocolate-server):
 
-set(DEDSERV_FILES
+option(DOOM_BUILD_SERVER "Build server" ON)
+if(DOOM_BUILD_SERVER)
+    add_executable(server WIN32
     d_dedicated.c
     d_iwad.c            d_iwad.h
     d_mode.c            d_mode.h
@@ -27,16 +35,22 @@ set(DEDSERV_FILES
     net_query.c         net_query.h
     net_server.c        net_server.h
     net_structrw.c      net_structrw.h
-    z_native.c          z_zone.h)
+    z_native.c          z_zone.h
+    )
 
-add_executable("${PROGRAM_PREFIX}server" WIN32 ${COMMON_SOURCE_FILES} ${DEDSERV_FILES})
-target_include_directories("${PROGRAM_PREFIX}server"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
-target_link_libraries("${PROGRAM_PREFIX}server" SDL2::SDL2main SDL2::net)
+    target_link_libraries(server
+        common
+        SDL2::net
+    )
+
+    set_target_properties(server
+        PROPERTIES
+            OUTPUT_NAME "${PROGRAM_PREFIX}server"
+    )
+endif()
 
 # Source files used by the game binaries (chocolate-doom, etc.)
-
-set(GAME_SOURCE_FILES
+add_library(gamecommon STATIC EXCLUDE_FROM_ALL
     aes_prng.c          aes_prng.h
     d_event.c           d_event.h
                         doomkeys.h
@@ -97,132 +111,131 @@ set(GAME_SOURCE_FILES
     w_file_posix.c
     w_file_win32.c
     w_merge.c           w_merge.h
-    z_zone.c            z_zone.h)
-
-set(GAME_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../")
+    z_zone.c            z_zone.h
+)
 
 if(MSVC)
-    list(APPEND GAME_SOURCE_FILES
-         "../win32/win_opendir.c" "../win32/win_opendir.h")
-
-    list(APPEND GAME_INCLUDE_DIRS
-         "${PROJECT_SOURCE_DIR}/win32/")
+    target_sources(gamecommon PRIVATE
+         ../win32/win_opendir.c ../win32/win_opendir.h
+     )
 endif()
 
-set(DEHACKED_SOURCE_FILES
+target_include_directories(gamecommon INTERFACE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+target_link_libraries(gamecommon PUBLIC
+    common
+    SDL2::mixer
+    SDL2::net
+    textscreen
+    pcsound
+    opl
+)
+if(SAMPLERATE_FOUND)
+    target_link_libraries(gamecommon PUBLIC samplerate::samplerate)
+endif()
+if(PNG_FOUND)
+    target_link_libraries(gamecommon PUBLIC PNG::PNG)
+endif()
+
+# Some games support dehacked patches, some don't:
+add_library(gamecommon_dehacked STATIC
     deh_defs.h
     deh_io.c            deh_io.h
     deh_main.c          deh_main.h
     deh_mapping.c       deh_mapping.h
-    deh_text.c)
-
-# Some games support dehacked patches, some don't:
-
-set(SOURCE_FILES ${COMMON_SOURCE_FILES} ${GAME_SOURCE_FILES})
-set(SOURCE_FILES_WITH_DEH ${SOURCE_FILES} ${DEHACKED_SOURCE_FILES})
-
-set(EXTRA_LIBS SDL2::SDL2main SDL2::SDL2 SDL2::mixer SDL2::net textscreen pcsound opl)
-if(SAMPLERATE_FOUND)
-    list(APPEND EXTRA_LIBS samplerate::samplerate)
-endif()
-if(PNG_FOUND)
-    list(APPEND EXTRA_LIBS PNG::PNG)
-endif()
-
-if(WIN32)
-    add_executable("${PROGRAM_PREFIX}doom" WIN32 ${SOURCE_FILES_WITH_DEH} "${CMAKE_CURRENT_BINARY_DIR}/resource.rc")
-else()
-    add_executable("${PROGRAM_PREFIX}doom" ${SOURCE_FILES_WITH_DEH})
-endif()
-
-target_include_directories("${PROGRAM_PREFIX}doom" PRIVATE ${GAME_INCLUDE_DIRS})
-target_link_libraries("${PROGRAM_PREFIX}doom" doom ${EXTRA_LIBS})
-
-if(MSVC)
-    set_target_properties("${PROGRAM_PREFIX}doom" PROPERTIES
-                          LINK_FLAGS "/MANIFEST:NO")
-endif()
-
-if(WIN32)
-    add_executable("${PROGRAM_PREFIX}heretic" WIN32 ${SOURCE_FILES_WITH_DEH} "${CMAKE_CURRENT_BINARY_DIR}/resource.rc")
-else()
-    add_executable("${PROGRAM_PREFIX}heretic" ${SOURCE_FILES_WITH_DEH})
-endif()
-
-target_include_directories("${PROGRAM_PREFIX}heretic" PRIVATE ${GAME_INCLUDE_DIRS})
-target_link_libraries("${PROGRAM_PREFIX}heretic" heretic ${EXTRA_LIBS})
-
-if(MSVC)
-    set_target_properties("${PROGRAM_PREFIX}heretic" PROPERTIES
-                          LINK_FLAGS "/MANIFEST:NO")
-endif()
-
-if(WIN32)
-    add_executable("${PROGRAM_PREFIX}hexen" WIN32 ${SOURCE_FILES} "${CMAKE_CURRENT_BINARY_DIR}/resource.rc")
-else()
-    add_executable("${PROGRAM_PREFIX}hexen" ${SOURCE_FILES})
-endif()
-
-target_include_directories("${PROGRAM_PREFIX}hexen" PRIVATE ${GAME_INCLUDE_DIRS})
-target_link_libraries("${PROGRAM_PREFIX}hexen" hexen ${EXTRA_LIBS})
-
-if(MSVC)
-    set_target_properties("${PROGRAM_PREFIX}hexen" PROPERTIES
-                          LINK_FLAGS "/MANIFEST:NO")
-endif()
-
-if(WIN32)
-    add_executable("${PROGRAM_PREFIX}strife" WIN32 ${SOURCE_FILES_WITH_DEH} "${CMAKE_CURRENT_BINARY_DIR}/resource.rc")
-else()
-    add_executable("${PROGRAM_PREFIX}strife" ${SOURCE_FILES_WITH_DEH})
-endif()
-
-target_include_directories("${PROGRAM_PREFIX}strife" PRIVATE ${GAME_INCLUDE_DIRS})
-target_link_libraries("${PROGRAM_PREFIX}strife" strife ${EXTRA_LIBS})
-
-if(MSVC)
-    set_target_properties("${PROGRAM_PREFIX}strife" PROPERTIES
-                          LINK_FLAGS "/MANIFEST:NO")
-endif()
+    deh_text.c
+)
+target_link_libraries(gamecommon_dehacked PUBLIC
+    gamecommon
+)
 
 # Source files needed for chocolate-setup:
 
-set(SETUP_FILES
-    deh_str.c           deh_str.h
-    d_mode.c            d_mode.h
-    d_iwad.c            d_iwad.h
-    i_timer.c           i_timer.h
-    m_config.c          m_config.h
-    m_controls.c        m_controls.h
-    net_io.c            net_io.h
-    net_packet.c        net_packet.h
-    net_petname.c       net_petname.h
-    net_sdl.c           net_sdl.h
-    net_query.c         net_query.h
-    net_structrw.c      net_structrw.h
-    z_native.c          z_zone.h)
+option(DOOM_BUILD_SETUP "Build setup" ON)
+if(DOOM_BUILD_SETUP)
+    add_library(setupcommon
+        deh_str.c             deh_str.h
+        d_mode.c              d_mode.h
+        d_iwad.c              d_iwad.h
+        i_timer.c             i_timer.h
+        m_config.c            m_config.h
+        m_controls.c          m_controls.h
+        net_io.c              net_io.h
+        net_packet.c          net_packet.h
+        net_petname.c         net_petname.h
+        net_sdl.c             net_sdl.h
+        net_query.c           net_query.h
+        net_structrw.c        net_structrw.h
+        z_native.c            z_zone.h
+    )
 
-if(WIN32)
-    add_executable("${PROGRAM_PREFIX}setup" WIN32 ${SETUP_FILES} ${COMMON_SOURCE_FILES} "${CMAKE_CURRENT_BINARY_DIR}/setup-res.rc")
-else()
-    add_executable("${PROGRAM_PREFIX}setup" ${SETUP_FILES} ${COMMON_SOURCE_FILES})
+    target_link_libraries(setupcommon PUBLIC
+        common
+        SDL2::net
+    )
+
+    add_subdirectory(setup)
 endif()
 
-target_include_directories("${PROGRAM_PREFIX}setup"
-                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
-target_link_libraries("${PROGRAM_PREFIX}setup" SDL2::SDL2main SDL2::SDL2 SDL2::mixer SDL2::net setup textscreen)
-
-if(MSVC)
-    set_target_properties("${PROGRAM_PREFIX}setup" PROPERTIES
-                          LINK_FLAGS "/MANIFEST:NO")
+option(DOOM_BUILD_DOOM "Build doom" ON)
+if(DOOM_BUILD_DOOM)
+    add_subdirectory(doom)
 endif()
 
-add_executable(midiread midifile.c z_native.c i_system.c m_argv.c m_misc.c d_iwad.c deh_str.c m_config.c)
-target_compile_definitions(midiread PRIVATE "-DTEST")
-target_include_directories(midiread PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
-target_link_libraries(midiread SDL2::SDL2main SDL2::SDL2)
+option(DOOM_BUILD_HERETIC "Build heretic" ON)
+if(DOOM_BUILD_HERETIC)
+    add_subdirectory(heretic)
+endif()
 
-add_executable(mus2mid mus2mid.c memio.c z_native.c i_system.c m_argv.c m_misc.c d_iwad.c deh_str.c m_config.c)
-target_compile_definitions(mus2mid PRIVATE "-DSTANDALONE")
-target_include_directories(mus2mid PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
-target_link_libraries(mus2mid SDL2::SDL2main SDL2::SDL2)
+option(DOOM_BUILD_HEXEN "Build hexen" ON)
+if(DOOM_BUILD_HEXEN)
+    add_subdirectory(hexen)
+endif()
+
+option(DOOM_BUILD_STRIFE "Build strife" ON)
+if(DOOM_BUILD_STRIFE)
+    add_subdirectory(strife)
+endif()
+
+add_executable(midiread
+    deh_str.c             deh_str.h
+    d_iwad.c              d_iwad.h
+    i_system.c            i_system.h
+    midifile.c            midifile.h
+    m_argv.c              m_argv.h
+    m_config.c            m_config.h
+    m_misc.c              m_misc.h
+    z_native.c
+)
+target_compile_definitions(midiread PRIVATE
+    TEST
+)
+target_include_directories(midiread PRIVATE
+    "${PROJECT_BINARY_DIR}"
+)
+target_link_libraries(midiread PRIVATE
+    SDL2::SDL2
+)
+
+add_executable(mus2mid
+    mus2mid.c             mus2mid.h
+    memio.c               memio.h
+    z_native.c
+    i_system.c            i_system.h
+    m_argv.c              m_argv.h
+    m_misc.c              m_misc.h
+    d_iwad.c              d_iwad.h
+    deh_str.c             deh_str.h
+    m_config.c            m_config.h
+)
+target_compile_definitions(mus2mid PRIVATE
+    STANDALONE
+)
+target_include_directories(mus2mid PRIVATE
+    "${PROJECT_BINARY_DIR}"
+)
+target_link_libraries(mus2mid PRIVATE
+    SDL2::SDL2
+)

--- a/src/doom/CMakeLists.txt
+++ b/src/doom/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(doom STATIC
+add_executable(doom WIN32
             am_map.c        am_map.h
             deh_ammo.c
             deh_bexstr.c
@@ -65,7 +65,25 @@ add_library(doom STATIC
             statdump.c      statdump.h
             st_lib.c        st_lib.h
             st_stuff.c      st_stuff.h
-            wi_stuff.c      wi_stuff.h)
+            wi_stuff.c      wi_stuff.h
+)
 
-target_include_directories(doom PRIVATE "../" "${CMAKE_CURRENT_BINARY_DIR}/../../")
-target_link_libraries(doom SDL2::SDL2 SDL2::mixer SDL2::net)
+if(WIN32)
+    target_sources(doom PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}/../resource.rc"
+    )
+endif()
+
+target_link_libraries(doom PUBLIC
+    gamecommon_dehacked
+)
+
+set_target_properties(doom PROPERTIES
+    OUTPUT_NAME "${PROGRAM_PREFIX}doom"
+)
+
+if(MSVC)
+    set_target_properties("${PROGRAM_PREFIX}doom" PROPERTIES
+        LINK_FLAGS /MANIFEST:NO
+    )
+endif()

--- a/src/doom/CMakeLists.txt
+++ b/src/doom/CMakeLists.txt
@@ -87,3 +87,13 @@ if(MSVC)
         LINK_FLAGS /MANIFEST:NO
     )
 endif()
+
+generate_install_desktop(Doom)
+generate_install_desktop(Doom_Screensaver INSTALL_SUBDIR screensavers)
+generate_install_metainfo(Doom)
+
+doom_install(TARGETS doom)
+
+if(DOOM_BUILD_SETUP)
+    create_setup_link(doom)
+endif()

--- a/src/heretic/CMakeLists.txt
+++ b/src/heretic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(heretic STATIC
+add_executable(heretic WIN32
             am_data.h
             am_map.c            am_map.h
             ct_chat.c           ct_chat.h
@@ -51,7 +51,25 @@ add_library(heretic STATIC
             r_things.c
             sb_bar.c
             sounds.c            sounds.h
-            s_sound.c           s_sound.h)
+            s_sound.c           s_sound.h
+)
 
-target_include_directories(heretic PRIVATE "../" "${CMAKE_CURRENT_BINARY_DIR}/../../")
-target_link_libraries(heretic textscreen SDL2::SDL2 SDL2::mixer SDL2::net)
+if(WIN32)
+    target_sources(heretic PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}/../resource.rc"
+    )
+endif()
+
+target_link_libraries(heretic PUBLIC
+    gamecommon_dehacked
+)
+
+set_target_properties(heretic PROPERTIES
+    OUTPUT_NAME "${PROGRAM_PREFIX}heretic"
+)
+
+if(MSVC)
+    set_target_properties(heretic PROPERTIES
+        LINK_FLAGS "/MANIFEST:NO"
+    )
+endif()

--- a/src/heretic/CMakeLists.txt
+++ b/src/heretic/CMakeLists.txt
@@ -73,3 +73,12 @@ if(MSVC)
         LINK_FLAGS "/MANIFEST:NO"
     )
 endif()
+
+generate_install_desktop(Heretic)
+generate_install_metainfo(Heretic)
+
+doom_install(TARGETS heretic)
+
+if(DOOM_BUILD_SETUP)
+    create_setup_link(heretic)
+endif()

--- a/src/hexen/CMakeLists.txt
+++ b/src/hexen/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(hexen STATIC
+add_executable(hexen WIN32
             a_action.c
                                 am_data.h
             am_map.c            am_map.h
@@ -52,7 +52,25 @@ add_library(hexen STATIC
             st_start.c          st_start.h
             sv_save.c
                                 textdefs.h
-                                xddefs.h)
+                                xddefs.h
+)
 
-target_include_directories(hexen PRIVATE "../" "${CMAKE_CURRENT_BINARY_DIR}/../../")
-target_link_libraries(hexen SDL2::SDL2 SDL2::mixer SDL2::net)
+if(WIN32)
+    target_sources(hexen PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}/../resource.rc"
+    )
+endif()
+
+target_link_libraries(hexen PUBLIC
+    gamecommon
+)
+
+set_target_properties(hexen PROPERTIES
+    OUTPUT_NAME "${PROGRAM_PREFIX}hexen"
+)
+
+if(MSVC)
+    set_target_properties(hexen PROPERTIES
+        LINK_FLAGS "/MANIFEST:NO"
+    )
+endif()

--- a/src/hexen/CMakeLists.txt
+++ b/src/hexen/CMakeLists.txt
@@ -74,3 +74,12 @@ if(MSVC)
         LINK_FLAGS "/MANIFEST:NO"
     )
 endif()
+
+generate_install_desktop(Hexen)
+generate_install_metainfo(Hexen)
+
+doom_install(TARGETS hexen)
+
+if(DOOM_BUILD_SETUP)
+    create_setup_link(hexen)
+endif()

--- a/src/setup/CMakeLists.txt
+++ b/src/setup/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(setup STATIC
+add_executable(setup WIN32
             compatibility.c     compatibility.h
             display.c           display.h
             joystick.c          joystick.h
@@ -12,7 +12,26 @@ add_library(setup STATIC
             txt_joyaxis.c       txt_joyaxis.h
             txt_joybinput.c     txt_joybinput.h
             txt_keyinput.c      txt_keyinput.h
-            txt_mouseinput.c    txt_mouseinput.h)
+            txt_mouseinput.c    txt_mouseinput.h
+)
 
-target_include_directories(setup PRIVATE "../" "${CMAKE_CURRENT_BINARY_DIR}/../../")
-target_link_libraries(setup textscreen SDL2::SDL2 SDL2::mixer)
+if(WIN32)
+    target_sources(setup PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}/../setup-res.rc"
+    )
+endif()
+
+target_link_libraries(setup PRIVATE
+    setupcommon
+    textscreen
+)
+
+set_target_properties(setup PROPERTIES
+    OUTPUT_NAME "${PROGRAM_PREFIX}setup"
+)
+
+if(MSVC)
+    set_target_properties(setup PROPERTIES
+        LINK_FLAGS "/MANIFEST:NO"
+    )
+endif()

--- a/src/setup/CMakeLists.txt
+++ b/src/setup/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(setup WIN32
             mode.c              mode.h
             mouse.c             mouse.h
             multiplayer.c       multiplayer.h
+            setup_icon.c
             sound.c             sound.h
             execute.c           execute.h
             txt_joyaxis.c       txt_joyaxis.h
@@ -14,6 +15,8 @@ add_executable(setup WIN32
             txt_keyinput.c      txt_keyinput.h
             txt_mouseinput.c    txt_mouseinput.h
 )
+
+convert_icon("${PROJECT_DATADIR}/setup.png" setup_icon.c COPY "${CMAKE_CURRENT_SOURCE_DIR}/setup_icon.c")
 
 if(WIN32)
     target_sources(setup PRIVATE

--- a/src/setup/CMakeLists.txt
+++ b/src/setup/CMakeLists.txt
@@ -38,3 +38,25 @@ if(MSVC)
         LINK_FLAGS "/MANIFEST:NO"
     )
 endif()
+
+doom_install(TARGETS setup)
+
+generate_install_desktop(Setup
+    SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+add_custom_target(create_setups ALL)
+
+set(SETUP_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE INTERNAL "setup binary dir")
+
+function(create_setup_link NAME)
+    set(SETUP_NAME "${PROGRAM_PREFIX}${NAME}-setup${CMAKE_EXECUTABLE_SUFFIX}")
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${SETUP_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E create_symlink "$<TARGET_FILE:setup>" "${CMAKE_CURRENT_BINARY_DIR}/${SETUP_NAME}"
+    )
+    add_custom_target("create_setup_${NAME}" DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${SETUP_NAME}")
+    add_dependencies(create_setups "create_setup_${NAME}")
+
+    cmake_policy(SET CMP0087 NEW)
+    install(CODE "file(CREATE_LINK \"$<TARGET_FILE_BASE_NAME:setup>\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/${SETUP_NAME}\" SYMBOLIC)")
+endfunction()

--- a/src/strife/CMakeLists.txt
+++ b/src/strife/CMakeLists.txt
@@ -92,3 +92,12 @@ if(MSVC)
         LINK_FLAGS "/MANIFEST:NO"
     )
 endif()
+
+generate_install_desktop(Strife)
+generate_install_metainfo(Strife)
+
+doom_install(TARGETS strife)
+
+if(DOOM_BUILD_SETUP)
+    create_setup_link(strife)
+endif()

--- a/src/strife/CMakeLists.txt
+++ b/src/strife/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(STRIFE_SOURCES
+add_executable(strife WIN32
     am_map.c        am_map.h
     deh_ammo.c
     deh_cheat.c
@@ -65,9 +65,30 @@ set(STRIFE_SOURCES
     sounds.c        sounds.h
     st_lib.c        st_lib.h
     st_stuff.c      st_stuff.h
-    wi_stuff.c      wi_stuff.h)
+    wi_stuff.c      wi_stuff.h
+)
 
-add_library(strife STATIC ${STRIFE_SOURCES})
+if(WIN32)
+    target_sources(strife
+        "${CMAKE_CURRENT_BINARY_DIR}/../resource.rc"
+    )
+endif()
 
-target_include_directories(strife PRIVATE "../" "../../win32/" "${CMAKE_CURRENT_BINARY_DIR}/../../")
-target_link_libraries(strife textscreen SDL2::SDL2 SDL2::mixer SDL2::net)
+target_include_directories(strife
+    PRIVATE
+        "${PROJECT_SOURCE_DIR}/win32"
+)
+
+target_link_libraries(strife PUBLIC
+    gamecommon_dehacked
+)
+
+set_target_properties(strife PROPERTIES
+    OUTPUT_NAME "${PROGRAM_PREFIX}strife"
+)
+
+if(MSVC)
+    set_target_properties(strife PROPERTIES
+        LINK_FLAGS "/MANIFEST:NO"
+    )
+endif()

--- a/textscreen/CMakeLists.txt
+++ b/textscreen/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(textscreen STATIC
+add_library(textscreen STATIC EXCLUDE_FROM_ALL
             textscreen.h
             txt_conditional.c   txt_conditional.h
             txt_checkbox.c      txt_checkbox.h
@@ -21,8 +21,14 @@ add_library(textscreen STATIC
             txt_utf8.c          txt_utf8.h
             txt_widget.c        txt_widget.h
             txt_window.c        txt_window.h
-            txt_window_action.c txt_window_action.h)
+            txt_window_action.c txt_window_action.h
+)
+
 target_include_directories(textscreen
-                           INTERFACE "."
-                           PRIVATE "../src/")
-target_link_libraries(textscreen m SDL2::SDL2)
+    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}"
+    PUBLIC "${PROJECT_SOURCE_DIR}/src"
+)
+target_link_libraries(textscreen PUBLIC
+    m
+    SDL2::SDL2
+)


### PR DESCRIPTION
Changes to the cmake build system:
- compile the common doom/heretix/hexen/strife libraries as static libraries and link them together. This reduces the build time a little (13s -> 11s on my system using `-j9`)
- the project variables are parsed from `configure.ac`.
- add generation of the mans+bash completion+desktop icon+...
- add install target. The installed tree is the same as the one of `autotools`. The only difference is that it doesn't copy `chocolate-server` to chocolate-server-{doom,heretic,hexen,strife} but creates symbolic links.

Changes to autotools + cmake:
- ~generate headers from the images and include these (instead of `.c` files)~
- ~Use `PACKAGE_BUGREPORT` everywhere. Before, a mixture of `PACKAGE_ISSUES` and `PACKAGE_BUGREPORT` as used (but not both were set).~