### PR TITLE
convert first non-digit to locale's decimal in float value parsing

### DIFF
--- a/src/m_config.c
+++ b/src/m_config.c
@@ -2005,9 +2005,9 @@ static void SetVariable(default_t *def, const char *value)
             str = M_StringDuplicate(value);
 
             // Skip sign indicators.
-            if (str[0] == '-' || str[0] == '+')
+            if (str[i] == '-' || str[i] == '+')
             {
-                i = 1;
+                i++;
             }
 
             for ( ; str[i] != '\0'; i++)

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1997,7 +1997,7 @@ static void SetVariable(default_t *def, const char *value)
 
             for (i = 0; str[i] != '\0'; i++)
             {
-                if (!isdigit(str[i]))
+                if (!isdigit(str[i]) && str[i] != '-')
                 {
                     str[i] = dec;
                     break;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1988,6 +1988,15 @@ static void SetVariable(default_t *def, const char *value)
 
         case DEFAULT_FLOAT:
         {
+            // Different locales use different decimal separators.
+            // However, the choice of the current locale isn't always
+            // under our own control. If the atof() function fails to
+            // parse the string representing the floating point number
+            // using the current locale's decimal separator, it will
+            // return 0, resulting in silent sound effects. To
+            // mitigate this, we replace the first non-digit,
+            // non-minus character in the string with the current
+            // locale's decimal separator before passing it to atof().
             struct lconv *lc = localeconv();
             char dec, *str;
             int i;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -24,6 +24,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <assert.h>
+#include <locale.h>
 
 #include "SDL_filesystem.h"
 
@@ -1986,7 +1987,26 @@ static void SetVariable(default_t *def, const char *value)
             break;
 
         case DEFAULT_FLOAT:
-            *def->location.f = (float) atof(value);
+        {
+            struct lconv *lc = localeconv();
+            char dec, *str;
+            int i;
+
+            dec = lc->decimal_point[0];
+            str = M_StringDuplicate(value);
+
+            for (i = 0; str[i] != '\0'; i++)
+            {
+                if (!isdigit(str[i]))
+                {
+                    str[i] = dec;
+                    break;
+                }
+            }
+
+            *def->location.f = (float) atof(str);
+            free(str);
+        }
             break;
     }
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1999,14 +1999,20 @@ static void SetVariable(default_t *def, const char *value)
             // locale's decimal separator before passing it to atof().
             struct lconv *lc = localeconv();
             char dec, *str;
-            int i;
+            int i = 0;
 
             dec = lc->decimal_point[0];
             str = M_StringDuplicate(value);
 
-            for (i = 0; str[i] != '\0'; i++)
+            // Skip sign indicators.
+            if (str[0] == '-' || str[0] == '+')
             {
-                if (!isdigit(str[i]) && str[i] != '-')
+                i = 1;
+            }
+
+            for ( ; str[i] != '\0'; i++)
+            {
+                if (!isdigit(str[i]))
                 {
                     str[i] = dec;
                     break;


### PR DESCRIPTION
Different locales use different characters as decimal separators.
Since the currently used locale isn't always under our own control
(c.f. https://github.com/fabiangreffrath/crispy-doom/issues/620) this
commit makes sure to translate the first non-digit character in a
string that is going to get parsed as a float value into the current
locale's decimal separator.

Fixes https://github.com/fabiangreffrath/crispy-doom/issues/758.