### PR TITLE
Fix max volume musicpack at startup

### DIFF
--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -390,9 +390,14 @@ void I_ShutdownMusic(void)
 
 void I_SetMusicVolume(int volume)
 {
-    if (active_music_module != NULL)
+    if (music_module != NULL)
     {
-        active_music_module->SetMusicVolume(volume);
+        music_module->SetMusicVolume(volume);
+    }
+
+    if (music_packs_active)
+    {
+        music_pack_module.SetMusicVolume(volume);
     }
 }
 

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -393,11 +393,11 @@ void I_SetMusicVolume(int volume)
     if (music_module != NULL)
     {
         music_module->SetMusicVolume(volume);
-    }
 
-    if (music_packs_active)
-    {
-        music_pack_module.SetMusicVolume(volume);
+        if (music_packs_active && music_module != &music_pack_module)
+        {
+            music_pack_module.SetMusicVolume(volume);
+        }
     }
 }
 


### PR DESCRIPTION
Whenever I_SetMusicVolume is called, set the volume for both music_module and music_pack_module. Previously the music_pack_module volume would never get set at the first call of I_SetMusicVolume during initialization. Therefore, its volume would default to max.