### PR TITLE
Fix PC speaker emulation when using OPL

### DIFF
--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -172,9 +172,10 @@ static void FillBuffer(uint8_t *buffer, unsigned int nsamples)
 
 // Callback function to fill a new sound buffer:
 
-static void OPL_Mix_Callback(void *udata, Uint8 *buffer, int len)
+static void OPL_Mix_Callback(int chan, void *stream, int len, void *udata)
 {
     unsigned int filled, buffer_samples;
+    Uint8 *buffer = (Uint8*)stream;
 
     // Repeatedly call the OPL emulator update function until the buffer is
     // full.
@@ -351,7 +352,7 @@ static int OPL_SDL_Init(unsigned int port_base)
     // Set postmix that adds the OPL music. This is deliberately done
     // as a postmix and not using Mix_HookMusic() as the latter disables
     // normal SDL_mixer music mixing.
-    Mix_SetPostMix(OPL_Mix_Callback, NULL);
+    Mix_RegisterEffect(MIX_CHANNEL_POST, OPL_Mix_Callback, NULL, NULL);
 
     return 1;
 }

--- a/pcsound/pcsound_sdl.c
+++ b/pcsound/pcsound_sdl.c
@@ -53,7 +53,7 @@ static int phase_offset = 0;
 
 // Mixer function that does the PC speaker emulation
 
-static void PCSound_Mix_Callback(void *udata, Uint8 *stream, int len)
+static void PCSound_Mix_Callback(int chan, void *stream, int len, void *udata)
 {
     Sint16 *leftptr;
     Sint16 *rightptr;
@@ -236,7 +236,7 @@ static int PCSound_SDL_Init(pcsound_callback_func callback_func)
     current_freq = 0;
     current_remaining = 0;
 
-    Mix_SetPostMix(PCSound_Mix_Callback, NULL);
+    Mix_RegisterEffect(MIX_CHANNEL_POST, PCSound_Mix_Callback, NULL, NULL);
 
     return 1;
 }


### PR DESCRIPTION
Replace Mix_SetPostMix calls with Mix_RegisterEffect calls. Mix_SetPostMix allows only one callback to be registered, while Mix_RegisterEffect can handle multiple.

This fixes an issue where PC speaker effects would not work when used simultaneously with OPL emulation.

Fixes #1184.