### PR TITLE
Add option to disable memory pool for debugging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,14 @@ AS_IF([test "x$enable_icons" != xno], [
     ])
 ])
 
+# Check for memory pool debugging.
+AC_ARG_ENABLE([zpool],
+AS_HELP_STRING([--disable-zpool], [Disable memory pools for debugging])
+)
+AS_IF([test "x$enable_zpool" != xno], [], [
+    AC_DEFINE([DISABLE_ZPOOL], [1], [Memory pooling disabled])
+])
+
 # Check for libsamplerate.
 AC_ARG_WITH([libsamplerate],
 AS_HELP_STRING([--without-libsamplerate],
@@ -176,6 +184,7 @@ AM_CONDITIONAL(HAVE_BASH_COMPLETION, [test "x$enable_bash_completion" != xno])
 AM_CONDITIONAL(HAVE_DOC, [test "x$enable_doc" != xno])
 AM_CONDITIONAL(HAVE_FONTS, [test "x$enable_fonts" != xno])
 AM_CONDITIONAL(HAVE_ICONS, [test "x$enable_icons" != xno])
+AM_CONDITIONAL(HAVE_ZPOOL, [test "x$enable_zpool" != xno])
 
 dnl Automake v1.8.0 is required, please upgrade!
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -55,7 +55,7 @@ z_native.c           z_zone.h
 
 # Source files used by the game binaries (chocolate-doom, etc.)
 
-GAME_SOURCE_FILES=\
+GAME_BASE_FILES=\
 aes_prng.c           aes_prng.h            \
 d_event.c            d_event.h             \
                      doomkeys.h            \
@@ -115,8 +115,20 @@ w_file.c             w_file.h              \
 w_file_stdc.c                              \
 w_file_posix.c                             \
 w_file_win32.c                             \
-w_merge.c            w_merge.h             \
+w_merge.c            w_merge.h
+
+
+MEMORY_NATIVE_SOURCE_FILES=\
+z_native.c           z_zone.h
+
+MEMORY_ZONE_SOURCE_FILES=\
 z_zone.c             z_zone.h
+
+if HAVE_ZPOOL
+GAME_SOURCE_FILES=$(GAME_BASE_FILES) $(MEMORY_ZONE_SOURCE_FILES)
+else
+GAME_SOURCE_FILES=$(GAME_BASE_FILES) $(MEMORY_NATIVE_SOURCE_FILES)
+endif
 
 DEHACKED_SOURCE_FILES =                    \
 deh_defs.h                                 \


### PR DESCRIPTION
Add option to disable memory pool for debugging. This makes it possible to debug memory issues like #1242.