### PR TITLE
If running Doom as a daemon subprocess prefpath gets set to null pointer

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1599,6 +1599,7 @@ void D_DoomMain (void)
     if (!M_ParmExists("-noautoload") && gamemode != shareware)
     {
         char *autoload_dir;
+        DEH_printf("I_Init: Autoloading.\n");
 
         // common auto-loaded files for all Doom flavors
 
@@ -1765,9 +1766,13 @@ void D_DoomMain (void)
 
     DEH_printf("I_Init: Setting up machine state.\n");
     I_CheckIsScreensaver();
+    DEH_printf("I_Init: Setting up timer.\n");
     I_InitTimer();
+    DEH_printf("I_Init: Setting up joystick.\n");
     I_InitJoystick();
+    DEH_printf("I_Init: Setting up sound.\n");
     I_InitSound(true);
+    DEH_printf("I_Init: Setting up music.\n");
     I_InitMusic();
 
     printf ("NET_Init: Init network subsystem.\n");

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -2293,6 +2293,15 @@ float M_GetFloatVariable(const char *name)
     return *variable->location.f;
 }
 
+static char *GetPrefPath(const char *org, const char *app) {
+    char *ret = SDL_GetPrefPath(org, app);
+    if (!ret) {
+        ret = strdup("/root/.local/share/chocolate-doom/");
+    }
+
+    return ret;
+}
+
 // Get the path to the default configuration dir to use, if NULL
 // is passed to M_SetConfigDir.
 
@@ -2308,7 +2317,7 @@ static char *GetDefaultConfigDir(void)
     char *result;
     char *copy;
 
-    result = SDL_GetPrefPath("", PACKAGE_TARNAME);
+    result = GetPrefPath("", PACKAGE_TARNAME);
     if (result != NULL)
     {
         copy = M_StringDuplicate(result);
@@ -2370,7 +2379,7 @@ void M_SetMusicPackDir(void)
         return;
     }
 
-    prefdir = SDL_GetPrefPath("", PACKAGE_TARNAME);
+    prefdir = GetPrefPath("", PACKAGE_TARNAME);
     music_pack_path = M_StringJoin(prefdir, "music-packs", NULL);
 
     M_MakeDirectory(prefdir);
@@ -2466,7 +2475,7 @@ char *M_GetAutoloadDir(const char *iwadname)
     if (autoload_path == NULL || strlen(autoload_path) == 0)
     {
         char *prefdir;
-        prefdir = SDL_GetPrefPath("", PACKAGE_TARNAME);
+        prefdir = GetPrefPath("", PACKAGE_TARNAME);
         autoload_path = M_StringJoin(prefdir, "autoload", NULL);
         SDL_free(prefdir);
     }


### PR DESCRIPTION
Instead set to default directory in this case.