### PR TITLE
opl_linux: fix number of port requested by ioperm()

### DIFF
--- a/opl/opl_linux.c
+++ b/opl/opl_linux.c
@@ -35,7 +35,7 @@ static int OPL_Linux_Init(unsigned int port_base)
 {
     // Try to get permissions:
 
-    if (ioperm(port_base, 2, 1) < 0)
+    if (ioperm(port_base, 3, 1) < 0)
     {
         fprintf(stderr, "Failed to get I/O port permissions for 0x%x: %s\n",
                         port_base, strerror(errno));


### PR DESCRIPTION
These 3 port are used :

```
typedef enum
{
    OPL_REGISTER_PORT = 0,
    OPL_DATA_PORT = 1,
    OPL_REGISTER_PORT_OPL3 = 2
} opl_port_t;
```

but only 2 was requested, causing a crash.