### PR TITLE
deh: Handle orphan carriage returns

### DIFF
--- a/src/deh_io.c
+++ b/src/deh_io.c
@@ -175,9 +175,16 @@ int DEH_GetCharLump(deh_context_t *context)
 int DEH_GetChar(deh_context_t *context)
 {
     int result = 0;
+    boolean last_was_cr = false;
 
-    // Read characters, but ignore carriage returns
-    // Essentially this is a DOS->Unix conversion
+    // Track the current line number
+
+    if (context->last_was_newline)
+    {
+        ++context->linenum;
+    }
+
+    // Read characters, converting CRLF to LF
 
     do
     {
@@ -191,14 +198,27 @@ int DEH_GetChar(deh_context_t *context)
                 result = DEH_GetCharLump(context);
                 break;
         }
-    } while (result == '\r');
 
-    // Track the current line number
+        // Handle \r characters not paired with \n
+        if (last_was_cr && result != '\n')
+        {
+            switch (context->type)
+            {
+                case DEH_INPUT_FILE:
+                    ungetc(result, context->stream);
+                    break;
 
-    if (context->last_was_newline)
-    {
-        ++context->linenum;
-    }
+                case DEH_INPUT_LUMP:
+                    --context->input_buffer_pos;
+                    break;
+            }
+
+            return '\r';
+        }
+
+        last_was_cr = result == '\r';
+
+    } while (last_was_cr);
 
     context->last_was_newline = result == '\n';
 


### PR DESCRIPTION
Previously, the DeHacked parsing filtered out any carriage return (`\r`) characters. The assumption is that they will always be paired with linefeed characters (`\n`). However, there exist DeHacked substitution strings which contain "orphan" carriage returns which do *not* have adjoining linefeeds. If the parser encounters such a string, there will be a mismatch in the character count and this can break the parsing for all lines thereafter.

When encountering carriage returns during DeHacked parsing, check the next character to see if it's a linefeed. If so, filter out the `\r` and return the `\n` as before. If it's not a linefeed, return the "orphan" `\r`.

This has not been subject to much testing, but it seems to work on the "Doom 2 In Spain Only" deh file that first created the issue.

Fixes #1375.