### PR TITLE
Fix Fluidsynth pause on Windows

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -342,12 +342,17 @@ static void I_SDL_PauseSong(void)
     }
 
 #if defined(_WIN32)
-    I_WIN_PauseSong();
-#else
-    musicpaused = true;
-
-    UpdateMusicVolume();
+    if (win_midi_stream_opened)
+    {
+        I_WIN_PauseSong();
+    }
+    else
 #endif
+    {
+        musicpaused = true;
+
+        UpdateMusicVolume();
+    }
 }
 
 static void I_SDL_ResumeSong(void)
@@ -358,12 +363,17 @@ static void I_SDL_ResumeSong(void)
     }
 
 #if defined(_WIN32)
-    I_WIN_ResumeSong();
-#else
-    musicpaused = false;
-
-    UpdateMusicVolume();
+    if (win_midi_stream_opened)
+    {
+        I_WIN_ResumeSong();
+    }
+    else
 #endif
+    {
+        musicpaused = false;
+
+        UpdateMusicVolume();
+    }
 }
 
 static void I_SDL_StopSong(void)


### PR DESCRIPTION
SDL_Mixer don't support pause in Fluidsynth backend: https://github.com/libsdl-org/SDL_mixer/blob/60a82b21bdbf2f4626eebee11600f29cebbe1c49/src/codecs/music_fluidsynth.c#L366