### PR TITLE
Configurable reverb and chorus for native MIDI

### DIFF
--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -85,6 +85,10 @@ extern int opl_io_port;
 extern char *music_pack_path;
 extern char *fluidsynth_sf_path;
 extern char *timidity_cfg_path;
+#ifdef _WIN32
+extern int winmm_reverb_level;
+extern int winmm_chorus_level;
+#endif
 
 // DOS-specific options: These are unused but should be maintained
 // so that the config file can be shared between chocolate
@@ -513,6 +517,10 @@ void I_BindSoundVariables(void)
     M_BindStringVariable("timidity_cfg_path",    &timidity_cfg_path);
     M_BindStringVariable("gus_patch_path",       &gus_patch_path);
     M_BindIntVariable("gus_ram_kb",              &gus_ram_kb);
+#ifdef _WIN32
+    M_BindIntVariable("winmm_reverb_level",      &winmm_reverb_level);
+    M_BindIntVariable("winmm_chorus_level",      &winmm_chorus_level);
+#endif
 
     M_BindIntVariable("use_libsamplerate",       &use_libsamplerate);
     M_BindFloatVariable("libsamplerate_scale",   &libsamplerate_scale);

--- a/src/i_winmusic.h
+++ b/src/i_winmusic.h
@@ -31,6 +31,9 @@ boolean I_WIN_RegisterSong(char* filename);
 void I_WIN_UnRegisterSong(void);
 void I_WIN_ShutdownMusic(void);
 
+extern int winmm_reverb_level;
+extern int winmm_chorus_level;
+
 #endif
 
 #endif

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -965,6 +965,20 @@ static default_t extra_defaults_list[] =
 
     CONFIG_VARIABLE_INT(gus_ram_kb),
 
+#ifdef _WIN32
+    //!
+    // Reverb level for native Windows MIDI, default 40, range 0-127.
+    //
+
+    CONFIG_VARIABLE_INT(winmm_reverb_level),
+
+    //!
+    // Chorus level for native Windows MIDI, default 0, range 0-127.
+    //
+
+    CONFIG_VARIABLE_INT(winmm_chorus_level),
+#endif
+
     //!
     // @game doom strife
     //

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -70,6 +70,10 @@ static char *timidity_cfg_path = NULL;
 static char *fluidsynth_sf_path = NULL;
 static char *gus_patch_path = NULL;
 static int gus_ram_kb = 1024;
+#ifdef _WIN32
+static int winmm_reverb_level = 40;
+static int winmm_chorus_level = 0;
+#endif
 
 // DOS specific variables: these are unused but should be maintained
 // so that the config file can be shared between chocolate
@@ -225,6 +229,10 @@ void BindSoundVariables(void)
     M_BindStringVariable("music_pack_path",     &music_pack_path);
     M_BindStringVariable("timidity_cfg_path",     &timidity_cfg_path);
     M_BindStringVariable("fluidsynth_sf_path",    &fluidsynth_sf_path);
+#ifdef _WIN32
+    M_BindIntVariable("winmm_reverb_level",       &winmm_reverb_level);
+    M_BindIntVariable("winmm_chorus_level",       &winmm_chorus_level);
+#endif
 
     M_BindIntVariable("snd_sbport",               &snd_sbport);
     M_BindIntVariable("snd_sbirq",                &snd_sbirq);


### PR DESCRIPTION
This PR adds the ability to configure two commonly adjusted settings: reverb and chorus. These values will work with any MIDI file that doesn't already set reverb or chorus, such as the original Doom 1 and 2 music. Otherwise, the MIDI file settings have priority.

Related discussion: https://github.com/fabiangreffrath/crispy-doom/issues/940
Details about previous PR: https://github.com/chocolate-doom/chocolate-doom/pull/1493 and https://github.com/fabiangreffrath/woof/pull/706

New settings in chocolate-doom.cfg:

`winmm_reverb_level 40` (0 to 127)
Reverb send level for native Windows MIDI.

`winmm_chorus_level 0` (0 to 127)
Chorus send level for native Windows MIDI.

Crispy Doom: replace [this line](https://github.com/chocolate-doom/chocolate-doom/pull/1504/files#diff-105b97db3da24160549fe2b8d4cd4dc387ed3e074fff3ec42b4b50feb4ed612eR29) with `#include "crispy.h"`.