### PR TITLE
Add detection and search for doom2f.wad and french.deh, respectively.

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -38,6 +38,7 @@ static const iwad_t iwads[] =
     { "tnt.wad",      pack_tnt,  commercial, "Final Doom: TNT: Evilution" },
     { "doom.wad",     doom,      retail,     "Doom" },
     { "doom1.wad",    doom,      shareware,  "Doom Shareware" },
+    { "doom2f.wad",   doom2,     commercial, "Doom II: L'Enfer sur Terre" },
     { "chex.wad",     pack_chex, retail,     "Chex Quest" },
     { "hacx.wad",     pack_hacx, commercial, "Hacx" },
     { "freedoom2.wad", doom2,    commercial, "Freedoom: Phase 2" },

--- a/src/d_mode.h
+++ b/src/d_mode.h
@@ -35,6 +35,7 @@ typedef enum
     heretic,         // Heretic
     hexen,           // Hexen
     strife,          // Strife
+    doom2f,          // Doom 2: L'Enfer sur Terre
 
     none
 } GameMission_t;
@@ -82,7 +83,6 @@ typedef enum
     freedoom,   // FreeDoom: Phase 1 + 2
     freedm,     // FreeDM
     bfgedition, // Doom Classic (Doom 3: BFG Edition)
-    doom2f,     // Doom II (French)
 } GameVariant_t;
 
 // Skill level.

--- a/src/d_mode.h
+++ b/src/d_mode.h
@@ -82,6 +82,7 @@ typedef enum
     freedoom,   // FreeDoom: Phase 1 + 2
     freedm,     // FreeDM
     bfgedition, // Doom Classic (Doom 3: BFG Edition)
+    doom2f,     // Doom II (French)
 } GameVariant_t;
 
 // Skill level.

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1528,7 +1528,8 @@ void D_DoomMain (void)
     {
         gamevariant = bfgedition;
     }
-    else if (gamemission == doom2 && W_CheckNumForName("M_RDTHIS") < 0 && W_CheckNumForName("M_EPISOD") < 0 && W_CheckNumForName("M_EPI1") < 0 && W_CheckNumForName("M_EPI2") < 0 && W_CheckNumForName("M_EPI3") < 0 && W_CheckNumForName("WIOSTF") < 0 && W_CheckNumForName("WIOBJ") >= 0)
+    else if (gamemission == doom2 && W_CheckNumForName("M_RDTHIS") < 0 && W_CheckNumForName("M_EPISOD") < 0 && W_CheckNumForName("M_EPI1") < 0
+          && W_CheckNumForName("M_EPI2") < 0 && W_CheckNumForName("M_EPI3") < 0 && W_CheckNumForName("WIOSTF") < 0 && W_CheckNumForName("WIOBJ") >= 0)
     {
         gamevariant = doom2f;
     }

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1241,7 +1241,8 @@ static void LoadIwadDeh(void)
         }
     }
 
-    if (gamevariant == doom2f)
+    if (gamemission == doom2 && W_CheckNumForName("M_RDTHIS") < 0 && W_CheckNumForName("M_EPISOD") < 0 && W_CheckNumForName("M_EPI1") < 0
+          && W_CheckNumForName("M_EPI2") < 0 && W_CheckNumForName("M_EPI3") < 0 && W_CheckNumForName("WIOSTF") < 0 && W_CheckNumForName("WIOBJ") >= 0)
     {
         char *french_deh = NULL;
         char *dirname;
@@ -1527,11 +1528,6 @@ void D_DoomMain (void)
     else if (W_CheckNumForName("DMENUPIC") >= 0)
     {
         gamevariant = bfgedition;
-    }
-    else if (gamemission == doom2 && W_CheckNumForName("M_RDTHIS") < 0 && W_CheckNumForName("M_EPISOD") < 0 && W_CheckNumForName("M_EPI1") < 0
-          && W_CheckNumForName("M_EPI2") < 0 && W_CheckNumForName("M_EPI3") < 0 && W_CheckNumForName("WIOSTF") < 0 && W_CheckNumForName("WIOBJ") >= 0)
-    {
-        gamevariant = doom2f;
     }
 
     //!

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1240,6 +1240,41 @@ static void LoadIwadDeh(void)
             I_Error("Failed to load chex.deh needed for emulating chex.exe.");
         }
     }
+
+    if (gamevariant == doom2f)
+    {
+        char *french_deh = NULL;
+        char *dirname;
+
+        // Look for french.deh in the same directory as the IWAD file.
+        dirname = M_DirName(iwadfile);
+        french_deh = M_StringJoin(dirname, DIR_SEPARATOR_S, "french.deh", NULL);
+        free(dirname);
+
+        // If the dehacked patch isn't found, try searching the WAD
+        // search path instead.  We might find it...
+        if (!M_FileExists(french_deh))
+        {
+            free(french_deh);
+            french_deh = D_FindWADByName("french.deh");
+        }
+
+        // Still not found?
+        if (french_deh == NULL)
+        {
+            I_Error("Unable to find French Doom II dehacked file\n"
+                    "(french.deh).  The dehacked file is required in order to\n"
+                    "emulate French doom2.exe correctly.  It can be found in\n"
+                    "your nearest /idgames repository mirror at:\n\n"
+                    "   utils/exe_edit/patches/french.zip");
+        }
+
+        if (!DEH_LoadFile(french_deh))
+        {
+            I_Error("Failed to load french.deh needed for emulating French\n"
+                    "doom2.exe.");
+        }
+    }
 }
 
 static void G_CheckDemoStatusAtExit (void)
@@ -1492,6 +1527,10 @@ void D_DoomMain (void)
     else if (W_CheckNumForName("DMENUPIC") >= 0)
     {
         gamevariant = bfgedition;
+    }
+    else if (gamemission == doom2 && W_CheckNumForName("M_RDTHIS") < 0 && W_CheckNumForName("M_EPISOD") < 0 && W_CheckNumForName("M_EPI1") < 0 && W_CheckNumForName("M_EPI2") < 0 && W_CheckNumForName("M_EPI3") < 0 && W_CheckNumForName("WIOSTF") < 0 && W_CheckNumForName("WIOBJ") >= 0)
+    {
+        gamevariant = doom2f;
     }
 
     //!

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1183,6 +1183,14 @@ static void D_Endoom(void)
     I_Endoom(endoom);
 }
 
+boolean IsFrenchIWAD(void)
+{
+    return (gamemission == doom2 && W_CheckNumForName("M_RDTHIS") < 0
+          && W_CheckNumForName("M_EPISOD") < 0 && W_CheckNumForName("M_EPI1") < 0
+          && W_CheckNumForName("M_EPI2") < 0 && W_CheckNumForName("M_EPI3") < 0
+          && W_CheckNumForName("WIOSTF") < 0 && W_CheckNumForName("WIOBJ") >= 0);
+}
+
 // Load dehacked patches needed for certain IWADs.
 static void LoadIwadDeh(void)
 {
@@ -1241,8 +1249,7 @@ static void LoadIwadDeh(void)
         }
     }
 
-    if (gamemission == doom2 && W_CheckNumForName("M_RDTHIS") < 0 && W_CheckNumForName("M_EPISOD") < 0 && W_CheckNumForName("M_EPI1") < 0
-          && W_CheckNumForName("M_EPI2") < 0 && W_CheckNumForName("M_EPI3") < 0 && W_CheckNumForName("WIOSTF") < 0 && W_CheckNumForName("WIOBJ") >= 0)
+    if (IsFrenchIWAD())
     {
         char *french_deh = NULL;
         char *dirname;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1257,6 +1257,7 @@ static void LoadIwadDeh(void)
         // Look for french.deh in the same directory as the IWAD file.
         dirname = M_DirName(iwadfile);
         french_deh = M_StringJoin(dirname, DIR_SEPARATOR_S, "french.deh", NULL);
+        printf("French version\n");
         free(dirname);
 
         // If the dehacked patch isn't found, try searching the WAD


### PR DESCRIPTION
Chocolate Doom can currently load and play French DOOM II (DOOM2F.WAD), however the text strings are obviously English. I think accurate French DOOM2.EXE v1.8 behaviour reproduction falls within the scope of accurately replicating all behaviour of the original EXEs past v1.6.

What I propose is specific acknowledgement of doom2f.wad as an IWAD, then performing some lump checks to make sure it's French before, taking inspiration from the chex.wad handling, looking for fraggle's french.deh, and handling it identically to chex.wad/.deh. There's obviously a few different ways to handle this, and there could be some differences in line spacing or whatever, but I wanted to float this by all the same and see what the thoughts are about completing Chocolate Doom's library.

EDIT: Something I would have liked is rather than error-ing out for failure to produce french.deh, just give a warning message box before loading. Unlike chex.deh, it doesn't affect gameplay or engine mechanics. DOOM2F.WAD is otherwise playable with English text, it just isn't correct. However, I can't find such a generic start-up message in i_system, and I'm skittish on trying to monkey around there for a PR with undetermined status.