### PR TITLE
Adjust music volume to prevent clipping and match midiOutSetVolume curve

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -471,7 +471,7 @@ boolean I_WIN_InitMusic(void)
 
 void I_WIN_SetMusicVolume(int volume)
 {
-    volume_factor = (float)volume / 120;
+    volume_factor = sqrt((float)volume / 120);
 
     UpdateVolume();
 }

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -144,10 +144,6 @@ static void FillBuffer(void)
             channel_volume[MIDIEVENT_CHANNEL(event->dwEvent)] = volume;
 
             volume *= volume_factor;
-            if (volume > 127)
-            {
-                volume = 127;
-            }
 
             event->dwEvent = (event->dwEvent & 0xFF00FFFF) |
                              ((volume & 0x7F) << 16);
@@ -342,10 +338,6 @@ static void UpdateVolume(void)
         DWORD msg = 0;
 
         int value = channel_volume[i] * volume_factor;
-        if (value > 127)
-        {
-            value = 127;
-        }
 
         msg = MIDI_EVENT_CONTROLLER | i | (MIDI_CONTROLLER_MAIN_VOLUME << 8) |
               (value << 16);
@@ -479,7 +471,7 @@ boolean I_WIN_InitMusic(void)
 
 void I_WIN_SetMusicVolume(int volume)
 {
-    volume_factor = (float)volume / 100;
+    volume_factor = (float)volume / 120;
 
     UpdateVolume();
 }

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -144,6 +144,10 @@ static void FillBuffer(void)
             channel_volume[MIDIEVENT_CHANNEL(event->dwEvent)] = volume;
 
             volume *= volume_factor;
+            if (volume > 127)
+            {
+                volume = 127;
+            }
 
             event->dwEvent = (event->dwEvent & 0xFF00FFFF) |
                              ((volume & 0x7F) << 16);
@@ -338,6 +342,10 @@ static void UpdateVolume(void)
         DWORD msg = 0;
 
         int value = channel_volume[i] * volume_factor;
+        if (value > 127)
+        {
+            value = 127;
+        }
 
         msg = MIDI_EVENT_CONTROLLER | i | (MIDI_CONTROLLER_MAIN_VOLUME << 8) |
               (value << 16);
@@ -471,7 +479,7 @@ boolean I_WIN_InitMusic(void)
 
 void I_WIN_SetMusicVolume(int volume)
 {
-    volume_factor = (float)volume / 127;
+    volume_factor = (float)volume / 100;
 
     UpdateVolume();
 }


### PR DESCRIPTION
Edit: PR changed to be more conservative. See detailed post below.

<details><summary>Old Info</summary>
Music volume is too low compared to vanilla Doom. These changes make it identical to vanilla Doom but without the inconsistent way it handled volume for drums vs. other channels (see image). I think this was a bug in the DMX sound system. The PR can be updated if there is interest in preserving this behavior, but that would also affect channel balance for music in other wads.

![Untitled](https://user-images.githubusercontent.com/56656010/190604075-f06c5447-9eba-4c86-bce8-b282ed67f3a3.png)
</details>