### PR TITLE
Disable sector special 17 in gameversion 1.2

### DIFF
--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -1467,7 +1467,11 @@ void P_SpawnSpecials (void)
 	    break;
 	    
 	  case 17:
-	    P_SpawnFireFlicker(sector);
+	    // first introduced in official v1.4 beta
+	    if (gameversion > exe_doom_1_2)
+	    {
+	        P_SpawnFireFlicker(sector);
+	    }
 	    break;
 	}
     }

--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -1466,13 +1466,13 @@ void P_SpawnSpecials (void)
 	    P_SpawnDoorRaiseIn5Mins (sector, i);
 	    break;
 	    
-	  case 17:
-	    // first introduced in official v1.4 beta
-	    if (gameversion > exe_doom_1_2)
-	    {
-	        P_SpawnFireFlicker(sector);
-	    }
-	    break;
+      case 17:
+        // first introduced in official v1.4 beta
+        if (gameversion > exe_doom_1_2)
+        {
+            P_SpawnFireFlicker(sector);
+        }
+      break;
 	}
     }
 


### PR DESCRIPTION
The first vanilla exec to support sector special 17 (random flicker) was the official v1.4 beta. Disabling it for -gameversion 1.2 solves the desync on DEMO1 of CHURCH.WAD. Fixes #1529.