### PR TITLE
Const correctness fixes

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -698,7 +698,7 @@ static void AddXdgDirs(void)
 // about everyone.
 static void AddSteamDirs(void)
 {
-    char *homedir;
+    const char *homedir;
     char *steampath;
 
     homedir = getenv("HOME");

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -698,7 +698,8 @@ static void AddXdgDirs(void)
 // about everyone.
 static void AddSteamDirs(void)
 {
-    char *homedir, *steampath;
+    char *homedir;
+    char *steampath;
 
     homedir = getenv("HOME");
     if (homedir == NULL)

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -634,7 +634,7 @@ static void AddIWADPath(const char *path, const char *suffix)
 // <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>
 static void AddXdgDirs(void)
 {
-    char *env;
+    const char *env;
     char *tmp_env;
 
     // Quote:

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -634,7 +634,8 @@ static void AddIWADPath(const char *path, const char *suffix)
 // <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>
 static void AddXdgDirs(void)
 {
-    char *env, *tmp_env;
+    char *env;
+    char *tmp_env;
 
     // Quote:
     // > $XDG_DATA_HOME defines the base directory relative to which

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -72,7 +72,7 @@ boolean D_IsIWADName(const char *name)
 #define MAX_IWAD_DIRS 128
 
 static boolean iwad_dirs_built = false;
-static char *iwad_dirs[MAX_IWAD_DIRS];
+static const char *iwad_dirs[MAX_IWAD_DIRS];
 static int num_iwad_dirs = 0;
 
 static void AddIWADDir(char *dir)

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -75,7 +75,7 @@ static boolean iwad_dirs_built = false;
 static const char *iwad_dirs[MAX_IWAD_DIRS];
 static int num_iwad_dirs = 0;
 
-static void AddIWADDir(char *dir)
+static void AddIWADDir(const char *dir)
 {
     if (num_iwad_dirs < MAX_IWAD_DIRS)
     {

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1715,7 +1715,7 @@ static void I_OPL_ShutdownMusic(void)
 
 static boolean I_OPL_InitMusic(void)
 {
-    char *dmxoption;
+    const char *dmxoption;
     opl_init_result_t chip_type;
 
     OPL_SetSampleRate(snd_samplerate);

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -93,6 +93,12 @@ static boolean WriteWrapperTimidityConfig(char *write_path)
     return true;
 }
 
+
+// putenv requires a non-const string whose lifetime is the whole program
+// so can't use a string directly, have to do this silliness
+static char sdl_mixer_disable_fluidsynth[] = "SDL_MIXER_DISABLE_FLUIDSYNTH=1";
+
+
 void I_InitTimidityConfig(void)
 {
     char *env_string;
@@ -121,7 +127,7 @@ void I_InitTimidityConfig(void)
         // timidity_cfg_path or GUS mode), then disable Fluidsynth, because
         // SDL_mixer considers Fluidsynth a higher priority than Timidity and
         // therefore can end up circumventing Timidity entirely.
-        putenv("SDL_MIXER_DISABLE_FLUIDSYNTH=1");
+        putenv(sdl_mixer_disable_fluidsynth);
     }
     else
     {

--- a/src/strife/dstrings.c
+++ b/src/strife/dstrings.c
@@ -20,7 +20,7 @@
 
 #include "dstrings.h"
 
-char *doom1_endmsg[] =
+const char *doom1_endmsg[] =
 {
   "are you sure you want to\nquit this great game?",
   "please don't leave, there's more\ndemons to toast!",
@@ -32,7 +32,7 @@ char *doom1_endmsg[] =
   "go ahead and leave. see if i care.",
 };
 
-char *doom2_endmsg[] =
+const char *doom2_endmsg[] =
 {
   // QuitDOOM II messages
   "are you sure you want to\nquit this great game?",

--- a/src/strife/dstrings.h
+++ b/src/strife/dstrings.h
@@ -34,8 +34,8 @@
 // 8 per each game type
 #define NUM_QUITMESSAGES   8
 
-extern char *doom1_endmsg[];
-extern char *doom2_endmsg[];
+extern const char *doom1_endmsg[];
+extern const char *doom2_endmsg[];
 
 
 #endif


### PR DESCRIPTION
Mostly trivial. Some notes:
`iwad_dirs` can contain both constants and allocated strings. Making it const prevents freeing them but we don't care about that kind of leak since a pointer to them still exists. Someone could refactor it the be correctly freed later (by making all of the strings allocated) if they want.

The hack in `I_InitTimidityConfig` is silly but apparently required for correct usage of `putenv`.

The end messages in Strife appear to be unused. Should I just remove them instead?
