### PR TITLE
Change setup tool to use -merge instead of -file.

### DIFF
--- a/src/setup/multiplayer.c
+++ b/src/setup/multiplayer.c
@@ -175,7 +175,7 @@ static void AddWADs(execute_context_t *exec)
         {
             if (!have_wads)
             {
-                AddCmdLineParameter(exec, "-file");
+                AddCmdLineParameter(exec, "-merge");
                 have_wads = 1;
             }
 


### PR DESCRIPTION
This is the more "ergonomic" option to use that correctly handles WADs
that use sprites, and is consistent with what we do in the macOS launcher
and when doing drag-and-drop.