### PR TITLE
Set soundfont path directly from Chocolate

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -56,6 +56,7 @@ static boolean sdl_was_initialized = false;
 static boolean musicpaused = false;
 static int current_music_volume;
 
+char *fluidsynth_sf_path = "";
 char *timidity_cfg_path = "";
 
 static char *temp_timidity_cfg = NULL;
@@ -207,6 +208,14 @@ static boolean I_SDL_InitMusic(void)
     // file can be removed.
 
     RemoveTimidityConfig();
+
+    // When using FluidSynth, proceed to set the soundfont path via
+    // Mix_SetSoundFonts if necessary.
+
+    if (strlen(fluidsynth_sf_path) > 0 && strlen(timidity_cfg_path) == 0)
+    {
+        Mix_SetSoundFonts(fluidsynth_sf_path);
+    }
 
     // If snd_musiccmd is set, we need to call Mix_SetMusicCMD to
     // configure an external music playback program.

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -83,6 +83,7 @@ extern int opl_io_port;
 // For native music module:
 
 extern char *music_pack_path;
+extern char *fluidsynth_sf_path;
 extern char *timidity_cfg_path;
 
 // DOS-specific options: These are unused but should be maintained
@@ -504,6 +505,7 @@ void I_BindSoundVariables(void)
     M_BindIntVariable("snd_pitchshift",          &snd_pitchshift);
 
     M_BindStringVariable("music_pack_path",      &music_pack_path);
+    M_BindStringVariable("fluidsynth_sf_path",   &fluidsynth_sf_path);
     M_BindStringVariable("timidity_cfg_path",    &timidity_cfg_path);
     M_BindStringVariable("gus_patch_path",       &gus_patch_path);
     M_BindIntVariable("gus_ram_kb",              &gus_ram_kb);

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -929,7 +929,7 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_STRING(music_pack_path),
 
     //!
-    // Documentation goes here.
+    // Full path to a soundfont file to use with FluidSynth MIDI playback.
     //
 
     CONFIG_VARIABLE_STRING(fluidsynth_sf_path),

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -929,6 +929,12 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_STRING(music_pack_path),
 
     //!
+    // Documentation goes here.
+    //
+
+    CONFIG_VARIABLE_STRING(fluidsynth_sf_path),
+
+    //!
     // Full path to a Timidity configuration file to use for MIDI
     // playback. The file will be evaluated from the directory where
     // it is evaluated, so there is no need to add "dir" commands

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -42,7 +42,7 @@ static const char *opltype_strings[] =
 };
 
 static const char *cfg_extension[] = { "cfg", NULL };
-static const char *sf2_extension[] = { "sf2", NULL };
+static const char *sf_extension[] = { "sf2", "sf3", NULL };
 
 // Config file variables:
 
@@ -202,7 +202,7 @@ void ConfigSound(TXT_UNCAST_ARG(widget), void *user_data)
                 TXT_NewStrut(4, 0),
                 TXT_NewFileSelector(&fluidsynth_sf_path, 34,
                                     "Select FluidSynth soundfont file",
-                                    sf2_extension),
+                                    sf_extension),
                 NULL)),
         NULL);
 }

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -42,6 +42,7 @@ static const char *opltype_strings[] =
 };
 
 static const char *cfg_extension[] = { "cfg", NULL };
+static const char *sf2_extension[] = { "sf2", NULL };
 
 // Config file variables:
 
@@ -65,6 +66,7 @@ static float libsamplerate_scale = 0.65;
 
 static char *music_pack_path = NULL;
 static char *timidity_cfg_path = NULL;
+static char *fluidsynth_sf_path = NULL;
 static char *gus_patch_path = NULL;
 static int gus_ram_kb = 1024;
 
@@ -195,6 +197,12 @@ void ConfigSound(TXT_UNCAST_ARG(widget), void *user_data)
                 TXT_NewFileSelector(&timidity_cfg_path, 34,
                                     "Select Timidity config file",
                                     cfg_extension),
+                TXT_NewStrut(4, 0),
+                TXT_NewLabel("FluidSynth soundfont file: "),
+                TXT_NewStrut(4, 0),
+                TXT_NewFileSelector(&fluidsynth_sf_path, 34,
+                                    "Select FluidSynth soundfont file",
+                                    sf2_extension),
                 NULL)),
         NULL);
 }
@@ -215,6 +223,7 @@ void BindSoundVariables(void)
     M_BindStringVariable("gus_patch_path",        &gus_patch_path);
     M_BindStringVariable("music_pack_path",     &music_pack_path);
     M_BindStringVariable("timidity_cfg_path",     &timidity_cfg_path);
+    M_BindStringVariable("fluidsynth_sf_path",    &fluidsynth_sf_path);
 
     M_BindIntVariable("snd_sbport",               &snd_sbport);
     M_BindIntVariable("snd_sbirq",                &snd_sbirq);


### PR DESCRIPTION
As a convenience to the user, allow them to specify the path their preferred soundfont file in the setup program. If a soundfont path is provided, pass this to the SDL Mixer FluidSynth backend via Mix_SetSoundFonts. SDL Mixer assigns higher priority to programatically-set soundfont paths, so this avoids the problem where a soundfont path set by environment variable gets overruled by a default OS path or other compile-time path.

As a bonus this also eliminates the need for users to mess around with environment variables, which should lead to less friction in getting FluidSynth up and working.