### PR TITLE
iwad: Support autoloading GOG.com releases of Heretic and Hexen

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -208,6 +208,30 @@ static registry_value_t root_path_keys[] =
         SOFTWARE_KEY "\\GOG.com\\Games\\1432899949",
         "PATH",
     },
+
+    // Heretic
+
+    {
+        HKEY_LOCAL_MACHINE,
+        SOFTWARE_KEY "\\GOG.com\\Games\\1290366318",
+        "PATH",
+    },
+
+    // Hexen
+
+    {
+        HKEY_LOCAL_MACHINE,
+        SOFTWARE_KEY "\\GOG.com\\Games\\1247951670",
+        "PATH",
+    },
+
+    // Hexen: Deathkings of a Dark Citadel
+
+    {
+        HKEY_LOCAL_MACHINE,
+        SOFTWARE_KEY "\\GOG.com\\Games\\1983497091",
+        "PATH",
+    },
 };
 
 // Subdirectories of the above install path, where IWADs are installed.


### PR DESCRIPTION
Verified myself by installing the games from the GOG releases, installing them (via Wine), and then building both 32- and 64-bit versions of Chocolate Heretic/Hexen and checking they work.