### PR TITLE
hexen: Disable checks in A_SoAExplode not present in version 1.1

### DIFF
--- a/src/hexen/a_action.c
+++ b/src/hexen/a_action.c
@@ -1177,9 +1177,11 @@ void A_SoAExplode(mobj_t * actor)
     }
     if (actor->args[0])
     {                           // Spawn an item
+#if 0 // Checks are not present in version 1.1
         if (!nomonsters
             || !(mobjinfo[TranslateThingType[actor->args[0]]].
                  flags & MF_COUNTKILL))
+#endif
         {                       // Only spawn monsters if not -nomonsters
             P_SpawnMobj(actor->x, actor->y, actor->z,
                         TranslateThingType[actor->args[0]]);


### PR DESCRIPTION
I've recently inspected version 1.1 of the Hexen EXE for DOS. Following earlier hints from Nuke.YKT, I've used (for the purpose of building a DOS EXE only) the DMX 33gs headers and the DMX 34a lib, along with Watcom C32 10.0 and Turbo Assembler 3.1, in order to build an EXE. The build command is "M F". I've then found out one difference in A_SoAExplode.

After disabling the checks as described in my suggested commit, I've gotten an EXE which is - probably - more-or-less binary identical to the original. I believe that it differs from the latter just by the lack of the DOS/4GW Professional loader, the VERSIONTEXT macro and garbage data inserted by Watcom C32 10.0 between C string literals (at least for most).

Nuke.YKT has then found out that this difference is still present in the Chocolate Doom codebase, thus leading me to here with this patch.

I haven't actually checked what impact does this have on the game, thus I'm simply adding the patch so it isn't forgotten.