### PR TITLE
-nomonsters and -respawn for v1.2 demo playback

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2240,6 +2240,10 @@ void G_DoPlayDemo (void)
         fastparm = 0;
         nomonsters = 0;
         consoleplayer = 0;
+
+        // Ability to force -nomonsters and -respawn for playback of v1.2 demos
+        respawnparm = M_CheckParm("-respawn");
+        nomonsters = M_CheckParm("-nomonsters");
     }
     
         


### PR DESCRIPTION
v1.2 introduced "-nomonsters" and "-respawn" switches, however the demo header was not expanded to accommodate the corresponding settings until v1.4. Thus the only way to play back correctly any v1.2 demo recorded with these switches is by adding them on the command line.

An example of a v1.2 -nomonsters demo: MESH.LMP for MESH.WAD in [mesh.zip](https://www.doomworld.com/idgames/levels/doom/m-o/mesh) on /idgames. This example is referenced in the corresponding section of Prboom-plus' g_game.c.