### PR TITLE
win midi: Fix volume issues

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -83,25 +83,6 @@ typedef struct
 
 static buffer_t buffer;
 
-static const int volume_correction[] = {
-    0,   4,   7,   11,  13,  14,  16,  18,
-    21,  22,  23,  24,  24,  24,  25,  25,
-    25,  26,  26,  27,  27,  27,  28,  28,
-    29,  29,  29,  30,  30,  31,  31,  32,
-    32,  32,  33,  33,  34,  34,  35,  35,
-    36,  37,  37,  38,  38,  39,  39,  40,
-    40,  41,  42,  42,  43,  43,  44,  45,
-    45,  46,  47,  47,  48,  49,  49,  50,
-    51,  52,  52,  53,  54,  55,  56,  56,
-    57,  58,  59,  60,  61,  62,  62,  63,
-    64,  65,  66,  67,  68,  69,  70,  71,
-    72,  73,  74,  75,  77,  78,  79,  80,
-    81,  82,  84,  85,  86,  87,  89,  90,
-    91,  92,  94,  95,  96,  98,  99,  101,
-    102, 104, 105, 107, 108, 110, 112, 113,
-    115, 117, 118, 120, 122, 123, 125, 127
-};
-
 // Message box for midiStream errors.
 
 static void MidiErrorMessageBox(DWORD dwError)
@@ -152,8 +133,6 @@ static void FillBuffer(void)
             channel_volume[MIDIEVENT_CHANNEL(event->dwEvent)] = volume;
 
             volume *= volume_factor;
-
-            volume = volume_correction[volume];
 
             event->dwEvent = (event->dwEvent & 0xFF00FFFF) |
                              ((volume & 0x7F) << 16);


### PR DESCRIPTION
Non-linear volume correction changes the relative volume of the instruments, which affects the sound of some MIDI files with volume control events, so I think it is better to remove it.

Update the volume when the song starts playing fixes DWANGO5 map11 MIDI (thanks @OpenRift412)

