### PR TITLE
Add missing includes for FreeBSD

### DIFF
--- a/src/i_input.c
+++ b/src/i_input.c
@@ -16,6 +16,7 @@
 //     SDL implementation of system-specific input interface.
 //
 
+#include <string.h>
 
 #include "SDL.h"
 #include "SDL_keycode.h"

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -18,6 +18,7 @@
 
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "SDL.h"
 #include "SDL_opengl.h"

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -15,6 +15,7 @@
 // Sound control menu
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "SDL_mixer.h"
 

--- a/textscreen/txt_fileselect.c
+++ b/textscreen/txt_fileselect.c
@@ -15,6 +15,7 @@
 // Routines for selecting files.
 //
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
On FreeBSD some includes are not pulled in implicitly by other headers, so this pull request adds a few missing includes of <ctype.h> and <string.h>