### PR TITLE
Fix transparent patch function mix-up

### DIFF
--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -895,10 +895,10 @@ void IN_DrawDMStats(void)
             }
             else
             {
-                V_DrawTLPatch(40, ypos,
+                V_DrawAltTLPatch(40, ypos,
                               W_CacheLumpNum(patchFaceOkayBase + i,
                                              PU_CACHE));
-                V_DrawTLPatch(xpos, 18,
+                V_DrawAltTLPatch(xpos, 18,
                               W_CacheLumpNum(patchFaceDeadBase + i,
                                              PU_CACHE));
             }

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -950,7 +950,7 @@ void DrawFullScreenStuff(void)
         if (CPlayer->readyArtifact > 0)
         {
             patch = DEH_String(patcharti[CPlayer->readyArtifact]);
-            V_DrawTLPatch(286, 170, W_CacheLumpName(DEH_String("ARTIBOX"), PU_CACHE));
+            V_DrawAltTLPatch(286, 170, W_CacheLumpName(DEH_String("ARTIBOX"), PU_CACHE));
             V_DrawPatch(286, 170, W_CacheLumpName(patch, PU_CACHE));
             DrSmallNumber(CPlayer->inventory[inv_ptr].count, 307, 192);
         }
@@ -960,7 +960,7 @@ void DrawFullScreenStuff(void)
         x = inv_ptr - curpos;
         for (i = 0; i < 7; i++)
         {
-            V_DrawTLPatch(50 + i * 31, 168,
+            V_DrawAltTLPatch(50 + i * 31, 168,
                           W_CacheLumpName(DEH_String("ARTIBOX"), PU_CACHE));
             if (CPlayer->inventorySlotNum > x + i
                 && CPlayer->inventory[x + i].type != arti_none)

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -315,7 +315,7 @@ void V_DrawTLPatch(int x, int y, patch_t * patch)
 
             while (count--)
             {
-                *dest = tinttable[((*dest) << 8) + *source++];
+                *dest = tinttable[*dest + ((*source++) << 8)];
                 dest += SCREENWIDTH;
             }
             column = (column_t *) ((byte *) column + column->length + 4);


### PR DESCRIPTION
In the current code there are two transparent patch drawers used by Hexen and Heretic: `V_DrawTLPatch()` and `V_DrawAltTLPatch()`. I believe these originate from the Hexen source's `V_DrawFuzzPatch()` and `V_DrawAltFuzzPatch()` respectively. In today's code, `V_DrawTLPatch()` and `V_DrawAltTLPatch()` are the same, which is not consistent with the original `*FuzzPatch()` functions.

I think the confusion arises because `V_DrawFuzzPatch()` is also present in the Heretic source release. It is equivalent to Hexen's `V_DrawAltFuzzPatch()`. Phew!

The net of this is that the Hexen patches drawn using this function are not entirely faithful.

Current state:
![Screenshot from 2022-06-07 22-05-34](https://user-images.githubusercontent.com/43701387/172515732-fc163e17-1f6c-454b-a810-9f31578480d9.png)

Correct behavior:
![Screenshot from 2022-06-07 22-04-52](https://user-images.githubusercontent.com/43701387/172515809-204a22b7-1009-4a41-8204-8514fa148c02.png)