### PR TITLE
When running sscanf on numbers in hex or octal, make sure the argumen…

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1371,10 +1371,10 @@ void I_InitGraphics(void)
     if (env != NULL)
     {
         char winenv[30];
-        int winid;
+        unsigned int winid;
 
         sscanf(env, "0x%x", &winid);
-        M_snprintf(winenv, sizeof(winenv), "SDL_WINDOWID=%i", winid);
+        M_snprintf(winenv, sizeof(winenv), "SDL_WINDOWID=%u", winid);
 
         putenv(winenv);
     }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1923,7 +1923,7 @@ static int ParseIntParameter(const char *strparm)
     int parm;
 
     if (strparm[0] == '0' && strparm[1] == 'x')
-        sscanf(strparm+2, "%x", &parm);
+        sscanf(strparm+2, "%x", (unsigned int *) &parm);
     else
         sscanf(strparm, "%i", &parm);
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -259,9 +259,9 @@ char *M_TempFile(const char *s)
 
 boolean M_StrToInt(const char *str, int *result)
 {
-    return sscanf(str, " 0x%x", result) == 1
-        || sscanf(str, " 0X%x", result) == 1
-        || sscanf(str, " 0%o", result) == 1
+    return sscanf(str, " 0x%x", (unsigned int *) result) == 1
+        || sscanf(str, " 0X%x", (unsigned int *) result) == 1
+        || sscanf(str, " 0%o", (unsigned int *) result) == 1
         || sscanf(str, " %d", result) == 1;
 }
 


### PR DESCRIPTION
…t type is unsigned int *

This fixes warnings that were showing up in cppcheck.

I figured in src/i_video, it would be safe to change the type of winid from int to unsigned int since that was just being used for a printout. For the other cases, I wanted to preserve the return and argument types.