### PR TITLE
Fix Setup's "Add WADs" feature

### DIFF
--- a/src/setup/multiplayer.c
+++ b/src/setup/multiplayer.c
@@ -176,6 +176,7 @@ static void AddWADs(execute_context_t *exec)
             if (!have_wads)
             {
                 AddCmdLineParameter(exec, "-file");
+                have_wads = 1;
             }
 
             AddCmdLineParameter(exec, "\"%s\"", wads[i]);


### PR DESCRIPTION
This bug prevented players from adding multiple files. Because this variable was never set to 1, Setup would pass the parameter `-file btsx_e1a.wad -file btsx_e1b.wad` to the engine, thus the only added wad would be `btsx_e1a.wad` because the engine only parses the first `-file` argument.