### PR TITLE
Textscreen: support for forcing software rendering

### DIFF
--- a/src/i_endoom.c
+++ b/src/i_endoom.c
@@ -39,6 +39,10 @@ void I_Endoom(byte *endoom_data)
 
     // Set up text mode screen
 
+    // textscreen does not know Doom's force software renderer settings, 
+    // but it should follow them anyway when rendering endoom
+    TXT_SetForceSoftwareRenderer(force_software_renderer); 
+
     TXT_Init();
 
     TXT_SetWindowTitle(PACKAGE_STRING);

--- a/src/setup/mainmenu.c
+++ b/src/setup/mainmenu.c
@@ -306,6 +306,9 @@ static void InitTextscreen(void)
 {
     SetDisplayDriver();
 
+    // If the forced software renderer toggle is set, setup shouild pass it on to textscreen
+    TXT_SetForceSoftwareRenderer(M_GetIntVariable("force_software_renderer"));
+
     if (!TXT_Init())
     {
         fprintf(stderr, "Failed to initialize GUI\n");

--- a/textscreen/txt_main.h
+++ b/textscreen/txt_main.h
@@ -179,6 +179,11 @@ void TXT_GetMousePosition(int *x, int *y);
 // Optional timeout in ms (timeout == 0 : sleep forever)
 void TXT_Sleep(int timeout);
 
+// Force initialization of textscreen with a software renderer, where applicable
+// Must be called before TXT_Init for the value to apply
+// Default is assumed to be false (0)
+void TXT_SetForceSoftwareRendering(int force_software_rendering);
+
 // Change mode for text input.
 void TXT_SetInputMode(txt_input_mode_t mode);
 

--- a/textscreen/txt_main.h
+++ b/textscreen/txt_main.h
@@ -182,7 +182,7 @@ void TXT_Sleep(int timeout);
 // Force initialization of textscreen with a software renderer, where applicable
 // Must be called before TXT_Init for the value to apply
 // Default is assumed to be false (0)
-void TXT_SetForceSoftwareRendering(int force_software_rendering);
+void TXT_SetForceSoftwareRenderer(int force_software_rendering);
 
 // Change mode for text input.
 void TXT_SetInputMode(txt_input_mode_t mode);

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -59,6 +59,8 @@ static SDL_Renderer *renderer;
 // Current input mode.
 static txt_input_mode_t input_mode = TXT_INPUT_NORMAL;
 
+static int txt_force_software_rendering = 0;
+
 // Dimensions of the screen image in screen coordinates (not pixels); this
 // is the value that was passed to SDL_CreateWindow().
 static int screen_image_w, screen_image_h;
@@ -253,7 +255,8 @@ int TXT_Init(void)
     if (TXT_SDLWindow == NULL)
         return 0;
 
-    renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
+    if (!txt_force_software_rendering)
+        renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
 
     if (renderer == NULL)
         renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_SOFTWARE);
@@ -889,6 +892,10 @@ void TXT_Sleep(int timeout)
             SDL_Delay(1);
         }
     }
+}
+
+void TXT_SetForceSoftwareRendering(int force_software_rendering) {
+    txt_force_software_rendering = force_software_rendering;
 }
 
 void TXT_SetInputMode(txt_input_mode_t mode)

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -257,18 +257,24 @@ int TXT_Init(void)
 
     if (txt_force_software_renderer || getenv("TXT_FORCE_SOFTWARE_RENDERER") != NULL) {
         renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_SOFTWARE);
-        printf("force software\n");
     } else {
         renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
-        printf("regular renderer\n");
         if (renderer == NULL) {
             renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_SOFTWARE);
-            printf("fallback software\n");
         }
     }
 
     if (renderer == NULL)
         return 0;
+
+    SDL_RendererInfo rinfo;
+    SDL_GetRendererInfo(renderer, &rinfo);
+    printf("Textscreen using SDL renderer %s; software=%s accelerated=%s vsync=%s targettexture=%s\n",
+        rinfo.name, 
+        rinfo.flags & SDL_RENDERER_SOFTWARE, 
+        rinfo.flags & SDL_RENDERER_ACCELERATED, 
+        rinfo.flags & SDL_RENDERER_ACCELERATED, 
+        rinfo.flags & SDL_RENDERER_TARGETTEXTURE);
 
     // Special handling for OS X retina display. If we successfully set the
     // highdpi flag, check the output size for the screen renderer. If we get

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -59,7 +59,7 @@ static SDL_Renderer *renderer;
 // Current input mode.
 static txt_input_mode_t input_mode = TXT_INPUT_NORMAL;
 
-static int txt_force_software_rendering = 0;
+static int txt_force_software_renderer = 0;
 
 // Dimensions of the screen image in screen coordinates (not pixels); this
 // is the value that was passed to SDL_CreateWindow().
@@ -255,7 +255,7 @@ int TXT_Init(void)
     if (TXT_SDLWindow == NULL)
         return 0;
 
-    if (!txt_force_software_rendering)
+    if (!txt_force_software_renderer)
         renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
 
     if (renderer == NULL)
@@ -894,8 +894,8 @@ void TXT_Sleep(int timeout)
     }
 }
 
-void TXT_SetForceSoftwareRendering(int force_software_rendering) {
-    txt_force_software_rendering = force_software_rendering;
+void TXT_SetForceSoftwareRenderer(int force_software_renderer) {
+    txt_force_software_renderer = force_software_renderer;
 }
 
 void TXT_SetInputMode(txt_input_mode_t mode)

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -255,11 +255,17 @@ int TXT_Init(void)
     if (TXT_SDLWindow == NULL)
         return 0;
 
-    if (!txt_force_software_renderer)
-        renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
-
-    if (renderer == NULL)
+    if (txt_force_software_renderer || getenv("TXT_FORCE_SOFTWARE_RENDERER") != NULL) {
         renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_SOFTWARE);
+        printf("force software\n");
+    } else {
+        renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
+        printf("regular renderer\n");
+        if (renderer == NULL) {
+            renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_SOFTWARE);
+            printf("fallback software\n");
+        }
+    }
 
     if (renderer == NULL)
         return 0;

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -269,12 +269,12 @@ int TXT_Init(void)
 
     SDL_RendererInfo rinfo;
     SDL_GetRendererInfo(renderer, &rinfo);
-    printf("Textscreen using SDL renderer %s; software=%s accelerated=%s vsync=%s targettexture=%s\n",
+    printf("TXT_Init: SDL renderer name=%s software=%d accelerated=%d vsync=%d targettexture=%d\n",
         rinfo.name, 
-        rinfo.flags & SDL_RENDERER_SOFTWARE, 
-        rinfo.flags & SDL_RENDERER_ACCELERATED, 
-        rinfo.flags & SDL_RENDERER_ACCELERATED, 
-        rinfo.flags & SDL_RENDERER_TARGETTEXTURE);
+        rinfo.flags & SDL_RENDERER_SOFTWARE ? 1 : 0,
+        rinfo.flags & SDL_RENDERER_ACCELERATED ? 1 : 0,
+        rinfo.flags & SDL_RENDERER_ACCELERATED ? 1 : 0,
+        rinfo.flags & SDL_RENDERER_TARGETTEXTURE ? 1 : 0);
 
     // Special handling for OS X retina display. If we successfully set the
     // highdpi flag, check the output size for the screen renderer. If we get


### PR DESCRIPTION
Added a `TXT_SetForceSoftwareRenderer` function to set a global configuration flag for textscreen, plus support for a `TXT_FORCE_SOFTWARE_RENDERER` environment variable. Setting either of these has the same effect on how `SDL_CreateRenderer` is called as the `force_software_renderer` option in Choco's config does.

Additionally, Setup and Endoom call `TXT_Init`, call `TXT_SetForceSoftwareRenderer` as appropriate given the configurations they are operating under.