### PR TITLE
Blockmap Size Error Checking (Fixes bug #1287)

### DIFF
--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -532,7 +532,9 @@ void P_LoadBlockMap (int lump)
     lumplen = W_LumpLength(lump);
     count = lumplen / 2;
     if(count >= 32766)
+    {
 	I_Error("Blockmap too large");
+    }
 	
     blockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
     W_ReadLump(lump, blockmaplump);

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -531,6 +531,8 @@ void P_LoadBlockMap (int lump)
 
     lumplen = W_LumpLength(lump);
     count = lumplen / 2;
+    if(count >= 32766)
+	I_Error("Blockmap too large");
 	
     blockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
     W_ReadLump(lump, blockmaplump);

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -430,7 +430,9 @@ void P_LoadBlockMap(int lump)
 
     lumplen = W_LumpLength(lump);
     if((lumplen / 2) >= 32766)
+    {
 	    I_Error("Blockmap too large");
+    }
 
     blockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
     W_ReadLump(lump, blockmaplump);

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -429,6 +429,8 @@ void P_LoadBlockMap(int lump)
     int lumplen;
 
     lumplen = W_LumpLength(lump);
+    if((lumplen / 2) >= 32766)
+	    I_Error("Blockmap too large");
 
     blockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
     W_ReadLump(lump, blockmaplump);

--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -540,7 +540,9 @@ void P_LoadBlockMap(int lump)
 
     lumplen = W_LumpLength(lump);
     if((lumplen / 2) >= 32766)
+    {
 	I_Error("Blockmap too large");
+    }
 
     blockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
     W_ReadLump(lump, blockmaplump);

--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -539,6 +539,8 @@ void P_LoadBlockMap(int lump)
     int lumplen;
 
     lumplen = W_LumpLength(lump);
+    if((lumplen / 2) >= 32766)
+	I_Error("Blockmap too large");
 
     blockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
     W_ReadLump(lump, blockmaplump);

--- a/src/strife/p_setup.c
+++ b/src/strife/p_setup.c
@@ -511,7 +511,9 @@ void P_LoadBlockMap (int lump)
     lumplen = W_LumpLength(lump);
     count = lumplen / 2;
     if(count >= 32766)
+    {
 	I_Error("Blockmap too large");
+    }
 	
     blockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
     W_ReadLump(lump, blockmaplump);

--- a/src/strife/p_setup.c
+++ b/src/strife/p_setup.c
@@ -510,6 +510,8 @@ void P_LoadBlockMap (int lump)
 
     lumplen = W_LumpLength(lump);
     count = lumplen / 2;
+    if(count >= 32766)
+	I_Error("Blockmap too large");
 	
     blockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
     W_ReadLump(lump, blockmaplump);


### PR DESCRIPTION
This checks for a large blockmap size and produces an error instead of allowing the map to mess up memory and cause a segfault.