### PR TITLE
textscreen: deliberately create a software renderer

### DIFF
--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -253,7 +253,7 @@ int TXT_Init(void)
     if (TXT_SDLWindow == NULL)
         return 0;
 
-    renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, 0);
+    renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_SOFTWARE);
 
     // Special handling for OS X retina display. If we successfully set the
     // highdpi flag, check the output size for the screen renderer. If we get


### PR DESCRIPTION
On systems which lack sufficient hardware acceleration capabilities we
would have no chance to open the setup window otherwise.

Fixes https://github.com/fabiangreffrath/crispy-doom/issues/670.