### PR TITLE
fix savegame directory on Windows

### DIFF
--- a/src/i_main.c
+++ b/src/i_main.c
@@ -57,6 +57,7 @@ int main(int argc, char **argv)
 #endif
 
     M_FindResponseFile();
+    M_SetExeDir();
 
     #ifdef SDL_HINT_NO_SIGNAL_HANDLERS
     SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");

--- a/src/i_musicpack.c
+++ b/src/i_musicpack.c
@@ -933,7 +933,7 @@ static void LoadSubstituteConfigs(void)
     {
         musicdir = M_StringJoin(music_pack_path, DIR_SEPARATOR_S, NULL);
     }
-    else if (!strcmp(configdir, ""))
+    else if (!strcmp(configdir, exedir))
     {
         musicdir = M_StringDuplicate("");
     }

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -417,7 +417,7 @@ const char *M_GetExecutableName(void)
     return M_BaseName(myargv[0]);
 }
 
-const char *exedir;
+const char *exedir = NULL;
 
 void M_SetExeDir(void)
 {

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -417,3 +417,16 @@ const char *M_GetExecutableName(void)
     return M_BaseName(myargv[0]);
 }
 
+const char *exedir;
+
+void M_SetExeDir(void)
+{
+    if (exedir == NULL)
+    {
+        char *dirname;
+
+        dirname = M_DirName(myargv[0]);
+        exedir = M_StringJoin(dirname, DIR_SEPARATOR_S, NULL);
+        free(dirname);
+    }
+}

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -417,16 +417,13 @@ const char *M_GetExecutableName(void)
     return M_BaseName(myargv[0]);
 }
 
-const char *exedir = NULL;
+char *exedir = NULL;
 
 void M_SetExeDir(void)
 {
-    if (exedir == NULL)
-    {
-        char *dirname;
+    char *dirname;
 
-        dirname = M_DirName(myargv[0]);
-        exedir = M_StringJoin(dirname, DIR_SEPARATOR_S, NULL);
-        free(dirname);
-    }
+    dirname = M_DirName(myargv[0]);
+    exedir = M_StringJoin(dirname, DIR_SEPARATOR_S, NULL);
+    free(dirname);
 }

--- a/src/m_argv.h
+++ b/src/m_argv.h
@@ -28,7 +28,7 @@
 extern  int	myargc;
 extern  char**	myargv;
 
-extern const char *exedir;
+extern char *exedir;
 void M_SetExeDir(void);
 
 // Returns the position of the given parameter

--- a/src/m_argv.h
+++ b/src/m_argv.h
@@ -28,6 +28,9 @@
 extern  int	myargc;
 extern  char**	myargv;
 
+extern const char *exedir;
+void M_SetExeDir(void);
+
 // Returns the position of the given parameter
 // in the arg list (0 if not found).
 int M_CheckParm (const char* check);

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -2268,15 +2268,30 @@ float M_GetFloatVariable(const char *name)
     return *variable->location.f;
 }
 
+static const char *GetExeDir(void)
+{
+    static const char *exedir;
+
+    if (exedir == NULL)
+    {
+        char *dirname;
+
+        dirname = M_DirName(myargv[0]);
+        exedir = M_StringJoin(dirname, DIR_SEPARATOR_S, NULL);
+        free(dirname);
+    }
+
+    return exedir;
+}
+
 // Get the path to the default configuration dir to use, if NULL
 // is passed to M_SetConfigDir.
 
-static char *GetDefaultConfigDir(void)
+static const char *GetDefaultConfigDir(void)
 {
-    char *result;
-    char *copy;
-
 #if !defined(_WIN32) || defined(_WIN32_WCE)
+    char *result;
+    char const *copy;
 
     // Configuration settings are stored in an OS-appropriate path
     // determined by SDL.  On typical Unix systems, this might be
@@ -2292,10 +2307,7 @@ static char *GetDefaultConfigDir(void)
     }
 #endif /* #ifndef _WIN32 */
 
-    result = M_DirName(myargv[0]);
-    copy = M_StringJoin(result, DIR_SEPARATOR_S, NULL);
-    free(result);
-    return copy;
+    return GetExeDir();
 }
 
 // 
@@ -2318,7 +2330,7 @@ void M_SetConfigDir(const char *dir)
         configdir = GetDefaultConfigDir();
     }
 
-    if (strcmp(configdir, "") != 0)
+    if (configdir != GetExeDir())
     {
         printf("Using %s for configuration and saves\n", configdir);
     }
@@ -2410,7 +2422,7 @@ char *M_GetSaveGameDir(const char *iwadname)
 #endif
     // If not "doing" a configuration directory (Windows), don't "do"
     // a savegame directory, either.
-    else if (!strcmp(configdir, ""))
+    else if (configdir == GetExeDir())
     {
 	savegamedir = M_StringDuplicate("");
     }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -46,7 +46,6 @@
 // default.cfg, savegames, etc.
 
 const char *configdir;
-static const char *exedir;
 
 static char *autoload_path = "";
 
@@ -2269,18 +2268,6 @@ float M_GetFloatVariable(const char *name)
     return *variable->location.f;
 }
 
-static void M_SetExeDir(void)
-{
-    if (exedir == NULL)
-    {
-        char *dirname;
-
-        dirname = M_DirName(myargv[0]);
-        exedir = M_StringJoin(dirname, DIR_SEPARATOR_S, NULL);
-        free(dirname);
-    }
-}
-
 // Get the path to the default configuration dir to use, if NULL
 // is passed to M_SetConfigDir.
 
@@ -2316,8 +2303,6 @@ static const char *GetDefaultConfigDir(void)
 
 void M_SetConfigDir(const char *dir)
 {
-    M_SetExeDir();
-
     // Use the directory that was passed, or find the default.
 
     if (dir != NULL)
@@ -2388,8 +2373,6 @@ char *M_GetSaveGameDir(const char *iwadname)
     char *savegamedir;
     char *topdir;
     int p;
-
-    M_SetExeDir();
 
     //!
     // @arg <directory>

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -46,6 +46,7 @@
 // default.cfg, savegames, etc.
 
 const char *configdir;
+static const char *exedir;
 
 static char *autoload_path = "";
 
@@ -2268,10 +2269,8 @@ float M_GetFloatVariable(const char *name)
     return *variable->location.f;
 }
 
-static const char *GetExeDir(void)
+static void M_SetExeDir(void)
 {
-    static const char *exedir;
-
     if (exedir == NULL)
     {
         char *dirname;
@@ -2280,8 +2279,6 @@ static const char *GetExeDir(void)
         exedir = M_StringJoin(dirname, DIR_SEPARATOR_S, NULL);
         free(dirname);
     }
-
-    return exedir;
 }
 
 // Get the path to the default configuration dir to use, if NULL
@@ -2307,7 +2304,7 @@ static const char *GetDefaultConfigDir(void)
     }
 #endif /* #ifndef _WIN32 */
 
-    return GetExeDir();
+    return M_StringDuplicate(exedir);
 }
 
 // 
@@ -2319,6 +2316,8 @@ static const char *GetDefaultConfigDir(void)
 
 void M_SetConfigDir(const char *dir)
 {
+    M_SetExeDir();
+
     // Use the directory that was passed, or find the default.
 
     if (dir != NULL)
@@ -2330,7 +2329,7 @@ void M_SetConfigDir(const char *dir)
         configdir = GetDefaultConfigDir();
     }
 
-    if (configdir != GetExeDir())
+    if (strcmp(configdir, exedir) != 0)
     {
         printf("Using %s for configuration and saves\n", configdir);
     }
@@ -2390,6 +2389,8 @@ char *M_GetSaveGameDir(const char *iwadname)
     char *topdir;
     int p;
 
+    M_SetExeDir();
+
     //!
     // @arg <directory>
     //
@@ -2422,7 +2423,7 @@ char *M_GetSaveGameDir(const char *iwadname)
 #endif
     // If not "doing" a configuration directory (Windows), don't "do"
     // a savegame directory, either.
-    else if (configdir == GetExeDir())
+    else if (!strcmp(configdir, exedir))
     {
 	savegamedir = M_StringDuplicate("");
     }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -2271,16 +2271,17 @@ float M_GetFloatVariable(const char *name)
 // Get the path to the default configuration dir to use, if NULL
 // is passed to M_SetConfigDir.
 
-static const char *GetDefaultConfigDir(void)
+static char *GetDefaultConfigDir(void)
 {
 #if !defined(_WIN32) || defined(_WIN32_WCE)
-    char *result;
-    char const *copy;
 
     // Configuration settings are stored in an OS-appropriate path
     // determined by SDL.  On typical Unix systems, this might be
     // ~/.local/share/chocolate-doom.  On Windows, we behave like
     // Vanilla Doom and save in the current directory.
+
+    char *result;
+    char *copy;
 
     result = SDL_GetPrefPath("", PACKAGE_TARNAME);
     if (result != NULL)
@@ -2290,7 +2291,6 @@ static const char *GetDefaultConfigDir(void)
         return copy;
     }
 #endif /* #ifndef _WIN32 */
-
     return M_StringDuplicate(exedir);
 }
 


### PR DESCRIPTION
On Windows, we are supposed to put savegames into the current
directory instead of a "savegames" subdirectory unless the
-savedir parameter was given.

Hopefully fixes #1359 for good.