### PR TITLE
heretic: Move detailLevel extern declaration to r_local.h

### DIFF
--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -117,9 +117,6 @@ static void DrawSaveMenu(void);
 static void DrawSlider(Menu_t * menu, int item, int width, int slot);
 void MN_LoadSlotText(void);
 
-// External Data
-
-extern int detailLevel;
 
 // Public Data
 

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -294,6 +294,7 @@ extern fixed_t viewcos, viewsin;
 
 extern int detailshift;         // 0 = high, 1 = low
 
+extern int detailLevel;
 extern int screenblocks;
 
 extern void (*colfunc) (void);


### PR DESCRIPTION
Trivial conflict in Crispy and also causes a warning there because Crispy added another copy of the extern.
