### PR TITLE
Heretic: Allow Morph Ovum to be bound to a key

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -494,6 +494,11 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         gamekeydown[key_arti_torch] = false;
         cmd->arti = arti_torch;
     }
+    else if (gamekeydown[key_arti_morph] && !cmd->arti)
+    {
+        gamekeydown[key_arti_morph] = false;
+        cmd->arti = arti_egg;
+    }
 
 //
 // buttons

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1612,6 +1612,14 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_KEY(key_arti_torch),
 
     //!
+    // @game heretic
+    //
+    // Key to use "morph ovum" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_morph),
+
+    //!
     // @game hexen
     //
     // Key to use one of each artifact.

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -63,6 +63,7 @@ int key_arti_chaosdevice = 0;
 int key_arti_shadowsphere = 0;
 int key_arti_wings = 0;
 int key_arti_torch = 0;
+int key_arti_morph = 0;
 
 //
 // Hexen key controls
@@ -278,6 +279,7 @@ void M_BindHereticControls(void)
     M_BindIntVariable("key_arti_shadowsphere",  &key_arti_shadowsphere);
     M_BindIntVariable("key_arti_wings",         &key_arti_wings);
     M_BindIntVariable("key_arti_torch",         &key_arti_torch);
+    M_BindIntVariable("key_arti_morph",         &key_arti_morph);
 }
 
 void M_BindHexenControls(void)

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -76,6 +76,7 @@ extern int key_arti_chaosdevice;
 extern int key_arti_shadowsphere;
 extern int key_arti_wings;
 extern int key_arti_torch;
+extern int key_arti_morph;
 
 extern int key_arti_all;
 extern int key_arti_health;

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -47,7 +47,8 @@ static int *controls[] = { &key_left, &key_right, &key_up, &key_down,
                            &key_weapon7, &key_weapon8,
                            &key_arti_quartz, &key_arti_urn, &key_arti_bomb,
                            &key_arti_tome, &key_arti_ring, &key_arti_chaosdevice,
-                           &key_arti_shadowsphere, &key_arti_wings, &key_arti_torch,
+                           &key_arti_shadowsphere, &key_arti_wings, 
+                           &key_arti_torch, &key_arti_morph,
                            &key_arti_all, &key_arti_health, &key_arti_poisonbag,
                            &key_arti_blastradius, &key_arti_teleport,
                            &key_arti_teleportother, &key_arti_egg,
@@ -256,6 +257,7 @@ static void ConfigExtraKeys(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
             AddKeyControl(table, "Shadowsphere", &key_arti_shadowsphere);
             AddKeyControl(table, "Wings of Wrath", &key_arti_wings);
             AddKeyControl(table, "Torch", &key_arti_torch);
+            AddKeyControl(table, "Morph Ovum", &key_arti_morph);
         }
 
         if (gamemission == hexen)


### PR DESCRIPTION
It was forgotten in the previous commit that added hotkeys for artifacts.

I followed the previous commit's method of not duplicating Hexen artifact keys, and so the new key is key_arti_morph.

@JNechaevsky you might want to add this to Russian Doom. (er, Russian Heretic that is)