### PR TITLE
M_DirName()/M_BaseName(): accept forward slash on Windows

### DIFF
--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -138,12 +138,5 @@ typedef int16_t dpixel_t;
 
 #define arrlen(array) (sizeof(array) / sizeof(*array))
 
-#ifndef MIN
- #define MIN(a,b) (((a)<(b))?(a):(b))
-#endif
-#ifndef MAX
- #define MAX(a,b) (((a)>(b))?(a):(b))
-#endif
-
 #endif
 

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -138,5 +138,12 @@ typedef int16_t dpixel_t;
 
 #define arrlen(array) (sizeof(array) / sizeof(*array))
 
+#ifndef MIN
+ #define MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+#ifndef MAX
+ #define MAX(a,b) (((a)>(b))?(a):(b))
+#endif
+
 #endif
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -274,6 +274,15 @@ char *M_DirName(const char *path)
     char *p, *result;
 
     p = strrchr(path, DIR_SEPARATOR);
+#ifdef _WIN32
+    if (p == NULL)
+    {
+        // Windows allows for both backward and forward slashes as path
+        // separators. So, if we cannot find the former, try the latter
+        // instead, but don't accept mixed forms.
+        p = strrchr(path, '/');
+    }
+#endif
     if (p == NULL)
     {
         return M_StringDuplicate(".");
@@ -294,6 +303,15 @@ const char *M_BaseName(const char *path)
     const char *p;
 
     p = strrchr(path, DIR_SEPARATOR);
+#ifdef _WIN32
+    if (p == NULL)
+    {
+        // Windows allows for both backward and forward slashes as path
+        // separators. So, if we cannot find the former, try the latter
+        // instead, but don't accept mixed forms.
+        p = strrchr(path, '/');
+    }
+#endif
     if (p == NULL)
     {
         return path;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -271,24 +271,21 @@ boolean M_StrToInt(const char *str, int *result)
 // and must be freed by the caller after use.
 char *M_DirName(const char *path)
 {
-    char *p, *result;
+    char *pf, *pb, *result;
 
-    p = strrchr(path, DIR_SEPARATOR);
+    pf = strrchr(path, '/');
 #ifdef _WIN32
-    if (p == NULL)
-    {
-        // Windows allows for both backward and forward slashes as path
-        // separators. So, if we cannot find the former, try the latter
-        // instead, but don't accept mixed forms.
-        p = strrchr(path, '/');
-    }
+    pb = strrchr(path, '\\');
+#else
+    pb = NULL;
 #endif
-    if (p == NULL)
+    if (pf == NULL && pb == NULL)
     {
         return M_StringDuplicate(".");
     }
     else
     {
+        char *p = MAX(pf, pb);
         result = M_StringDuplicate(path);
         result[p - path] = '\0';
         return result;
@@ -300,24 +297,21 @@ char *M_DirName(const char *path)
 // allocated.
 const char *M_BaseName(const char *path)
 {
-    const char *p;
+    const char *pf, *pb;
 
-    p = strrchr(path, DIR_SEPARATOR);
+    pf = strrchr(path, '/');
 #ifdef _WIN32
-    if (p == NULL)
-    {
-        // Windows allows for both backward and forward slashes as path
-        // separators. So, if we cannot find the former, try the latter
-        // instead, but don't accept mixed forms.
-        p = strrchr(path, '/');
-    }
+    pb = strrchr(path, '\\');
+#else
+    pb = NULL;
 #endif
-    if (p == NULL)
+    if (pf == NULL && pb == NULL)
     {
         return path;
     }
     else
     {
+        const char *p = MAX(pf, pb);
         return p + 1;
     }
 }

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -271,7 +271,8 @@ boolean M_StrToInt(const char *str, int *result)
 // and must be freed by the caller after use.
 char *M_DirName(const char *path)
 {
-    char *pf, *pb, *result;
+    char *result;
+    const char *pf, *pb;
 
     pf = strrchr(path, '/');
 #ifdef _WIN32
@@ -285,7 +286,7 @@ char *M_DirName(const char *path)
     }
     else
     {
-        char *p = MAX(pf, pb);
+        const char *p = (pf > pb) ? pf : pb;
         result = M_StringDuplicate(path);
         result[p - path] = '\0';
         return result;
@@ -311,7 +312,7 @@ const char *M_BaseName(const char *path)
     }
     else
     {
-        const char *p = MAX(pf, pb);
+        const char *p = (pf > pb) ? pf : pb;
         return p + 1;
     }
 }


### PR DESCRIPTION
Windows allows for both backward and forward slashes as path
separators. So, if we cannot find the former, try the latter
instead, but don't accept mixed forms.

Actually, the latter is the prefered form when using Unix-like
shells on Windows like e.g. Cygwin or MSYS2.

Fixes: #1271 and https://github.com/fabiangreffrath/crispy-doom/issues/618