### PR TITLE
docs: fix simple typo, apropriate -> appropriate

### DIFF
--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -795,7 +795,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
 	return;
     }
 
-    // check for apropriate skill level
+    // check for appropriate skill level
     if (!netgame && (mthing->options & 16) )
 	return;
 		

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1089,7 +1089,7 @@ void D_DoomMain(void)
     IncThermo();
 
 //
-// start the apropriate game based on parms
+// start the appropriate game based on params
 //
 
     D_CheckRecordFrom();

--- a/src/heretic/p_mobj.c
+++ b/src/heretic/p_mobj.c
@@ -1075,7 +1075,7 @@ void P_SpawnMapThing(mapthing_t * mthing)
         return;
     }
 
-// check for apropriate skill level
+// check for appropriate skill level
     if (!netgame && (mthing->options & 16))
         return;
 

--- a/src/strife/p_mobj.c
+++ b/src/strife/p_mobj.c
@@ -946,7 +946,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
         return;
     }
 
-    // check for apropriate skill level
+    // check for appropriate skill level
     if (!netgame && (mthing->options & 16) )
         return;
 


### PR DESCRIPTION
There is a small typo in src/doom/p_mobj.c, src/heretic/p_mobj.c, src/strife/p_mobj.c.

Should read `appropriate` rather than `apropriate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md