### PR TITLE
Fix "array subscript is above array bounds" warning in strife

### DIFF
--- a/src/strife/p_inter.c
+++ b/src/strife/p_inter.c
@@ -354,7 +354,8 @@ boolean P_GivePower(player_t* player, powertype_t power)
         return false;
 
     // villsa [STRIFE]
-    if(power == pw_targeter)
+    switch (power) {
+    case pw_targeter:
     {
         player->powers[power] = TARGTICS;
         P_SetPsprite(player, ps_targcenter, S_TRGT_00); // 10
@@ -368,7 +369,7 @@ boolean P_GivePower(player_t* player, powertype_t power)
         return true;
     }
 
-    if(power == pw_invisibility)
+    case pw_invisibility:
     {
         // if player already had this power...
         if(player->powers[power])
@@ -386,13 +387,13 @@ boolean P_GivePower(player_t* player, powertype_t power)
         return true;
     }
 
-    if(power == pw_ironfeet)
+    case pw_ironfeet:
     {
         player->powers[power] = IRONTICS;
         return true;
     }
 
-    if(power == pw_strength)
+    case pw_strength:
     {
         P_GiveBody(player, 100);
         player->powers[power] = 1;
@@ -400,7 +401,7 @@ boolean P_GivePower(player_t* player, powertype_t power)
     }
 
     // villsa [STRIFE]
-    if(power == pw_allmap)
+    case pw_allmap:
     {
         // remember in mapstate
         if(gamemap < 40)
@@ -411,14 +412,17 @@ boolean P_GivePower(player_t* player, powertype_t power)
     }
 
     // villsa [STRIFE]
-    if(power == pw_communicator)
+    case pw_communicator:
     {
         player->powers[power] = 1;
         return true;
     }
 
-    // default behavior:
-    player->powers[power] = 1;
+    case NUMPOWERS:
+        // This should never actually happen
+        break;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
GCC 11 and 12 warn about this. Refactor an if ladder into a switch and then explicitly ignore
`NUMPOWERS` value which should never happen. This makes the compiler shut up.

Note that I haven't actually tried this since I don't really play Strife.
