### PR TITLE
Fix clang warnings

### DIFF
--- a/src/heretic/r_segs.c
+++ b/src/heretic/r_segs.c
@@ -356,7 +356,7 @@ void R_StoreWallRange(int start, int stop)
 // calculate rw_distance for scale calculation
 //
     rw_normalangle = curline->angle + ANG90;
-    offsetangle = abs(rw_normalangle - rw_angle1);
+    offsetangle = abs((int) rw_normalangle - (int) rw_angle1);
     if (offsetangle > ANG90)
         offsetangle = ANG90;
     distangle = ANG90 - offsetangle;

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -4032,7 +4032,7 @@ void A_SorcBallOrbit(mobj_t * actor)
         case SORC_STOPPING:    // Balls stopping
             if ((parent->special2.i == actor->type) &&
                 (parent->args[1] > SORCBALL_SPEED_ROTATIONS) &&
-                (abs(angle - (parent->angle >> ANGLETOFINESHIFT)) <
+                (abs((int) angle - (int) (parent->angle >> ANGLETOFINESHIFT)) <
                  (30 << 5)))
             {
                 // Can stop now

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -2877,7 +2877,7 @@ static void DragonSeek(mobj_t * actor, angle_t thresh, angle_t turnMax)
     {                           // attack the destination mobj if it's attackable
         mobj_t *oldTarget;
 
-        if (abs(actor->angle - R_PointToAngle2(actor->x, actor->y,
+        if (abs((int) actor->angle - (int) R_PointToAngle2(actor->x, actor->y,
                                                target->x,
                                                target->y)) < ANG45 / 2)
         {

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -2915,9 +2915,9 @@ static void DragonSeek(mobj_t * actor, angle_t thresh, angle_t turnMax)
                 mo = P_FindMobjFromTID(target->args[i], &search);
                 angleToSpot = R_PointToAngle2(actor->x, actor->y,
                                               mo->x, mo->y);
-                if (abs(angleToSpot - angleToTarget) < bestAngle)
+                if (abs((int) angleToSpot - (int) angleToTarget) < bestAngle)
                 {
-                    bestAngle = abs(angleToSpot - angleToTarget);
+                    bestAngle = abs((int) angleToSpot - (int) angleToTarget);
                     bestArg = i;
                 }
             }

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -2986,13 +2986,13 @@ void A_DragonFlight(mobj_t * actor)
         }
         angle = R_PointToAngle2(actor->x, actor->y, actor->target->x,
                                 actor->target->y);
-        if (abs(actor->angle - angle) < ANG45 / 2
+        if (abs((int) actor->angle - (int) angle) < ANG45 / 2
             && P_CheckMeleeRange(actor))
         {
             P_DamageMobj(actor->target, actor, actor, HITDICE(8));
             S_StartSound(actor, SFX_DRAGON_ATTACK);
         }
-        else if (abs(actor->angle - angle) <= ANG1 * 20)
+        else if (abs((int) actor->angle - (int) angle) <= ANG1 * 20)
         {
             P_SetMobjState(actor, actor->info->missilestate);
             S_StartSound(actor, SFX_DRAGON_ATTACK);

--- a/src/hexen/p_mobj.c
+++ b/src/hexen/p_mobj.c
@@ -537,7 +537,7 @@ void P_XYMovement(mobj_t * mo)
                     {
                         case MT_CENTAUR:
                         case MT_CENTAURLEADER:
-                            if (abs(angle - BlockingMobj->angle) >> 24 > 45)
+                            if (abs((int) angle - (int) BlockingMobj->angle) >> 24 > 45)
                                 goto explode;
                             if (mo->type == MT_HOLY_FX)
                                 goto explode;

--- a/src/hexen/r_segs.c
+++ b/src/hexen/r_segs.c
@@ -348,7 +348,7 @@ void R_StoreWallRange(int start, int stop)
 // calculate rw_distance for scale calculation
 //
     rw_normalangle = curline->angle + ANG90;
-    offsetangle = abs(rw_normalangle - rw_angle1);
+    offsetangle = abs((int) rw_normalangle - (int) rw_angle1);
     if (offsetangle > ANG90)
         offsetangle = ANG90;
     distangle = ANG90 - offsetangle;

--- a/src/strife/r_segs.c
+++ b/src/strife/r_segs.c
@@ -407,7 +407,7 @@ R_StoreWallRange
     
     // calculate rw_distance for scale calculation
     rw_normalangle = curline->angle + ANG90;
-    offsetangle = abs(rw_normalangle-rw_angle1);
+    offsetangle = abs((int) rw_normalangle - (int) rw_angle1);
     
     if (offsetangle > ANG90)
 	offsetangle = ANG90;


### PR DESCRIPTION
Closes #882

Fixes clang warnings about use of `abs`  on unsigned values. It seems some similar warnings were already fixed in Doom by adding `int` casts. I did the same. However I'm not certain this is the right thing to do. Some of these were in gameplay code and some demos might have been relying on the old behavior.

WIP because I haven't tested this yet.