### PR TITLE
Remove static qualifier from some Windows-only variables

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -19,12 +19,16 @@
 
 #include <windows.h>
 #include <mmsystem.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "doomtype.h"
 #include "m_misc.h"
 #include "midifile.h"
+#include "i_sound.h"
+#include "i_winmusic.h"
+
 
 #define BETWEEN(l,u,x) (((l)>(x))?(l):((x)>(u))?(u):(x))
 

--- a/src/i_winmusic.h
+++ b/src/i_winmusic.h
@@ -32,6 +32,6 @@ void I_WIN_UnRegisterSong(void);
 void I_WIN_ShutdownMusic(void);
 
 
-#endif
+#endif // _WIN32
 
-#endif
+#endif // __I_WINMUSIC__

--- a/src/i_winmusic.h
+++ b/src/i_winmusic.h
@@ -31,8 +31,6 @@ boolean I_WIN_RegisterSong(char* filename);
 void I_WIN_UnRegisterSong(void);
 void I_WIN_ShutdownMusic(void);
 
-extern int winmm_reverb_level;
-extern int winmm_chorus_level;
 
 #endif
 

--- a/src/i_winmusic.h
+++ b/src/i_winmusic.h
@@ -14,10 +14,10 @@
 // DESCRIPTION:
 //      Windows native MIDI
 
-#ifdef _WIN32
-
 #ifndef __I_WINMUSIC__
 #define __I_WINMUSIC__
+
+#ifdef _WIN32
 
 #include "doomtype.h"
 

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -82,8 +82,8 @@ static char **midi_names;
 static int midi_num_devices;
 static int midi_index;
 char *winmm_midi_device = NULL;
-static int winmm_reverb_level = 40;
-static int winmm_chorus_level = 0;
+int winmm_reverb_level = 40;
+int winmm_chorus_level = 0;
 #endif
 
 // DOS specific variables: these are unused but should be maintained


### PR DESCRIPTION
Might fix #1515. I don't test on Windows. We also don't seem to have it in our CI.
