### PR TITLE
Workaround SDL_WINDOW_FULLSCREEN_DESKTOP issues.

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1366,6 +1366,8 @@ void I_InitGraphics(void)
 
     env = getenv("XSCREENSAVER_WINDOW");
 
+    SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
+
     if (env != NULL)
     {
         char winenv[30];


### PR DESCRIPTION
On some environments using `SDL_WINDOW_FULLSCREEN_DESKTOP` will result in the program losing its fullscreen property when switching workspaces, moving the program to a different workspace and maybe some other scenarios.

This can be worked in the user's environment with:
```
SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS=0
```
But its better to set the hint in chocolate-doom directly.