### PR TITLE
Clean up extern in doom, part inf

### DIFF
--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -236,6 +236,10 @@ extern mobj_t*	linetarget;	// who got hit (or NULL)
 
 extern fixed_t attackrange;
 
+// slopes to top and bottom of target
+extern fixed_t	topslope;
+extern fixed_t	bottomslope;
+
 
 fixed_t
 P_AimLineAttack

--- a/src/doom/p_map.c
+++ b/src/doom/p_map.c
@@ -830,10 +830,6 @@ fixed_t		attackrange;
 
 fixed_t		aimslope;
 
-// slopes to top and bottom of target
-extern fixed_t	topslope;
-extern fixed_t	bottomslope;	
-
 
 //
 // PTR_AimTraverse


### PR DESCRIPTION
The final `extern` in a header in Doom and the whole codebase :tada: 

Trivial conflict with Crispy and also redundant `extern`s after.
