### PR TITLE
Clean up extern in .c files

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -45,3 +45,7 @@ jobs:
         if: steps.linter.outputs.checks-failed > 0
         run: |
           echo "Some files failed the linting checks! Fail fast disabled until false posivite issue is fixed"
+
+      - name: Check no extern used in .c files
+        run: |
+          ./check-extern.sh


### PR DESCRIPTION
Using `extern` in .c -files is a bad idea that can result in undefined behavior and strange breakage. Let's remove them.

This just adds a check to CI workflow. I expect it to fail and want to see that.
