### PR TITLE
Use PACKAGE_BUGREPORT (instead of PACKAGE_ISSUES)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ PACKAGE_LICENSE="GNU General Public License, version 2"
 PACKAGE_MAINTAINER="Simon Howard"
 PACKAGE_URL="https://www.chocolate-doom.org/"
 PACKAGE_RDNS="org.chocolate_doom"
-PACKAGE_ISSUES="https://github.com/chocolate-doom/chocolate-doom/issues"
+PACKAGE_BUGREPORT="https://github.com/chocolate-doom/chocolate-doom/issues"
 
 AC_CONFIG_AUX_DIR(autotools)
 AC_CANONICAL_HOST
@@ -144,7 +144,7 @@ AC_SUBST(PACKAGE_LICENSE)
 AC_SUBST(PACKAGE_MAINTAINER)
 AC_SUBST(PACKAGE_URL)
 AC_SUBST(PACKAGE_RDNS)
-AC_SUBST(PACKAGE_ISSUES)
+AC_SUBST(PACKAGE_BUGREPORT)
 
 dnl Shut up the datarootdir warnings.
 AC_DEFUN([AC_DATAROOTDIR_CHECKED])

--- a/src/Doom.metainfo.xml.in
+++ b/src/Doom.metainfo.xml.in
@@ -8,7 +8,7 @@
   <project_license>GPL-2.0+</project_license>
   <developer_name>@PACKAGE_MAINTAINER@</developer_name>
   <url type="homepage">@PACKAGE_URL@</url>
-  <url type="bugtracker">@PACKAGE_ISSUES@</url>
+  <url type="bugtracker">@PACKAGE_BUGREPORT@</url>
   <description>
     <p>
       @PACKAGE_SHORTNAME@ Doom is a conservative,

--- a/src/Heretic.metainfo.xml.in
+++ b/src/Heretic.metainfo.xml.in
@@ -8,7 +8,7 @@
   <project_license>GPL-2.0+</project_license>
   <developer_name>@PACKAGE_MAINTAINER@</developer_name>
   <url type="homepage">@PACKAGE_URL@</url>
-  <url type="bugtracker">@PACKAGE_ISSUES@</url>
+  <url type="bugtracker">@PACKAGE_BUGREPORT@</url>
   <description>
     <p>
       @PACKAGE_SHORTNAME@ Heretic is a conservative,

--- a/src/Hexen.metainfo.xml.in
+++ b/src/Hexen.metainfo.xml.in
@@ -8,7 +8,7 @@
   <project_license>GPL-2.0+</project_license>
   <developer_name>@PACKAGE_MAINTAINER@</developer_name>
   <url type="homepage">@PACKAGE_URL@</url>
-  <url type="bugtracker">@PACKAGE_ISSUES@</url>
+  <url type="bugtracker">@PACKAGE_BUGREPORT@</url>
   <description>
     <p>
       @PACKAGE_SHORTNAME@ Hexen is a conservative,

--- a/src/Strife.metainfo.xml.in
+++ b/src/Strife.metainfo.xml.in
@@ -8,7 +8,7 @@
   <project_license>GPL-2.0+</project_license>
   <developer_name>@PACKAGE_MAINTAINER@</developer_name>
   <url type="homepage">@PACKAGE_URL@</url>
-  <url type="bugtracker">@PACKAGE_ISSUES@</url>
+  <url type="bugtracker">@PACKAGE_BUGREPORT@</url>
   <description>
     <p>
       @PACKAGE_SHORTNAME@ Strife is a conservative,


### PR DESCRIPTION
Extracted from #1265 

Use `PACKAGE_BUGREPORT` everywhere.

Before, a mixture of `PACKAGE_ISSUES` and `PACKAGE_BUGREPORT` was used (but not both were set).