### PR TITLE
Additional artifact keybinds for Hexen/ setup restructure

### DIFF
--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -408,21 +408,48 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         gamekeydown[key_arti_all] = false;     // Use one of each artifact
         cmd->arti = NUMARTIFACTS;
     }
+	else if (gamekeydown[key_arti_invulnerability] && !cmd->arti
+             && !players[consoleplayer].powers[pw_invulnerability])
+    {
+        gamekeydown[key_arti_invulnerability] = false;
+        cmd->arti = arti_invulnerability;
+    }
     else if (gamekeydown[key_arti_health] && !cmd->arti
              && (players[consoleplayer].mo->health < MAXHEALTH))
     {
         gamekeydown[key_arti_health] = false;
         cmd->arti = arti_health;
-    }
-    else if (gamekeydown[key_arti_poisonbag] && !cmd->arti)
+	}
+	else if (gamekeydown[key_arti_superhealth] && !cmd->arti
+             && (players[consoleplayer].mo->health < MAXHEALTH))
     {
-        gamekeydown[key_arti_poisonbag] = false;
-        cmd->arti = arti_poisonbag;
+        gamekeydown[key_arti_superhealth] = false;
+        cmd->arti = arti_superhealth;
     }
-    else if (gamekeydown[key_arti_blastradius] && !cmd->arti)
+	else if (gamekeydown[key_arti_healingradius] && !cmd->arti)
+	{
+		gamekeydown[key_arti_healingradius] = false;
+		cmd->arti = arti_healingradius;
+	}
+	else if (gamekeydown[key_arti_torch] && !cmd->arti)
     {
-        gamekeydown[key_arti_blastradius] = false;
-        cmd->arti = arti_blastradius;
+        gamekeydown[key_arti_torch] = false;
+        cmd->arti = arti_torch;
+    }
+    else if (gamekeydown[key_arti_egg] && !cmd->arti)
+    {
+        gamekeydown[key_arti_egg] = false;
+        cmd->arti = arti_egg;
+    }
+    else if (gamekeydown[key_arti_fly] && !cmd->arti)
+    {
+        gamekeydown[key_arti_fly] = false;
+        cmd->arti = arti_fly;
+    }
+	else if (gamekeydown[key_arti_summon] && !cmd->arti)
+    {
+        gamekeydown[key_arti_summon] = false;
+        cmd->arti = arti_summon;
     }
     else if (gamekeydown[key_arti_teleport] && !cmd->arti)
     {
@@ -434,16 +461,30 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         gamekeydown[key_arti_teleportother] = false;
         cmd->arti = arti_teleportother;
     }
-    else if (gamekeydown[key_arti_egg] && !cmd->arti)
+    else if (gamekeydown[key_arti_poisonbag] && !cmd->arti)
     {
-        gamekeydown[key_arti_egg] = false;
-        cmd->arti = arti_egg;
+        gamekeydown[key_arti_poisonbag] = false;
+        cmd->arti = arti_poisonbag;
     }
-    else if (gamekeydown[key_arti_invulnerability] && !cmd->arti
-             && !players[consoleplayer].powers[pw_invulnerability])
+	else if (gamekeydown[key_arti_speed] && !cmd->arti)
     {
-        gamekeydown[key_arti_invulnerability] = false;
-        cmd->arti = arti_invulnerability;
+        gamekeydown[key_arti_speed] = false;
+        cmd->arti = arti_speed;
+    }
+	else if (gamekeydown[key_arti_boostmana] && !cmd->arti)
+    {
+        gamekeydown[key_arti_boostmana] = false;
+        cmd->arti = arti_boostmana;
+    }
+	else if (gamekeydown[key_arti_boostarmor] && !cmd->arti)
+	{
+		gamekeydown[key_arti_boostarmor] = false;
+		cmd->arti = arti_boostarmor;
+	}
+    else if (gamekeydown[key_arti_blastradius] && !cmd->arti)
+    {
+        gamekeydown[key_arti_blastradius] = false;
+        cmd->arti = arti_blastradius;
     }
 
 //

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1672,6 +1672,14 @@ static default_t extra_defaults_list[] =
     //!
     // @game hexen
     //
+    // Key to use "mystic urn" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_superhealth),
+
+    //!
+    // @game hexen
+    //
     // Key to use "flechette" artifact.
     //
 
@@ -1704,11 +1712,67 @@ static default_t extra_defaults_list[] =
     //!
     // @game hexen
     //
+    // Key to use "wings of wrath" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_fly),
+
+    //!
+    // @game hexen
+    //
+    // Key to use "torch" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_torch),
+	
+    //!
+    // @game hexen
+    //
     // Key to use "porkalator" artifact.
     //
 
     CONFIG_VARIABLE_KEY(key_arti_egg),
 
+    //!
+    // @game hexen
+    //
+    // Key to use "dark servant" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_summon),
+	
+    //!
+    // @game hexen
+    //
+    // Key to use "boots of speed" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_speed),
+	
+    //!
+    // @game hexen
+    //
+    // Key to use "krater of might" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_boostmana),
+
+    //!
+    // @game hexen
+    //
+    // Key to use "dragonskin bracers" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_boostarmor),
+	
+    //!
+    // @game hexen
+    //
+    // Key to use "mystic ambit incant" artifact.
+    //
+
+    CONFIG_VARIABLE_KEY(key_arti_healingradius),
+	
     //!
     // @game hexen
     //

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -72,13 +72,20 @@ int key_arti_morph = 0;
 int key_jump = '/';
 
 int key_arti_all             = KEY_BACKSPACE;
-int key_arti_health          = '\\';
-int key_arti_poisonbag       = '0';
-int key_arti_blastradius     = '9';
-int key_arti_teleport        = '8';
-int key_arti_teleportother   = '7';
-int key_arti_egg             = '6';
-int key_arti_invulnerability = '5';
+int key_arti_invulnerability = 0;
+int key_arti_health          = 0;
+int key_arti_superhealth     = 0;
+int key_arti_healingradius   = 0;
+int key_arti_egg             = 0;
+int key_arti_fly             = 0;
+int key_arti_summon          = 0;
+int key_arti_teleport        = 0;
+int key_arti_teleportother   = 0;
+int key_arti_poisonbag       = 0;
+int key_arti_speed           = 0;
+int key_arti_boostmana       = 0;
+int key_arti_boostarmor      = 0;
+int key_arti_blastradius     = 0;
 
 //
 // Strife key controls
@@ -297,13 +304,21 @@ void M_BindHexenControls(void)
     M_BindIntVariable("joyb_jump",          &joybjump);
 
     M_BindIntVariable("key_arti_all",             &key_arti_all);
+    M_BindIntVariable("key_arti_invulnerability", &key_arti_invulnerability);
     M_BindIntVariable("key_arti_health",          &key_arti_health);
-    M_BindIntVariable("key_arti_poisonbag",       &key_arti_poisonbag);
-    M_BindIntVariable("key_arti_blastradius",     &key_arti_blastradius);
+	M_BindIntVariable("key_arti_superhealth",     &key_arti_superhealth);
+    M_BindIntVariable("key_arti_healingradius",   &key_arti_healingradius);
+	M_BindIntVariable("key_arti_torch",           &key_arti_torch);
+    M_BindIntVariable("key_arti_egg",             &key_arti_egg);
+	M_BindIntVariable("key_arti_fly",             &key_arti_fly);
+    M_BindIntVariable("key_arti_summon",          &key_arti_summon);
     M_BindIntVariable("key_arti_teleport",        &key_arti_teleport);
     M_BindIntVariable("key_arti_teleportother",   &key_arti_teleportother);
-    M_BindIntVariable("key_arti_egg",             &key_arti_egg);
-    M_BindIntVariable("key_arti_invulnerability", &key_arti_invulnerability);
+    M_BindIntVariable("key_arti_poisonbag",       &key_arti_poisonbag);
+	M_BindIntVariable("key_arti_speed",           &key_arti_speed);
+	M_BindIntVariable("key_arti_boostmana",       &key_arti_boostmana);
+	M_BindIntVariable("key_arti_boostarmor",      &key_arti_boostarmor);
+    M_BindIntVariable("key_arti_blastradius",     &key_arti_blastradius);
 }
 
 void M_BindStrifeControls(void)

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -79,13 +79,20 @@ extern int key_arti_torch;
 extern int key_arti_morph;
 
 extern int key_arti_all;
+extern int key_arti_invulnerability;
 extern int key_arti_health;
-extern int key_arti_poisonbag;
-extern int key_arti_blastradius;
+extern int key_arti_superhealth;
+extern int key_arti_healingradius;
+extern int key_arti_egg;
+extern int key_arti_fly;
+extern int key_arti_summon;
 extern int key_arti_teleport;
 extern int key_arti_teleportother;
-extern int key_arti_egg;
-extern int key_arti_invulnerability;
+extern int key_arti_poisonbag;
+extern int key_arti_speed;
+extern int key_arti_boostmana;
+extern int key_arti_boostarmor;
+extern int key_arti_blastradius;
 
 extern int key_demo_quit;
 extern int key_spy;

--- a/src/setup/keyboard.c
+++ b/src/setup/keyboard.c
@@ -49,10 +49,13 @@ static int *controls[] = { &key_left, &key_right, &key_up, &key_down,
                            &key_arti_tome, &key_arti_ring, &key_arti_chaosdevice,
                            &key_arti_shadowsphere, &key_arti_wings, 
                            &key_arti_torch, &key_arti_morph,
-                           &key_arti_all, &key_arti_health, &key_arti_poisonbag,
-                           &key_arti_blastradius, &key_arti_teleport,
-                           &key_arti_teleportother, &key_arti_egg,
-                           &key_arti_invulnerability,
+                           &key_arti_all, &key_arti_invulnerability,
+						   &key_arti_health, &key_arti_superhealth,
+						   &key_arti_healingradius, &key_arti_fly, &key_arti_egg,
+                           &key_arti_summon, &key_arti_teleport,
+                           &key_arti_teleportother, &key_arti_speed,
+						   &key_arti_poisonbag, &key_arti_boostmana,
+						   &key_arti_boostarmor, &key_arti_blastradius,
                            &key_prevweapon, &key_nextweapon, NULL };
 
 static int *menu_nav[] = { &key_menu_activate, &key_menu_up, &key_menu_down,
@@ -265,14 +268,22 @@ static void ConfigExtraKeys(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
             AddSectionLabel(table, "Artifacts", true);
 
             AddKeyControl(table, "One of each", &key_arti_all);
+			AddKeyControl(table, "Icon of the Defender",
+			              &key_arti_invulnerability);
             AddKeyControl(table, "Quartz Flask", &key_arti_health);
-            AddKeyControl(table, "Flechette", &key_arti_poisonbag);
-            AddKeyControl(table, "Disc of Repulsion", &key_arti_blastradius);
-            AddKeyControl(table, "Chaos Device", &key_arti_teleport);
+			AddKeyControl(table, "Mystic Urn", &key_arti_superhealth);
+			AddKeyControl(table, "Mystic Ambit Incant", &key_arti_healingradius);
+			AddKeyControl(table, "Torch", &key_arti_torch);
+			AddKeyControl(table, "Porkalator", &key_arti_egg);
+			AddKeyControl(table, "Wings of Wrath", &key_arti_fly);
+			AddKeyControl(table, "Dark Servant", &key_arti_summon);
+			AddKeyControl(table, "Chaos Device", &key_arti_teleport);
             AddKeyControl(table, "Banishment Device", &key_arti_teleportother);
-            AddKeyControl(table, "Porkalator", &key_arti_egg);
-            AddKeyControl(table, "Icon of the Defender",
-                          &key_arti_invulnerability);
+            AddKeyControl(table, "Flechette", &key_arti_poisonbag);
+			AddKeyControl(table, "Boots of Speed", &key_arti_speed);
+			AddKeyControl(table, "Krater of Might", &key_arti_boostmana);
+			AddKeyControl(table, "Dragonskin Bracers", &key_arti_boostarmor);
+            AddKeyControl(table, "Disc of Repulsion", &key_arti_blastradius);
         }
     }
     else
@@ -286,10 +297,19 @@ static void ConfigExtraKeys(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     AddKeyControl(table, "Weapon 2", &key_weapon2);
     AddKeyControl(table, "Weapon 3", &key_weapon3);
     AddKeyControl(table, "Weapon 4", &key_weapon4);
+	
+	if (gamemission != hexen)
+	{
     AddKeyControl(table, "Weapon 5", &key_weapon5);
     AddKeyControl(table, "Weapon 6", &key_weapon6);
     AddKeyControl(table, "Weapon 7", &key_weapon7);
+	}
+	
+	if (gamemission == doom || gamemission == strife)
+	{
     AddKeyControl(table, "Weapon 8", &key_weapon8);
+	}
+	
     AddKeyControl(table, "Previous weapon", &key_prevweapon);
     AddKeyControl(table, "Next weapon", &key_nextweapon);
 }


### PR DESCRIPTION
This pull request does the following things:

- Adds dedicated key bindings for all of the Hexen artifacts that were missing them (e.g.: Dragonskin Bracers); now all of the artifacts, including the Mystic Ambit Incant (which does not show during singleplayer in the IWAD levels), have their own unique key
- By default, none of the artifacts have a key bound (this was done to mirror somewhat the Heretic implementation, which lacks default binds for all but the Tome of Power; with this implementation, in Hexen, only the "Use all artifacts" default bind is kept)
- Restructures the artifact order (now they should all correspond to the order in which they appear in src\hexen\p_user.c
- Additionally, this disables the key binding for weapons 5-8 in Hexen only, while also disabling the key binding for weapon 8 in Heretic, since neither game uses these bindings for any functions (they are only disabled in their respective setup tool menus).

I apologize in advance for any mistakes I might have made while making these changes.
Although this looks fine on my end (compiles, all additional keybinds work, no apparent demo compatibility issues), due to my lack of experience it's entirely possible I might have messed something up.
Please let me know if anything needs to be changed.