### PR TITLE
Add ability to map mouse buttons to run!

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -345,7 +345,8 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     speed = key_speed >= NUMKEYS
          || joybspeed >= MAX_JOY_BUTTONS
          || gamekeydown[key_speed] 
-         || joybuttons[joybspeed];
+         || joybuttons[joybspeed]
+         || mousebuttons[mousebspeed];
  
     forward = side = 0;
     

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -310,7 +310,8 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         || joybuttons[joybstrafe];
     speed = joybspeed >= MAX_JOY_BUTTONS
          || gamekeydown[key_speed]
-         || joybuttons[joybspeed];
+         || joybuttons[joybspeed]
+         || mousebuttons[mousebspeed];
 
     // haleyjd: removed externdriver crap
     

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -229,7 +229,8 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     speed = key_speed >= NUMKEYS
         || joybspeed >= MAX_JOY_BUTTONS
         || gamekeydown[key_speed]
-        || joybuttons[joybspeed];
+        || joybuttons[joybspeed]
+        || mousebuttons[mousebspeed];
 
     // haleyjd: removed externdriver crap
     

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -442,6 +442,13 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(mouseb_forward),
 
     //!
+    // Mouse button to turn on running.  When held down, the player
+    // will run while moving.
+    //
+
+    CONFIG_VARIABLE_INT(mouseb_speed),
+
+    //!
     // @game hexen strife
     //
     // Mouse button to jump.

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -107,6 +107,7 @@ int key_invdrop   = KEY_BACKSPACE;
 int mousebfire = 0;
 int mousebstrafe = 1;
 int mousebforward = 2;
+int mousebspeed = 3;
 
 int mousebjump = -1;
 
@@ -233,6 +234,7 @@ void M_BindBaseControls(void)
     M_BindIntVariable("mouseb_fire",        &mousebfire);
     M_BindIntVariable("mouseb_strafe",      &mousebstrafe);
     M_BindIntVariable("mouseb_forward",     &mousebforward);
+    M_BindIntVariable("mouseb_speed",       &mousebspeed);
 
     M_BindIntVariable("joyb_fire",          &joybfire);
     M_BindIntVariable("joyb_strafe",        &joybstrafe);

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -136,6 +136,7 @@ extern int key_menu_screenshot;
 extern int mousebfire;
 extern int mousebstrafe;
 extern int mousebforward;
+extern int mousebspeed;
 
 extern int mousebjump;
 

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1063,7 +1063,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 
     if (joybspeed < 20)
     {
-        AddJoystickControl(window, "Speed", &joybspeed);
+        AddJoystickControl(window, "Run", &joybspeed);
     }
 
     if (gamemission == hexen || gamemission == strife)

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -407,7 +407,7 @@ void ConfigKeyboard(TXT_UNCAST_ARG(widget), void *user_data)
 
     AddKeyControl(window, "Turn Left", &key_left);
     TXT_AddWidget(window, TXT_TABLE_EMPTY);
-    AddKeyControl(window, "Speed On", &key_speed);
+    AddKeyControl(window, "Run", &key_speed);
 
     AddKeyControl(window, "Turn Right", &key_right);
     TXT_AddWidget(window, TXT_TABLE_EMPTY);

--- a/src/setup/mouse.c
+++ b/src/setup/mouse.c
@@ -47,6 +47,7 @@ static int *all_mouse_buttons[] = {
     &mousebjump,
     &mousebprevweapon,
     &mousebnextweapon,
+    &mousebspeed,
     &mousebinvleft,
     &mousebinvright,
     &mousebturnleft,
@@ -106,6 +107,7 @@ static void ConfigExtraButtons(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     AddMouseControl(buttons_table, "Previous weapon", &mousebprevweapon);
     AddMouseControl(buttons_table, "Strafe on", &mousebstrafe);
     AddMouseControl(buttons_table, "Next weapon", &mousebnextweapon);
+    AddMouseControl(buttons_table, "Run on", &mousebspeed);
     
     if (gamemission == heretic)
     {

--- a/src/setup/mouse.c
+++ b/src/setup/mouse.c
@@ -107,7 +107,7 @@ static void ConfigExtraButtons(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     AddMouseControl(buttons_table, "Previous weapon", &mousebprevweapon);
     AddMouseControl(buttons_table, "Strafe on", &mousebstrafe);
     AddMouseControl(buttons_table, "Next weapon", &mousebnextweapon);
-    AddMouseControl(buttons_table, "Run on", &mousebspeed);
+    AddMouseControl(buttons_table, "Run", &mousebspeed);
     
     if (gamemission == heretic)
     {

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -388,7 +388,8 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     speed = key_speed >= NUMKEYS
          || joybspeed >= MAX_JOY_BUTTONS
          || gamekeydown[key_speed] 
-         || joybuttons[joybspeed];
+         || joybuttons[joybspeed]
+         || mousebuttons[mousebspeed];
  
     forward = side = 0;
 


### PR DESCRIPTION
Under the "More controls" menu in mouse setup, I added "Run on" as a command you can set to a mouse button..!

This allows for using right click to mouse run, which is a common control scheme with people who usually use RMB for jump (A mouse command that exists already) in games where running is your jump~ (It's also popular with people who've played Marathon, since that's how you ran in those games, but that's just a bonus)

Before:
![The Chocolate Doom mouse setup menu with the existing options, and a hole in the bottom left under "Strafe on"](https://user-images.githubusercontent.com/1385527/146095514-f00948c9-8d0e-4454-a3de-dfab1aa89a0c.png)

After:
![The Chocolate Doom mouse setup menu with a new "Run on" menu option below "Strafe on"](https://user-images.githubusercontent.com/1385527/146095505-84900a1c-e1c5-4a95-8d97-2fd582fcf9a0.png)

I also put it in the hole under "Strafe on", since it seemed like all the other mouse commands were paired into logical groups, and "Run on" seemed like the appropriate missing counterpart to "Strafe on", since those are the two main movement modifiers in Doom engine games!