### PR TITLE
Fixes to support CHERI/Morello

### DIFF
--- a/src/doom/r_plane.c
+++ b/src/doom/r_plane.c
@@ -371,15 +371,15 @@ void R_DrawPlanes (void)
 				
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
-	I_Error ("R_DrawPlanes: drawsegs overflow (%" PRIiPTR ")",
+	I_Error ("R_DrawPlanes: drawsegs overflow (%td)",
 		 ds_p - drawsegs);
     
     if (lastvisplane - visplanes > MAXVISPLANES)
-	I_Error ("R_DrawPlanes: visplane overflow (%" PRIiPTR ")",
+	I_Error ("R_DrawPlanes: visplane overflow (%td)",
 		 lastvisplane - visplanes);
     
     if (lastopening - openings > MAXOPENINGS)
-	I_Error ("R_DrawPlanes: opening overflow (%" PRIiPTR ")",
+	I_Error ("R_DrawPlanes: opening overflow (%td)",
 		 lastopening - openings);
 #endif
 

--- a/src/heretic/r_plane.c
+++ b/src/heretic/r_plane.c
@@ -386,13 +386,13 @@ void R_DrawPlanes(void)
 
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
-        I_Error("R_DrawPlanes: drawsegs overflow (%" PRIiPTR ")",
+        I_Error("R_DrawPlanes: drawsegs overflow (%td)",
                 ds_p - drawsegs);
     if (lastvisplane - visplanes > MAXVISPLANES)
-        I_Error("R_DrawPlanes: visplane overflow (%" PRIiPTR ")",
+        I_Error("R_DrawPlanes: visplane overflow (%td)",
                 lastvisplane - visplanes);
     if (lastopening - openings > MAXOPENINGS)
-        I_Error("R_DrawPlanes: opening overflow (%" PRIiPTR ")",
+        I_Error("R_DrawPlanes: opening overflow (%td)",
                 lastopening - openings);
 #endif
 

--- a/src/hexen/r_plane.c
+++ b/src/hexen/r_plane.c
@@ -390,17 +390,17 @@ void R_DrawPlanes(void)
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
     {
-        I_Error("R_DrawPlanes: drawsegs overflow (%" PRIiPTR ")",
+        I_Error("R_DrawPlanes: drawsegs overflow (%td)",
                 ds_p - drawsegs);
     }
     if (lastvisplane - visplanes > MAXVISPLANES)
     {
-        I_Error("R_DrawPlanes: visplane overflow (%" PRIiPTR ")",
+        I_Error("R_DrawPlanes: visplane overflow (%td)",
                 lastvisplane - visplanes);
     }
     if (lastopening - openings > MAXOPENINGS)
     {
-        I_Error("R_DrawPlanes: opening overflow (%" PRIiPTR ")",
+        I_Error("R_DrawPlanes: opening overflow (%td)",
                 lastopening - openings);
     }
 #endif

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -342,7 +342,7 @@ void *I_Realloc(void *ptr, size_t size)
 
     if (size != 0 && new_ptr == NULL)
     {
-        I_Error ("I_Realloc: failed on reallocation of %" PRIuPTR " bytes", size);
+        I_Error ("I_Realloc: failed on reallocation of %zu bytes", size);
     }
 
     return new_ptr;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -424,7 +424,7 @@ char *M_StringDuplicate(const char *orig)
 
     if (result == NULL)
     {
-        I_Error("Failed to duplicate string (length %" PRIuPTR ")\n",
+        I_Error("Failed to duplicate string (length %zu)\n",
                 strlen(orig));
     }
 

--- a/src/setup/multiplayer.c
+++ b/src/setup/multiplayer.c
@@ -394,8 +394,8 @@ static void LevelSelectDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(user_data))
     const iwad_t *iwad;
     char buf[10];
     int episodes;
-    intptr_t x, y;
-    intptr_t l;
+    int x, y;
+    int l;
     int i;
 
     window = TXT_NewWindow("Select level");
@@ -424,10 +424,10 @@ static void LevelSelectDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(user_data))
                 }
 
                 M_snprintf(buf, sizeof(buf),
-                           " E%" PRIiPTR "M%" PRIiPTR " ", x, y);
+                           " E%dM%d ", x, y);
                 button = TXT_NewButton(buf);
                 TXT_SignalConnect(button, "pressed",
-                                  SetExMyWarp, (void *) (x * 10 + y));
+                                  SetExMyWarp, (void *) (intptr_t) (x * 10 + y));
                 TXT_SignalConnect(button, "pressed",
                                   CloseLevelSelectDialog, window);
                 TXT_AddWidget(window, button);
@@ -456,10 +456,10 @@ static void LevelSelectDialog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(user_data))
                 continue;
             }
 
-            M_snprintf(buf, sizeof(buf), " MAP%02" PRIiPTR " ", l);
+            M_snprintf(buf, sizeof(buf), " MAP%02d ", l);
             button = TXT_NewButton(buf);
             TXT_SignalConnect(button, "pressed", 
-                              SetMAPxyWarp, (void *) l);
+                              SetMAPxyWarp, (void *) (intptr_t) l);
             TXT_SignalConnect(button, "pressed",
                               CloseLevelSelectDialog, window);
             TXT_AddWidget(window, button);

--- a/src/strife/r_plane.c
+++ b/src/strife/r_plane.c
@@ -369,15 +369,15 @@ void R_DrawPlanes (void)
 				
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
-	I_Error ("R_DrawPlanes: drawsegs overflow (%" PRIiPTR ")",
+	I_Error ("R_DrawPlanes: drawsegs overflow (%td)",
 		 ds_p - drawsegs);
     
     if (lastvisplane - visplanes > MAXVISPLANES)
-	I_Error ("R_DrawPlanes: visplane overflow (%" PRIiPTR ")",
+	I_Error ("R_DrawPlanes: visplane overflow (%td)",
 		 lastvisplane - visplanes);
     
     if (lastopening - openings > MAXOPENINGS)
-	I_Error ("R_DrawPlanes: opening overflow (%" PRIiPTR ")",
+	I_Error ("R_DrawPlanes: opening overflow (%td)",
 		 lastopening - openings);
 #endif
 

--- a/textscreen/fonts/Makefile.am
+++ b/textscreen/fonts/Makefile.am
@@ -6,13 +6,13 @@ noinst_DATA = $(FONT_HDRS)
 if HAVE_FONTS
 
 small.h: small.png convert-font
-	./convert-font small small.png small.h
+	$(srcdir)/convert-font small small.png small.h
 
 normal.h: normal.png convert-font
-	./convert-font normal normal.png normal.h
+	$(srcdir)/convert-font normal normal.png normal.h
 
 large.h: large.png convert-font
-	./convert-font large large.png large.h
+	$(srcdir)/convert-font large large.png large.h
 
 endif
 


### PR DESCRIPTION
This is needed to support CHERI, and thus Arm's experimental Morello prototype, where pointers are implemented using unforgeable capabilities that include bounds and permissions metadata to provide fine-grained spatial and referential memory safety, as well as revocation by sweeping memory to provide heap temporal memory safety.

The middle commit is what is strictly necessary to support CHERI. The first commit is an issue I found trying to do out-of-tree builds. The final commit is additional cleanup that I noticed could be done for efficiency and to better convey programmer intent when I was sweeping through the codebase looking for all uses of PRIiPTR/PRIuPTR (which, it turns out, there are now none of, as they were all either wrong or for unnecessary uses of intptr_t).