### PR TITLE
Fix Alt+Tab bug in fullscreen mode on Linux

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -347,6 +347,7 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
 
         case SDL_WINDOWEVENT_FOCUS_GAINED:
             window_focused = true;
+            screenvisible = true;
             break;
 
         case SDL_WINDOWEVENT_FOCUS_LOST:


### PR DESCRIPTION
This commit fixes the window content remaining invisible upon restoring the window on Linux. The bug happened when the game was in fullscreen mode before using Alt+Tab.