### PR TITLE
Set default soundfont path to empty string in setup

### DIFF
--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -247,6 +247,7 @@ void BindSoundVariables(void)
     music_pack_path = M_StringDuplicate("");
     timidity_cfg_path = M_StringDuplicate("");
     gus_patch_path = M_StringDuplicate("");
+    fluidsynth_sf_path = M_StringDuplicate("");
 
     // All versions of Heretic and Hexen did pitch-shifting.
     // Most versions of Doom did not and Strife never did.


### PR DESCRIPTION
This is a follow-up PR for #1387. This fixes an issue where the setup tool can assign the string "(null)" to the `fluidsynth_sf_path` config variable. Instead, assign an empty string as expected.