### PR TITLE
heretic: Move spechit and numspechit extern declarations to p_local.h

### DIFF
--- a/src/heretic/p_enemy.c
+++ b/src/heretic/p_enemy.c
@@ -242,9 +242,6 @@ fixed_t xspeed[8] =
 fixed_t yspeed[8] =
     { 0, 47000, FRACUNIT, 47000, 0, -47000, -FRACUNIT, -47000 };
 
-#define	MAXSPECIALCROSS		8
-extern line_t *spechit[MAXSPECIALCROSS];
-extern int numspechit;
 
 boolean P_Move(mobj_t * actor)
 {

--- a/src/heretic/p_local.h
+++ b/src/heretic/p_local.h
@@ -243,6 +243,11 @@ void P_LineAttack(mobj_t * t1, angle_t angle, fixed_t distance, fixed_t slope,
 
 void P_RadiusAttack(mobj_t * spot, mobj_t * source, int damage);
 
+#define	MAXSPECIALCROSS		8
+extern line_t *spechit[MAXSPECIALCROSS];
+extern int numspechit;
+
+
 // ***** P_SETUP *****
 
 extern byte *rejectmatrix;      // for fast sight rejection


### PR DESCRIPTION
This is the one that conflicts with Crispy Heretic.
