### PR TITLE
Disable sector special 17 in gameversion 1.2

### DIFF
--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -1466,9 +1466,13 @@ void P_SpawnSpecials (void)
 	    P_SpawnDoorRaiseIn5Mins (sector, i);
 	    break;
 	    
-	  case 17:
-	    P_SpawnFireFlicker(sector);
-	    break;
+      case 17:
+        // first introduced in official v1.4 beta
+        if (gameversion > exe_doom_1_2)
+        {
+            P_SpawnFireFlicker(sector);
+        }
+        break;
 	}
     }
 

--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -1466,13 +1466,13 @@ void P_SpawnSpecials (void)
 	    P_SpawnDoorRaiseIn5Mins (sector, i);
 	    break;
 	    
-      case 17:
-        // first introduced in official v1.4 beta
-        if (gameversion > exe_doom_1_2)
-        {
-            P_SpawnFireFlicker(sector);
-        }
-        break;
+        case 17:
+            // first introduced in official v1.4 beta
+            if (gameversion > exe_doom_1_2)
+            {
+                P_SpawnFireFlicker(sector);
+            }
+            break;
 	}
     }
 


### PR DESCRIPTION
The first vanilla exec to support sector special 17 (random flicker) was the official v1.4 beta. Disabling it for -gameversion 1.2 solves the desync on DEMO1 of CHURCH.WAD. Fixes #1529.

@turol: I hope I got the formatting right this time. The thing that threw me off was that almost the whole of P_SpawnSpecials is indented with TABs. Hmm, of the 1500+ lines of p_spec.c over 600 are that way. 

>Have you tested that it doesn't break any other version demos?

I don't see how it could affect anything but v1.2 compat, but since you asked I did some research. Here are a few D1 WADs with that special that have demos on DSDA:
- [02WHAT](https://dsdarchive.com/wads/02what) 4:36
- [AMAZED](https://dsdarchive.com/wads/amazed2) 4:26
- [BASETR1](https://dsdarchive.com/wads/basetr1) 1:46
- [CALGON](https://dsdarchive.com/wads/calgon)  16:32
- [CHURCH](https://dsdarchive.com/wads/church_1995) 12:09
- [WASTE](https://dsdarchive.com/wads/waste) own demos for E2M3, E2M5-E2M7 (nine in all)

all v1.9-format/UDoom-compat, no desyncs. 