### PR TITLE
Hexen: Support two variations of v1.1 with -gameversion

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -26,7 +26,7 @@ of compatibility:
 
  * DOS Doom 1.9 (although there are actually multiple “1.9”s).
  * DOS Heretic 1.3.
- * DOS Hexen 1.1.
+ * DOS Hexen 1.1 (although there are actually two known “1.1”s).
  * DOS Strife 1.31.
  * DOS Chex Quest.
 

--- a/man/bash-completion/hexen.template.in
+++ b/man/bash-completion/hexen.template.in
@@ -27,6 +27,9 @@ _@PROGRAM_SPREFIX@_hexen()
     esac
 
     case $prev in
+        -gameversion)
+            COMPREPLY=(1.1 1.1r2)
+            ;;
         -setmem)
             COMPREPLY=(dos622 dos71 dosbox)
             ;;

--- a/src/d_mode.c
+++ b/src/d_mode.c
@@ -132,6 +132,7 @@ static struct {
     { doom,     exe_chex },
     { heretic,  exe_heretic_1_3 },
     { hexen,    exe_hexen_1_1 },
+    { hexen,    exe_hexen_1_1r2 },
     { strife,   exe_strife_1_2 },
     { strife,   exe_strife_1_31 },
 };

--- a/src/d_mode.h
+++ b/src/d_mode.h
@@ -71,6 +71,7 @@ typedef enum
     exe_heretic_1_3, // Heretic 1.3
 
     exe_hexen_1_1,   // Hexen 1.1
+    exe_hexen_1_1r2, // Hexen 1.1 (alternate exe)
     exe_strife_1_2,  // Strife v1.2
     exe_strife_1_31  // Strife v1.31
 } GameVersion_t;

--- a/src/hexen/a_action.c
+++ b/src/hexen/a_action.c
@@ -1177,11 +1177,9 @@ void A_SoAExplode(mobj_t * actor)
     }
     if (actor->args[0])
     {                           // Spawn an item
-#if 0 // Checks are not present in version 1.1
-        if (!nomonsters
+        if ((gameversion != exe_hexen_1_1r2) || !nomonsters
             || !(mobjinfo[TranslateThingType[actor->args[0]]].
                  flags & MF_COUNTKILL))
-#endif
         {                       // Only spawn monsters if not -nomonsters
             P_SpawnMobj(actor->x, actor->y, actor->z,
                         TranslateThingType[actor->args[0]]);

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -95,6 +95,7 @@ extern boolean askforquit;
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
 GameMode_t gamemode;
+GameVersion_t gameversion = exe_hexen_1_1;
 static const char *gamedescription;
 char *iwadfile;
 static char demolumpname[9];    // Demo lump to start playing.
@@ -357,6 +358,81 @@ void D_SetGameDescription(void)
     }
 }
 
+static struct
+{
+    const char *description;
+    const char *cmdline;
+    GameVersion_t version;
+} gameversions[] = {
+    {"Hexen 1.1",            "1.1",        exe_hexen_1_1},
+    {"Hexen 1.1 (alt)",      "1.1r2",      exe_hexen_1_1r2},
+    { NULL,                  NULL,         0},
+};
+
+// Initialize the game version
+
+static void InitGameVersion(void)
+{
+    int p;
+    int i;
+
+    //!
+    // @arg <version>
+    // @category compat
+    //
+    // Emulate a specific version of Hexen.
+    // Valid values are "1.1" and "1.1r2".
+    //
+
+    p = M_CheckParmWithArgs("-gameversion", 1);
+
+    if (p)
+    {
+        for (i=0; gameversions[i].description != NULL; ++i)
+        {
+            if (!strcmp(myargv[p+1], gameversions[i].cmdline))
+            {
+                gameversion = gameversions[i].version;
+                break;
+            }
+        }
+
+        if (gameversions[i].description == NULL)
+        {
+            printf("Supported game versions:\n");
+
+            for (i=0; gameversions[i].description != NULL; ++i)
+            {
+                printf("\t%s (%s)\n", gameversions[i].cmdline,
+                        gameversions[i].description);
+            }
+
+            I_Error("Unknown game version '%s'", myargv[p+1]);
+        }
+    }
+    else
+    {
+        // Determine automatically
+
+        gameversion = exe_hexen_1_1;
+    }
+}
+
+void PrintGameVersion(void)
+{
+    int i;
+
+    for (i=0; gameversions[i].description != NULL; ++i)
+    {
+        if (gameversions[i].version == gameversion)
+        {
+            printf("Emulating the behavior of the "
+                   "'%s' executable.\n", gameversions[i].description);
+            break;
+        }
+    }
+}
+
 //==========================================================================
 //
 // H2_Main
@@ -438,6 +514,7 @@ void D_DoomMain(void)
     D_AddFile(iwadfile);
     W_CheckCorrectIWAD(hexen);
     D_IdentifyVersion();
+    InitGameVersion();
     D_SetGameDescription();
     AdjustForMacIWAD();
 
@@ -512,6 +589,8 @@ void D_DoomMain(void)
 
     ST_Message("D_CheckNetGame: Checking network game status.\n");
     D_CheckNetGame();
+
+    PrintGameVersion();
 
     ST_Message("SB_Init: Loading patches.\n");
     SB_Init();

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -587,7 +587,7 @@ void NET_SendFrags(player_t * player);
 
 #define TELEFOGHEIGHT (32*FRACUNIT)
 
-extern GameMode_t gamemode;         // Always commercial
+extern GameMode_t gamemode;
 
 extern gameaction_t gameaction;
 

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -73,8 +73,9 @@
 //#endif
 #define HEXEN_VERSIONTEXT ((gamemode == shareware) ? \
                            "DEMO 10 16 95" : \
-                           "VERSION 1.1 MAR 12 1996 (CBI)" \
-                           /*"VERSION 1.1 MAR 22 1996 (BCP)"*/)
+                           (gameversion != exe_hexen_1_1r2) ? \
+                           "VERSION 1.1 MAR 12 1996 (CBI)" : \
+                           "VERSION 1.1 MAR 22 1996 (BCP)")
 
 // all exterior data is defined here
 #include "xddefs.h"
@@ -589,6 +590,7 @@ void NET_SendFrags(player_t * player);
 #define TELEFOGHEIGHT (32*FRACUNIT)
 
 extern GameMode_t gamemode;
+extern GameVersion_t gameversion;
 
 extern gameaction_t gameaction;
 

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -73,7 +73,8 @@
 //#endif
 #define HEXEN_VERSIONTEXT ((gamemode == shareware) ? \
                            "DEMO 10 16 95" : \
-                           "VERSION 1.1 MAR 22 1996 (BCP)")
+                           "VERSION 1.1 MAR 12 1996 (CBI)" \
+                           /*"VERSION 1.1 MAR 22 1996 (BCP)"*/)
 
 // all exterior data is defined here
 #include "xddefs.h"


### PR DESCRIPTION
This is a continuation of PR #1266, and it covers issue #1378.

Possibly less related changes, like adjustments to spacing, are done in their own commits.

The bash-completion addition remains untested. It couldn't work for me, possibly since at the most, I installed the binaries to a subdir within the home directory.

To summarize what matters here:
* Originally, PR #1266 reverted the behaviors of A_SoAExplode to cover a Vanilla Bug. This turned out to be somewhat wrong, as there are actually two DOS EXEs identified as "1.1" floating around: One with the bug, and another one without it.
* Thus, as of this PR, Hexen gets the -gameversion switch, letting you choose between versions identified as 1.1 and 1.1r2. 1.1r2 is the one which covers a fix for the bug, impacting a few maps in DK when used with -nomonsters.
* The added code is mostly based on existing code used for Doom.
* One thing which PR #1266 missed was a change to HEXEN_VERSIONTEXT. This is now covered here.
* Note that I made no change involving the support for the demo IWAD. In particular, I added no separate game version for the demo.
* Before starting a multiplayer game, all players should ensure they use the same version, in case it's changed. I don't think this differs from the situation with Doom, though.

[hex11tst](https://github.com/chocolate-doom/chocolate-doom/files/4455949/hex11tst.zip)
[hexendk_007](https://user-images.githubusercontent.com/6780140/78892178-918c3700-7a71-11ea-9946-41244e4b6911.png)