### PR TITLE
Fix heretic coop demos

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -115,6 +115,7 @@ boolean longtics;               // specify high resolution turning in demos
 boolean lowres_turn;
 boolean shortticfix;            // calculate lowres turning like doom
 boolean demoplayback;
+boolean netdemo;
 boolean demoextend;
 byte *demobuffer, *demo_p, *demoend;
 boolean singledemo;             // quit after playing a demo from cmdline
@@ -1070,7 +1071,7 @@ void G_Ticker(void)
             if (demorecording)
                 G_WriteDemoTiccmd(cmd);
 
-            if (netgame && !(gametic % ticdup))
+            if (netgame && !netdemo && !(gametic % ticdup))
             {
                 if (gametic > BACKUPTICS
                     && consistancy[i][buf] != cmd->consistancy)
@@ -1691,6 +1692,7 @@ void G_InitNew(skill_t skill, int episode, int map)
     paused = false;
     demorecording = false;
     demoplayback = false;
+    netdemo = false;
     viewactive = true;
     gameepisode = episode;
     gamemap = map;
@@ -1987,11 +1989,22 @@ void G_DoPlayDemo(void)
     for (i = 0; i < MAXPLAYERS; i++)
         playeringame[i] = (*demo_p++) != 0;
 
+    if (playeringame[1] || M_CheckParm("-solo-net") > 0
+                            || M_CheckParm("-netdemo") > 0)
+    {
+    	netgame = true;
+    }
+
     precache = false;           // don't spend a lot of time in loadlevel
     G_InitNew(skill, episode, map);
     precache = true;
     usergame = false;
     demoplayback = true;
+
+    if (netgame == true)
+    {
+      netdemo = true;
+    }
 }
 
 
@@ -2025,6 +2038,12 @@ void G_TimeDemo(char *name)
         playeringame[i] = (*demo_p++) != 0;
     }
 
+    if (playeringame[1] || M_CheckParm("-solo-net") > 0
+                        || M_CheckParm("-netdemo") > 0)
+    {
+      netgame = true;
+    }
+
     G_InitNew(skill, episode, map);
     starttime = I_GetTime();
 
@@ -2032,6 +2051,11 @@ void G_TimeDemo(char *name)
     demoplayback = true;
     timingdemo = true;
     singletics = true;
+
+    if (netgame == true)
+    {
+      netdemo = true;
+    }
 }
 
 
@@ -2066,6 +2090,8 @@ boolean G_CheckDemoStatus(void)
 
         W_ReleaseLumpName(defdemoname);
         demoplayback = false;
+        netdemo = false;
+        netgame = false;
         D_AdvanceDemo();
         return true;
     }

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1990,7 +1990,7 @@ void G_DoPlayDemo(void)
         playeringame[i] = (*demo_p++) != 0;
 
     if (playeringame[1] || M_CheckParm("-solo-net") > 0
-                            || M_CheckParm("-netdemo") > 0)
+                        || M_CheckParm("-netdemo") > 0)
     {
     	netgame = true;
     }


### PR DESCRIPTION
Fixes https://github.com/chocolate-doom/chocolate-doom/issues/1027

This netgame / netdemo handling code is copied over from `doom/g_game.c` - it was just missing in heretic's copy.

The reason the `netgame = true` and `netdemo = true` lines are split into separate `if` blocks is because of how `G_InitNew` in heretic works. It needs to know it's a netgame in order to spawn things correctly, but it also resets the demo playback globals, so they need to be set afterwords.