### PR TITLE
Remove unused variable "state" in P_MovePsprites

### DIFF
--- a/src/doom/p_pspr.c
+++ b/src/doom/p_pspr.c
@@ -861,13 +861,12 @@ void P_MovePsprites (player_t* player)
 {
     int		i;
     pspdef_t*	psp;
-    state_t*	state;
 	
     psp = &player->psprites[0];
     for (i=0 ; i<NUMPSPRITES ; i++, psp++)
     {
 	// a null state means not active
-	if ( (state = psp->state) )	
+	if (psp->state)
 	{
 	    // drop tic count and possibly change state
 

--- a/src/heretic/p_pspr.c
+++ b/src/heretic/p_pspr.c
@@ -1885,12 +1885,11 @@ void P_MovePsprites(player_t * player)
 {
     int i;
     pspdef_t *psp;
-    state_t *state;
 
     psp = &player->psprites[0];
     for (i = 0; i < NUMPSPRITES; i++, psp++)
     {
-        if ((state = psp->state) != 0)  // a null state means not active
+        if (psp->state != 0)  // a null state means not active
         {
             // drop tic count and possibly change state
             if (psp->tics != -1)        // a -1 tic count never changes

--- a/src/hexen/p_pspr.c
+++ b/src/hexen/p_pspr.c
@@ -2457,12 +2457,11 @@ void P_MovePsprites(player_t * player)
 {
     int i;
     pspdef_t *psp;
-    state_t *state;
 
     psp = &player->psprites[0];
     for (i = 0; i < NUMPSPRITES; i++, psp++)
     {
-        if ((state = psp->state) != 0)  // a null state means not active
+        if (psp->state != 0)  // a null state means not active
         {
             // drop tic count and possibly change state
             if (psp->tics != -1)        // a -1 tic count never changes

--- a/src/strife/p_pspr.c
+++ b/src/strife/p_pspr.c
@@ -970,13 +970,12 @@ void P_MovePsprites (player_t* player)
 {
     int		i;
     pspdef_t*	psp;
-    state_t*	state;
 
     psp = &player->psprites[0];
     for(i = 0; i < NUMPSPRITES; i++, psp++)
     {
         // a null state means not active
-        if((state = psp->state))	
+        if(psp->state)
         {
             // drop tic count and possibly change state
 


### PR DESCRIPTION
This fixes a warning generated by cppcheck.