### PR TITLE
Add -consoleplayer for hexen / heretic

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -1990,6 +1990,21 @@ void G_DoPlayDemo(void)
     for (i = 0; i < MAXPLAYERS; i++)
         playeringame[i] = (*demo_p++) != 0;
 
+    {
+        int p = M_CheckParm("-consoleplayer");
+
+        if (p && (p + 1 < myargc))
+        {
+            consoleplayer = atoi(myargv[p + 1]);
+
+            if (consoleplayer < 0 || consoleplayer >= MAXPLAYERS
+                                  || !playeringame[consoleplayer])
+            {
+                consoleplayer = 0;
+            }
+        }
+    }
+
     if (playeringame[1] || M_CheckParm("-solo-net") > 0
                         || M_CheckParm("-netdemo") > 0)
     {
@@ -2037,6 +2052,21 @@ void G_TimeDemo(char *name)
     for (i = 0; i < MAXPLAYERS; i++)
     {
         playeringame[i] = (*demo_p++) != 0;
+    }
+
+    {
+        int p = M_CheckParm("-consoleplayer");
+
+        if (p && (p + 1 < myargc))
+        {
+            consoleplayer = atoi(myargv[p + 1]);
+
+            if (consoleplayer < 0 || consoleplayer >= MAXPLAYERS
+                                  || !playeringame[consoleplayer])
+            {
+                consoleplayer = 0;
+            }
+        }
     }
 
     if (playeringame[1] || M_CheckParm("-solo-net") > 0

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -2093,6 +2093,21 @@ void G_DoPlayDemo(void)
         PlayerClass[i] = *demo_p++;
     }
 
+    {
+        int p = M_CheckParm("-consoleplayer");
+
+        if (p && (p + 1 < myargc))
+        {
+            consoleplayer = atoi(myargv[p + 1]);
+
+            if (consoleplayer < 0 || consoleplayer >= maxplayers
+                                  || !playeringame[consoleplayer])
+            {
+                consoleplayer = 0;
+            }
+        }
+    }
+
     // Initialize world info, etc.
     G_StartNewInit();
 
@@ -2133,6 +2148,21 @@ void G_TimeDemo(char *name)
     {
         playeringame[i] = (*demo_p++) != 0;
         PlayerClass[i] = *demo_p++;
+    }
+
+    {
+        int p = M_CheckParm("-consoleplayer");
+
+        if (p && (p + 1 < myargc))
+        {
+            consoleplayer = atoi(myargv[p + 1]);
+
+            if (consoleplayer < 0 || consoleplayer >= maxplayers
+                                  || !playeringame[consoleplayer])
+            {
+                consoleplayer = 0;
+            }
+        }
     }
 
     G_InitNew(skill, episode, map);


### PR DESCRIPTION
Hexen and heretic don't store the console player in the demo for coop runs, so demo playback always picks the first player. This PR adds `-consoleplayer` as a command-line option to manually set the console player.