### PR TITLE
Final DOOM Anthology IWADs default to Anthology EXE.

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -999,6 +999,16 @@ static struct
     { NULL,                  NULL,         0},
 };
 
+boolean IsAnthologyIWAD(void)
+{
+    // DMAPINFO check prevents false positives with attempts to load the Classic
+    // Unity IWADs.
+    return ((gamemission == pack_tnt || gamemission == pack_plut)
+          && W_CheckNumForName("P1_START") >= 0 && W_CheckNumForName("P1_END") >= 0
+          && W_CheckNumForName("F1_START") >= 0 && W_CheckNumForName("F1_END") >= 0
+          && W_CheckNumForName("DMAPINFO") < 0);
+}
+
 // Initialize the game version
 
 static void InitGameVersion(void)
@@ -1116,12 +1126,20 @@ static void InitGameVersion(void)
         else if (gamemode == commercial)
         {
             // Final Doom: tnt or plutonia
-            // Defaults to emulating the first Final Doom executable,
-            // which has the crash in the demo loop; however, having
-            // this as the default should mean that it plays back
-            // most demos correctly.
+            // Final Doom Anthology IWADs should default to the Anthology EXE.
+            if (IsAnthologyIWAD())
+            {
+                gameversion = exe_final2;
+            }
 
-            gameversion = exe_final;
+            // Otherwise, defaults to emulating the first Final Doom
+            // executable, which has the crash in the demo loop; however,
+            // having this as the default should mean that it plays back
+            // most demos correctly.
+            else
+            {
+                gameversion = exe_final;
+            }
         }
     }
 


### PR DESCRIPTION
The current philosophy behind the handling of Final DOOM's IWADs is to default to "final[1]", not "final2", since that's what most people might reasonably be expecting, given that those are the common IWAD variants used. I think that's a good idea (not that it matters, but I digress). However, players that (apparently) go out of their way enough to use the rarer Anthology/GOG variants probably know what they have, and likely want accurate reproduction of those IWADs' engine 'out of the box'.

The idea then is of course to scan the IWADs' (plutonia.wad and tnt.wad) lumps to determine what is what. I believe there are enough differences to create a concrete, grief-proof search. Feel free to chime in if I missed an esoteric variant.

gameversion must be either pack_tnt or pack_plut
+P1_START
+P1_END
+F1_START
+F1_END
-DMAPINFO (weeds out Classic Unity variants which fulfill the above requirements--Classic Unity support is an unrelated can of worms)