### PR TITLE
Fix builtin-declaration-mismatch

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -20,6 +20,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "doomtype.h"
 #include "m_misc.h"


### PR DESCRIPTION
Fix compiler warnings `'incompatible implicit declaration of built-in function 'malloc'`/`'free'` in **i_winmusic.c** introduced by #1399.