### PR TITLE
Implement M_getenv() wrapper to support non-Latin paths on Windows

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -227,6 +227,7 @@ C library function |   Wrapper
 `rename()`         |  `M_rename()`
 `stat()`           |  `M_stat()`
 `mkdir()`          |  `M_MakeDirectory()`
+`getenv()`         |  `M_getenv()`
 
 ## GNU GPL and licensing
 

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -744,14 +744,14 @@ static void BuildIWADDirList(void)
     AddIWADDir(M_DirName(myargv[0]));
 
     // Add DOOMWADDIR if it is in the environment
-    env = getenv("DOOMWADDIR");
+    env = M_getenv("DOOMWADDIR");
     if (env != NULL)
     {
         AddIWADDir(env);
     }
 
     // Add dirs from DOOMWADPATH:
-    env = getenv("DOOMWADPATH");
+    env = M_getenv("DOOMWADPATH");
     if (env != NULL)
     {
         AddIWADPath(env, "");

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -30,10 +30,11 @@
 wchar_t *M_ConvertUtf8ToWide(const char *str);
 #endif
 
-FILE* M_fopen(const char *filename, const char *mode);
+FILE *M_fopen(const char *filename, const char *mode);
 int M_remove(const char *path);
 int M_rename(const char *oldname, const char *newname);
 int M_stat(const char *path, struct stat *buf);
+char *M_getenv(const char *name);
 boolean M_WriteFile(const char *name, const void *source, int length);
 int M_ReadFile(const char *name, byte **buffer);
 void M_MakeDirectory(const char *dir);

--- a/src/setup/execute.c
+++ b/src/setup/execute.c
@@ -61,7 +61,7 @@ static char *TempFile(const char *s)
 #ifdef _WIN32
     // Check the TEMP environment variable to find the location.
 
-    tempdir = getenv("TEMP");
+    tempdir = M_getenv("TEMP");
 
     if (tempdir == NULL)
     {


### PR DESCRIPTION
This fixes `M_TempFile()` function on Windows, since `TEMP` directory path often contains non-Latin user name.

I only replace `getenv()` with `M_getenv()` in places where it can return a path on Windows. 