### PR TITLE
Fixes #1345

### DIFF
--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -478,7 +478,7 @@ ST_Responder (event_t* ev)
 	if (plyr->cheats & CF_GODMODE)
 	{
 	  if (plyr->mo)
-	    plyr->mo->health = 100;
+	    plyr->mo->health = deh_god_mode_health;
 	  
 	  plyr->health = deh_god_mode_health;
 	  plyr->message = DEH_String(STSTR_DQDON);


### PR DESCRIPTION
Replaced the numerical value for the player's mobj with a ref to a define in deh_misc.h.