### PR TITLE
heretic: Move ylookup extern declaration to r_local.h

### DIFF
--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -454,6 +454,8 @@ extern int dc_yh;
 extern fixed_t dc_iscale;
 extern fixed_t dc_texturemid;
 extern byte *dc_source;         // first pixel in a column
+extern byte *ylookup[MAXHEIGHT];
+
 
 void R_DrawColumn(void);
 void R_DrawColumnLow(void);

--- a/src/heretic/r_plane.c
+++ b/src/heretic/r_plane.c
@@ -381,8 +381,6 @@ void R_DrawPlanes(void)
     int count;
     fixed_t frac, fracstep;
 
-    extern byte *ylookup[MAXHEIGHT];
-
 #ifdef RANGECHECK
     if (ds_p - drawsegs > MAXDRAWSEGS)
         I_Error("R_DrawPlanes: drawsegs overflow (%td)",


### PR DESCRIPTION
Trivial conflict with Crispy
