### PR TITLE
heretic: Move R_ExecuteSetViewSize prototype to r_local.h

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -139,8 +139,6 @@ void DrawMessage(void)
 //
 //---------------------------------------------------------------------------
 
-void R_ExecuteSetViewSize(void);
-
 
 void D_Display(void)
 {

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -307,6 +307,7 @@ fixed_t R_PointToDist(fixed_t x, fixed_t y);
 fixed_t R_ScaleFromGlobalAngle(angle_t visangle);
 subsector_t *R_PointInSubsector(fixed_t x, fixed_t y);
 void R_AddPointToBox(int x, int y, fixed_t * box);
+void R_ExecuteSetViewSize(void);
 
 
 //


### PR DESCRIPTION
This conflicts with Crispy doom but should be easy to resolve. Also Crispy has added more copies of this prototype and those need to be removed to fix warnings.

We're hitting the point where we're getting lots of conflicts so the PRs will be really small.
