### PR TITLE
music: Disable Fluidsynth when we want Timidity.

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -110,11 +110,17 @@ void I_InitTimidityConfig(void)
 
     // Set the TIMIDITY_CFG environment variable to point to the temporary
     // config file.
-
     if (success)
     {
         env_string = M_StringJoin("TIMIDITY_CFG=", temp_timidity_cfg, NULL);
         putenv(env_string);
+        // env_string deliberately not freed; see putenv manpage
+
+        // If we're explicitly configured to use Timidity (either through
+        // timidity_cfg_path or GUS mode), then disable Fluidsynth, because
+        // SDL_mixer considers Fluidsynth a higher priority than Timidity and
+        // therefore can end up circumventing Timidity entirely.
+        putenv("SDL_MIXER_DISABLE_FLUIDSYNTH=1");
     }
     else
     {


### PR DESCRIPTION
When `timidity_cfg_path` is set, or we're using GUS pseudo-emulation, set the
SDL_mixer environment variable to disable Fluidsynth, because Fluidsynth has a
higher priority than Timidity inside SDL_mixer, and if it's configured
properly it will circumvent Timidity entirely along with any configuration
we've set up.

Thanks to DagothKronk for reporting this bug on Doomworld:
<https://www.doomworld.com/forum/topic/86366-chocolate-doom/?do=findComment&comment=2105318>