### PR TITLE
Add support for /usr/share/doom IWAD search path

### DIFF
--- a/man/INSTALL.template
+++ b/man/INSTALL.template
@@ -199,7 +199,9 @@ do one of the following:
  * Put the file into one of the following directories:
 
      $HOME/.local/share/games/doom
+     /usr/share/doom
      /usr/share/games/doom
+     /usr/local/share/doom
      /usr/local/share/games/doom
 
  * Set the environment variable DOOMWADDIR to specify the path to a

--- a/man/iwad_paths.man
+++ b/man/iwad_paths.man
@@ -35,7 +35,8 @@ Writeable directory in the user's home directory. The path can be overridden
 using the \fBXDG_DATA_HOME\fR environment variable (see the XDG Base Directory
 Specification).
 .TP
-\fB/usr/local/share/games/doom, /usr/share/games/doom\fR
+\fB/usr/local/share/doom, /usr/local/share/games/doom, /usr/share/doom,
+/usr/share/games/doom\fR
 System-wide locations that can be accessed by all users. The path
 \fB/usr/share/games/doom\fR is a standard path that is supported by most
 Doom source ports. These paths can be overridden using the \fBXDG_DATA_DIRS\fR

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -657,6 +657,7 @@ static void AddXdgDirs(void)
     // source ports is /usr/share/games/doom - we support this through the
     // XDG_DATA_DIRS mechanism, through which it can be overridden.
     AddIWADPath(env, "/games/doom");
+    AddIWADPath(env, "/doom");
 
     // The convention set by RBDOOM-3-BFG is to install Doom 3: BFG
     // Edition into this directory, under which includes the Doom


### PR DESCRIPTION
Some Linux distros such as Gentoo have deprecated the `/usr/share/games`
directory. IWADs are typically installed under the `/usr/share` directory
for these distros.