### PR TITLE
clang-format: Set SpaceAfterCStyleCast to true

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -115,7 +115,7 @@ PointerAlignment: Right
 ReflowComments:  false
 SortIncludes:    false
 SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
+SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true


### PR DESCRIPTION
To match what's specified in HACKING.md
