### PR TITLE
Check for functioning FluidSynth before using

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -186,7 +186,6 @@ static boolean SDLIsInitialized(void)
 static boolean I_SDL_InitMusic(void)
 {
     boolean fluidsynth_sf_is_set = false;
-    boolean fluidsynth_requested;
 
     // If SDL_mixer is not initialized, we have to initialize it
     // and have the responsibility to shut it down later on.
@@ -221,10 +220,7 @@ static boolean I_SDL_InitMusic(void)
     // Mix_Init() in order for FluidSynth to be registered as a valid decoder
     // in the Mix_GetMusicDecoder() list.
 
-    fluidsynth_requested =
-        ((strlen(fluidsynth_sf_path) > 0) && (strlen(timidity_cfg_path) == 0));
-
-    if (fluidsynth_requested)
+    if ((strlen(fluidsynth_sf_path) > 0) && (strlen(timidity_cfg_path) == 0))
     {
         if (M_FileExists(fluidsynth_sf_path))
         {
@@ -234,7 +230,6 @@ static boolean I_SDL_InitMusic(void)
         {
             fprintf(stderr,
                     "I_SDL_InitMusic: Can't find FluidSynth soundfont.\n");
-            fluidsynth_requested = false;
         }
     }
 
@@ -246,8 +241,9 @@ static boolean I_SDL_InitMusic(void)
 
     RemoveTimidityConfig();
 
-    // Confirm that FluidSynth is actually available.
-    if (fluidsynth_requested)
+    // If a soundfont has been set (either here on in the environment),
+    // confirm that FluidSynth is actually available before trying to use it.
+    if ((Mix_GetSoundFonts() != NULL) && (strlen(timidity_cfg_path) == 0))
     {
         int total;
 

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -186,6 +186,7 @@ static boolean SDLIsInitialized(void)
 static boolean I_SDL_InitMusic(void)
 {
     boolean fluidsynth_sf_is_set = false;
+    boolean fluidsynth_requested;
 
     // If SDL_mixer is not initialized, we have to initialize it
     // and have the responsibility to shut it down later on.
@@ -215,6 +216,28 @@ static boolean I_SDL_InitMusic(void)
         }
     }
 
+    // When using FluidSynth, proceed to set the soundfont path via
+    // Mix_SetSoundFonts if necessary. We need to do this before calling
+    // Mix_Init() in order for FluidSynth to be registered as a valid decoder
+    // in the Mix_GetMusicDecoder() list.
+
+    fluidsynth_requested =
+        ((strlen(fluidsynth_sf_path) > 0) && (strlen(timidity_cfg_path) == 0));
+
+    if (fluidsynth_requested)
+    {
+        if (M_FileExists(fluidsynth_sf_path))
+        {
+            Mix_SetSoundFonts(fluidsynth_sf_path);
+        }
+        else
+        {
+            fprintf(stderr,
+                    "I_SDL_InitMusic: Can't find FluidSynth soundfont.\n");
+            fluidsynth_requested = false;
+        }
+    }
+
     // Initialize SDL_Mixer for MIDI music playback
     Mix_Init(MIX_INIT_MID);
 
@@ -223,24 +246,32 @@ static boolean I_SDL_InitMusic(void)
 
     RemoveTimidityConfig();
 
-    // When using FluidSynth, proceed to set the soundfont path via
-    // Mix_SetSoundFonts if necessary.
-
-    if (strlen(fluidsynth_sf_path) > 0 && strlen(timidity_cfg_path) == 0)
+    // Confirm that FluidSynth is actually available.
+    if (fluidsynth_requested)
     {
-        if (M_FileExists(fluidsynth_sf_path))
+        int total;
+
+        total = Mix_GetNumMusicDecoders();
+
+        // If FluidSynth is present and has a valid soundfont, it will be in
+        // the list of available music decoders.
+        for (int i = 0; i < total; ++i)
         {
-            fluidsynth_sf_is_set = true;
+            if (!strcmp(Mix_GetMusicDecoder(i), "FLUIDSYNTH"))
+            {
+                fluidsynth_sf_is_set = true;
+                break;
+            }
+        }
+
+        if (fluidsynth_sf_is_set)
+        {
+            printf("I_SDL_InitMusic: Using FluidSynth.\n");
         }
         else
         {
-            fprintf(stderr, "Can't find Fluidsynth soundfont.\n");
+            fprintf(stderr, "I_SDL_InitMusic: FluidSynth unavailable.\n");
         }
-    }
-
-    if (fluidsynth_sf_is_set)
-    {
-        Mix_SetSoundFonts(fluidsynth_sf_path);
     }
 
     // If snd_musiccmd is set, we need to call Mix_SetMusicCMD to


### PR DESCRIPTION
Check that FluidSynth shows up in SDL Mixer's list of valid decoders before we try to use it. This ensures that FluidSynth is actually available and the soundfont file is good.

This should help prevent issues like #1473 and [this](https://www.doomworld.com/forum/topic/129927-crispy-doom-fluidsynth-question/) on Windows where the vast majority won't have FluidSynth. For those cases this change would cause us to fall back to using the local (non SDL Mixer) native MIDI.