### PR TITLE
Disable CI linter fail fast

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -43,4 +43,5 @@ jobs:
 
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed > 0
-        run: exit 1
+        run: |
+          echo "Some files failed the linting checks! Fail fast disabled until false posivite issue is fixed"

--- a/opl/opl.c
+++ b/opl/opl.c
@@ -112,7 +112,7 @@ static opl_init_result_t AutoSelectDriver(unsigned int port_base)
     int i;
     opl_init_result_t result;
 
-    for (i=0; drivers[i] != NULL; ++i)
+    for (i = 0; drivers[i] != NULL; ++i)
     {
         result = InitDriver(drivers[i], port_base);
         if (result != OPL_INIT_NONE)


### PR DESCRIPTION
Disable CI linter fail fast since it's causing false positives on lines which were not changed. I filed a bug upstream: https://github.com/cpp-linter/cpp-linter-action/issues/74

Also a whitespace change to make it fire on this PR.
