### PR TITLE
textscreen: Fix SetBufferFromValue to copy the right amount of data

### DIFF
--- a/textscreen/txt_inputbox.c
+++ b/textscreen/txt_inputbox.c
@@ -37,7 +37,7 @@ static void SetBufferFromValue(txt_inputbox_t *inputbox)
 
         if (*value != NULL)
         {
-            TXT_StringCopy(inputbox->buffer, *value, inputbox->size);
+            TXT_StringCopy(inputbox->buffer, *value, strnlen(*value, inputbox->buffer_len) + 1);
         }
         else
         {


### PR DESCRIPTION
Fix the amount of data that must be copied from the value pointer to the inputbox buffer. This fixes a bug with ASCII where the last character would be deleted if the inputbox is completely filled up. This also fixes a bug where UTF8 input would be truncated. Truncating UTF8 data could lead to a buffer overflow.

This fixes https://github.com/chocolate-doom/chocolate-doom/issues/1320

Note that invalid UTF8 characters can possibly still be read from the config file. I haven't tested to see if I could trigger a buffer overflow this way, but I have found other bugs which I will document or fix once I understand them better. Although, with this fix, it's not possible to trigger bugs from Chocolate-Setup's UI and bugs stated in the first paragraph are fixed. 