### PR TITLE
doom: Refactor chat macro defaults for const correctness

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -321,6 +321,22 @@ static void EnableLoadingDisk(void)
 // Add configuration file variable bindings.
 //
 
+
+static const char * const chat_macro_defaults[10] =
+{
+    HUSTR_CHATMACRO0,
+    HUSTR_CHATMACRO1,
+    HUSTR_CHATMACRO2,
+    HUSTR_CHATMACRO3,
+    HUSTR_CHATMACRO4,
+    HUSTR_CHATMACRO5,
+    HUSTR_CHATMACRO6,
+    HUSTR_CHATMACRO7,
+    HUSTR_CHATMACRO8,
+    HUSTR_CHATMACRO9
+};
+
+
 void D_BindVariables(void)
 {
     int i;
@@ -363,6 +379,7 @@ void D_BindVariables(void)
     {
         char buf[12];
 
+        chat_macros[i] = M_StringDuplicate(chat_macro_defaults[i]);
         M_snprintf(buf, sizeof(buf), "chatmacro%i", i);
         M_BindStringVariable(buf, &chat_macros[i]);
     }

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -63,19 +63,7 @@
 
 
 
-char *chat_macros[10] =
-{
-    HUSTR_CHATMACRO0,
-    HUSTR_CHATMACRO1,
-    HUSTR_CHATMACRO2,
-    HUSTR_CHATMACRO3,
-    HUSTR_CHATMACRO4,
-    HUSTR_CHATMACRO5,
-    HUSTR_CHATMACRO6,
-    HUSTR_CHATMACRO7,
-    HUSTR_CHATMACRO8,
-    HUSTR_CHATMACRO9
-};
+char *chat_macros[10];
 
 const char *player_names[] =
 {


### PR DESCRIPTION
chat_macros is passed to M_BindStringVariable which might ovewrite
its contents so it can't be const. But the default values are constants
so it should be const. Solve this by moving defaults to their own list
and initializing chat_macros in D_BindVariables just before they're
bound to string variables.

This might cause some memory leaks but I'm leaving that until later since it would require some refactoring and a lot of checking of the string config variable handling.