### PR TITLE
build: use python3 exclusively

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ orig_CFLAGS="$CFLAGS"
 AM_PROG_AR
 AC_PROG_CC
 AC_PROG_RANLIB
-AC_CHECK_PROG(HAVE_PYTHON, python, true, false)
+AC_CHECK_PROG(HAVE_PYTHON, python3, true, false)
 
 OPT_LEVEL=2
 

--- a/data/convert-icon
+++ b/data/convert-icon
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright(C) 2005-2014 Simon Howard
 #

--- a/man/docgen
+++ b/man/docgen
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # 
 # Chocolate Doom self-documentation tool.  This works similar to javadoc
 # or doxygen, but documents command line parameters and configuration

--- a/man/simplecpp
+++ b/man/simplecpp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008
 # Contributors to the Freedoom project.  All rights reserved.

--- a/pkg/win32/cp-with-libs
+++ b/pkg/win32/cp-with-libs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright(C) 2016 Simon Howard
 #

--- a/textscreen/fonts/convert-font
+++ b/textscreen/fonts/convert-font
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright(C) 2016 Simon Howard
 #


### PR DESCRIPTION
Python 2 is deprecated and is going to be removed from Linux
distributions in the short term [1,2]. Thus, (parts of) the build
process will fail on current systems like e.g. Debian unstable.

The /bin/python binary is not going to exist anymore. The canonical
name for the Python 3 binary is, you guess it, /bin/python3. So, let's
just use this during our build process and go future proof.

Fixes #1158.

[1] https://wiki.debian.org/Python#Python_in_Debian
[2] https://wiki.debian.org/Python/2Removal