### PR TITLE
Add selectable native MIDI devices to setup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,9 @@ endif()
 if(ENABLE_SDL2_NET)
     target_link_libraries("${PROGRAM_PREFIX}setup" SDL2::net)
 endif()
+if(WIN32)
+    target_link_libraries("${PROGRAM_PREFIX}setup" winmm)
+endif()
 
 if(MSVC)
     set_target_properties("${PROGRAM_PREFIX}setup" PROPERTIES

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -86,6 +86,7 @@ extern char *music_pack_path;
 extern char *fluidsynth_sf_path;
 extern char *timidity_cfg_path;
 #ifdef _WIN32
+extern int winmm_midi_device;
 extern int winmm_reverb_level;
 extern int winmm_chorus_level;
 #endif
@@ -518,6 +519,7 @@ void I_BindSoundVariables(void)
     M_BindStringVariable("gus_patch_path",       &gus_patch_path);
     M_BindIntVariable("gus_ram_kb",              &gus_ram_kb);
 #ifdef _WIN32
+    M_BindIntVariable("winmm_midi_device",       &winmm_midi_device);
     M_BindIntVariable("winmm_reverb_level",      &winmm_reverb_level);
     M_BindIntVariable("winmm_chorus_level",      &winmm_chorus_level);
 #endif

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -86,7 +86,6 @@ extern char *music_pack_path;
 extern char *fluidsynth_sf_path;
 extern char *timidity_cfg_path;
 #ifdef _WIN32
-extern int winmm_midi_device;
 extern int winmm_reverb_level;
 extern int winmm_chorus_level;
 #endif
@@ -519,7 +518,7 @@ void I_BindSoundVariables(void)
     M_BindStringVariable("gus_patch_path",       &gus_patch_path);
     M_BindIntVariable("gus_ram_kb",              &gus_ram_kb);
 #ifdef _WIN32
-    M_BindIntVariable("winmm_midi_device",       &winmm_midi_device);
+    M_BindStringVariable("winmm_midi_device",    &winmm_midi_device);
     M_BindIntVariable("winmm_reverb_level",      &winmm_reverb_level);
     M_BindIntVariable("winmm_chorus_level",      &winmm_chorus_level);
 #endif

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -246,5 +246,9 @@ typedef enum {
 
 void I_SetOPLDriverVer(opl_driver_ver_t ver);
 
+#ifdef _WIN32
+extern char *winmm_midi_device;
+#endif
+
 #endif
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -432,8 +432,7 @@ boolean I_WIN_InitMusic(void)
         mmr = midiOutGetDevCaps(MIDI_MAPPER, &mcaps, sizeof(mcaps));
         if (mmr == MMSYSERR_NOERROR)
         {
-            winmm_midi_device = malloc(sizeof(mcaps.szPname));
-            memcpy(winmm_midi_device, mcaps.szPname, sizeof(mcaps.szPname));
+            winmm_midi_device = M_StringDuplicate(mcaps.szPname);
         }
     }
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -407,6 +407,7 @@ boolean I_WIN_InitMusic(void)
         all_devices = midiOutGetNumDevs() + 1; // include MIDI_MAPPER
         for (i = 0; i < all_devices; ++i)
         {
+            // start from device id -1 (MIDI_MAPPER)
             mmr = midiOutGetDevCaps(i - 1, &mcaps, sizeof(mcaps));
             if (mmr == MMSYSERR_NOERROR)
             {

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -33,6 +33,7 @@
 #define CHORUS_MIN 0
 #define CHORUS_MAX 127
 
+int winmm_midi_device = -1;
 int winmm_reverb_level = 40;
 int winmm_chorus_level = 0;
 
@@ -393,9 +394,17 @@ void ResetDevice(void)
 
 boolean I_WIN_InitMusic(void)
 {
-    UINT MidiDevice = MIDI_MAPPER;
+    UINT MidiDevice = (UINT)winmm_midi_device;
     MIDIHDR *hdr = &buffer.MidiStreamHdr;
+    MIDIOUTCAPS mcaps;
     MMRESULT mmr;
+
+    mmr = midiOutGetDevCaps(MidiDevice, &mcaps, sizeof(mcaps));
+    if (mmr != MMSYSERR_NOERROR)
+    {
+        MidiDevice = MIDI_MAPPER;
+        winmm_midi_device = MIDI_MAPPER;
+    }
 
     mmr = midiStreamOpen(&hMidiStream, &MidiDevice, (DWORD)1,
                          (DWORD_PTR)MidiStreamProc, (DWORD_PTR)NULL,

--- a/src/i_winmusic.h
+++ b/src/i_winmusic.h
@@ -31,6 +31,7 @@ boolean I_WIN_RegisterSong(char* filename);
 void I_WIN_UnRegisterSong(void);
 void I_WIN_ShutdownMusic(void);
 
+extern int winmm_midi_device;
 extern int winmm_reverb_level;
 extern int winmm_chorus_level;
 

--- a/src/i_winmusic.h
+++ b/src/i_winmusic.h
@@ -31,7 +31,6 @@ boolean I_WIN_RegisterSong(char* filename);
 void I_WIN_UnRegisterSong(void);
 void I_WIN_ShutdownMusic(void);
 
-extern int winmm_midi_device;
 extern int winmm_reverb_level;
 extern int winmm_chorus_level;
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -967,6 +967,12 @@ static default_t extra_defaults_list[] =
 
 #ifdef _WIN32
     //!
+    // MIDI device for native Windows MIDI, default -1 (MIDI_MAPPER).
+    //
+
+    CONFIG_VARIABLE_INT(winmm_midi_device),
+
+    //!
     // Reverb level for native Windows MIDI, default 40, range 0-127.
     //
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -967,10 +967,10 @@ static default_t extra_defaults_list[] =
 
 #ifdef _WIN32
     //!
-    // MIDI device for native Windows MIDI, default -1 (MIDI_MAPPER).
+    // MIDI device for native Windows MIDI.
     //
 
-    CONFIG_VARIABLE_INT(winmm_midi_device),
+    CONFIG_VARIABLE_STRING(winmm_midi_device),
 
     //!
     // Reverb level for native Windows MIDI, default 40, range 0-127.

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -144,8 +144,7 @@ static void OpenMusicPackDir(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
 static void UpdateMidiDevice(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(data))
 {
     free(winmm_midi_device);
-    winmm_midi_device = malloc(strlen(midi_names[midi_index]) + 1);
-    strcpy(winmm_midi_device, midi_names[midi_index]);
+    winmm_midi_device = M_StringDuplicate(midi_names[midi_index]);
 }
 
 static txt_dropdown_list_t *MidiDeviceSelector(void)
@@ -194,8 +193,7 @@ static txt_dropdown_list_t *MidiDeviceSelector(void)
         mmr = midiOutGetDevCaps(device_ids[i], &mcaps, sizeof(mcaps));
         if (mmr == MMSYSERR_NOERROR)
         {
-            midi_names[i] = malloc(sizeof(mcaps.szPname)); // MAXPNAMELEN := 32
-            memcpy(midi_names[i], mcaps.szPname, sizeof(mcaps.szPname));
+            midi_names[i] = M_StringDuplicate(mcaps.szPname);
         }
     }
 
@@ -213,8 +211,7 @@ static txt_dropdown_list_t *MidiDeviceSelector(void)
             // give up and use MIDI_MAPPER
             midi_index = 0;
             free(winmm_midi_device);
-            winmm_midi_device = malloc(strlen(midi_names[0]) + 1);
-            strcpy(winmm_midi_device, midi_names[0]);
+            winmm_midi_device = M_StringDuplicate(midi_names[0]);
             break;
         }
     }


### PR DESCRIPTION
This uses the MME API (aka WinMM) to make a list of MIDI devices on the system. When running the setup executable, a dropdown list will appear under Configure Sound > Music > Native MIDI. This allows the user to more conveniently select non-default MIDI devices such as a loopMIDI port, a USB MIDI interface (e.g. UM-ONE mk2), or an older sound card.

New setting in chocolate-doom.cfg:

`winmm_midi_device ""`
MIDI device name for native Windows MIDI. The default is the device name for MIDI_MAPPER, e.g. `"Microsoft MIDI Mapper"`.