### PR TITLE
Clean up extern in Doom, part 1

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -161,7 +161,6 @@ void D_ProcessEvents (void)
 
 // wipegamestate can be set to -1 to force a wipe on the next draw
 gamestate_t     wipegamestate = GS_DEMOSCREEN;
-extern  boolean setsizeneeded;
 void R_ExecuteSetViewSize (void);
 
 boolean D_Display (void)

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -161,7 +161,6 @@ void D_ProcessEvents (void)
 
 // wipegamestate can be set to -1 to force a wipe on the next draw
 gamestate_t     wipegamestate = GS_DEMOSCREEN;
-void R_ExecuteSetViewSize (void);
 
 boolean D_Display (void)
 {

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -162,7 +162,6 @@ void D_ProcessEvents (void)
 // wipegamestate can be set to -1 to force a wipe on the next draw
 gamestate_t     wipegamestate = GS_DEMOSCREEN;
 extern  boolean setsizeneeded;
-extern  int             showMessages;
 void R_ExecuteSetViewSize (void);
 
 boolean D_Display (void)

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -105,7 +105,6 @@ boolean         respawnparm;	// checkparm of -respawn
 boolean         fastparm;	// checkparm of -fast
 
 
-extern  boolean	inhelpscreens;
 
 skill_t		startskill;
 int             startepisode;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1462,7 +1462,6 @@ void D_DoomMain (void)
     if ( (p=M_CheckParm ("-turbo")) )
     {
 	int     scale = 200;
-	extern fixed_t forwardmove[2];
 	extern fixed_t sidemove[2];
 	
 	if (p<myargc-1)

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1462,7 +1462,6 @@ void D_DoomMain (void)
     if ( (p=M_CheckParm ("-turbo")) )
     {
 	int     scale = 200;
-	extern fixed_t sidemove[2];
 	
 	if (p<myargc-1)
 	    scale = atoi (myargv[p+1]);

--- a/src/doom/d_main.h
+++ b/src/doom/d_main.h
@@ -46,6 +46,8 @@ void D_StartTitle (void);
 extern  gameaction_t    gameaction;
 extern boolean advancedemo;
 
+extern const char *pagename;
+
 
 #endif
 

--- a/src/doom/d_main.h
+++ b/src/doom/d_main.h
@@ -44,6 +44,7 @@ void D_StartTitle (void);
 //
 
 extern  gameaction_t    gameaction;
+extern boolean advancedemo;
 
 
 #endif

--- a/src/doom/d_net.c
+++ b/src/doom/d_net.c
@@ -68,7 +68,6 @@ static void PlayerQuitGame(player_t *player)
 
 static void RunTic(ticcmd_t *cmds, boolean *ingame)
 {
-    extern boolean advancedemo;
     unsigned int i;
 
     // Check for player quits.

--- a/src/doom/f_finale.c
+++ b/src/doom/f_finale.c
@@ -222,7 +222,6 @@ void F_Ticker (void)
 //
 
 #include "hu_stuff.h"
-extern	patch_t *hu_font[HU_FONTSIZE];
 
 
 void F_TextWrite (void)

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1334,7 +1334,6 @@ static const int chexpars[6] =
 // G_DoCompleted 
 //
 boolean		secretexit; 
-extern const char *pagename;
  
 void G_ExitLevel (void) 
 { 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -941,7 +941,6 @@ void G_Ticker (void)
              && turbodetected[i])
             {
                 static char turbomessage[80];
-                extern const char *player_names[4];
                 M_snprintf(turbomessage, sizeof(turbomessage),
                            "%s is turbo!", player_names[i]);
                 players[consoleplayer].message = turbomessage;

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1569,7 +1569,6 @@ void G_DoWorldDone (void)
 // G_InitFromSavegame
 // Can be called by the startup code or the menu task. 
 //
-extern boolean setsizeneeded;
 void R_ExecuteSetViewSize (void);
 
 char	savename[256];

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1569,7 +1569,6 @@ void G_DoWorldDone (void)
 // G_InitFromSavegame
 // Can be called by the startup code or the menu task. 
 //
-void R_ExecuteSetViewSize (void);
 
 char	savename[256];
 

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -81,6 +81,8 @@ extern int vanilla_demo_limit;
 extern fixed_t forwardmove[2];
 extern fixed_t sidemove[2];
 
+extern boolean sendpause;
+
 
 #endif
 

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -77,5 +77,9 @@ int G_VanillaVersionCode(void);
 
 extern int vanilla_savegame_limit;
 extern int vanilla_demo_limit;
+
+extern fixed_t forwardmove[2];
+
+
 #endif
 

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -79,6 +79,7 @@ extern int vanilla_savegame_limit;
 extern int vanilla_demo_limit;
 
 extern fixed_t forwardmove[2];
+extern fixed_t sidemove[2];
 
 
 #endif

--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -91,7 +91,6 @@ static boolean		message_nottobefuckedwith;
 static hu_stext_t	w_message;
 static int		message_counter;
 
-extern int		showMessages;
 
 static boolean		headsupactive = false;
 

--- a/src/doom/hu_stuff.h
+++ b/src/doom/hu_stuff.h
@@ -61,6 +61,8 @@ extern patch_t *hu_font[HU_FONTSIZE];
 
 extern boolean message_dontfuckwithme;
 
+extern boolean chat_on;
+
 
 #endif
 

--- a/src/doom/hu_stuff.h
+++ b/src/doom/hu_stuff.h
@@ -59,6 +59,8 @@ extern char *chat_macros[10];
 
 extern patch_t *hu_font[HU_FONTSIZE];
 
+extern boolean message_dontfuckwithme;
+
 
 #endif
 

--- a/src/doom/hu_stuff.h
+++ b/src/doom/hu_stuff.h
@@ -56,5 +56,8 @@ void HU_Erase(void);
 
 extern char *chat_macros[10];
 
+extern patch_t *hu_font[HU_FONTSIZE];
+
+
 #endif
 

--- a/src/doom/hu_stuff.h
+++ b/src/doom/hu_stuff.h
@@ -54,6 +54,7 @@ void HU_Drawer(void);
 char HU_dequeueChatChar(void);
 void HU_Erase(void);
 
+extern const char *player_names[4];
 extern char *chat_macros[10];
 
 extern patch_t *hu_font[HU_FONTSIZE];

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -123,7 +123,6 @@ boolean			menuactive;
 #define SKULLXOFF		-32
 #define LINEHEIGHT		16
 
-extern boolean		sendpause;
 char			savegamestrings[10][SAVESTRINGSIZE];
 
 char	endstring[160];

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -61,8 +61,6 @@
 #include "m_menu.h"
 
 
-extern boolean		message_dontfuckwithme;
-
 extern boolean		chat_on;		// in heads-up code
 
 //

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -61,8 +61,6 @@
 #include "m_menu.h"
 
 
-extern boolean		chat_on;		// in heads-up code
-
 //
 // defaulted values
 //

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -61,7 +61,6 @@
 #include "m_menu.h"
 
 
-extern patch_t*		hu_font[HU_FONTSIZE];
 extern boolean		message_dontfuckwithme;
 
 extern boolean		chat_on;		// in heads-up code

--- a/src/doom/m_menu.h
+++ b/src/doom/m_menu.h
@@ -56,6 +56,7 @@ extern int detailLevel;
 extern int screenblocks;
 
 extern boolean inhelpscreens;
+extern int showMessages;
 
 
 #endif

--- a/src/doom/m_menu.h
+++ b/src/doom/m_menu.h
@@ -56,6 +56,7 @@ void M_StartControlPanel (void);
 extern int detailLevel;
 extern int screenblocks;
 
+extern  boolean	inhelpscreens;
 
 
 #endif    

--- a/src/doom/m_menu.h
+++ b/src/doom/m_menu.h
@@ -52,11 +52,10 @@ void M_Init (void);
 void M_StartControlPanel (void);
 
 
-
 extern int detailLevel;
 extern int screenblocks;
 
-extern  boolean	inhelpscreens;
+extern boolean inhelpscreens;
 
 
-#endif    
+#endif

--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -233,6 +233,10 @@ boolean P_ChangeSector (sector_t* sector, boolean crunch);
 
 extern mobj_t*	linetarget;	// who got hit (or NULL)
 
+
+extern fixed_t attackrange;
+
+
 fixed_t
 P_AimLineAttack
 ( mobj_t*	t1,

--- a/src/doom/p_maputl.c
+++ b/src/doom/p_maputl.c
@@ -728,7 +728,6 @@ P_TraverseIntercepts
     return true;		// everything was traversed
 }
 
-extern fixed_t bulletslope;
 
 // Intercepts Overrun emulation, from PrBoom-plus.
 // Thanks to Andrey Budko (entryway) for researching this and his 

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -865,7 +865,6 @@ void P_SpawnMapThing (mapthing_t* mthing)
 //
 // P_SpawnPuff
 //
-extern fixed_t attackrange;
 
 void
 P_SpawnPuff

--- a/src/doom/p_pspr.h
+++ b/src/doom/p_pspr.h
@@ -68,4 +68,8 @@ typedef struct
 
 } pspdef_t;
 
+
+extern fixed_t bulletslope;
+
+
 #endif

--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -1192,8 +1192,6 @@ static void DonutOverrun(fixed_t *s3_floorheight, short *s3_floorpic,
     static int tmp_s3_floorheight;
     static int tmp_s3_floorpic;
 
-    extern int numflats;
-
     if (first)
     {
         int p;

--- a/src/doom/r_data.h
+++ b/src/doom/r_data.h
@@ -48,4 +48,8 @@ int R_FlatNumForName(const char *name);
 int R_TextureNumForName(const char *name);
 int R_CheckTextureNumForName(const char *name);
 
+
+extern int numflats;
+
+
 #endif

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -51,7 +51,6 @@ int			validcount = 1;
 
 
 lighttable_t*		fixedcolormap;
-extern lighttable_t**	walllights;
 
 int			centerx;
 int			centery;

--- a/src/doom/r_main.h
+++ b/src/doom/r_main.h
@@ -159,4 +159,7 @@ void R_Init (void);
 // Called by M_Responder.
 void R_SetViewSize (int blocks, int detail);
 
+void R_ExecuteSetViewSize(void);
+
+
 #endif

--- a/src/doom/r_main.h
+++ b/src/doom/r_main.h
@@ -49,6 +49,8 @@ extern int		validcount;
 extern int		linecount;
 extern int		loopcount;
 
+extern  boolean setsizeneeded;
+
 
 //
 // Lighting LUT.

--- a/src/doom/r_segs.h
+++ b/src/doom/r_segs.h
@@ -21,6 +21,7 @@
 #define __R_SEGS__
 
 
+extern lighttable_t **walllights;
 
 
 void


### PR DESCRIPTION
The bits that don't conflict with Crispy. This was surprisingly most of them. Causes two warnings though because Crispy added even more externs.
