### PR TITLE
If Nuked OPL3 is running at 49716 Hz, the emulator output isn't passe…

### DIFF
--- a/opl/opl3.c
+++ b/opl/opl3.c
@@ -1371,6 +1371,9 @@ void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples)
 
     for(i = 0; i < numsamples; i++)
     {
+        if (chip->rateratio == 1 << RSM_FRAC)
+        OPL3_Generate(chip, sndptr);
+        else
         OPL3_GenerateResampled(chip, sndptr);
         sndptr += 2;
     }


### PR DESCRIPTION
…d through the linear resampler when using OPL3_GenerateStream.