### PR TITLE
win midi: Reduce messages sent on startup/reset

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -122,6 +122,7 @@ typedef struct
     unsigned int elapsed_time;
     unsigned int saved_elapsed_time;
     unsigned int num_tracks;
+    boolean registered;
     boolean looping;
     boolean ff_loop;
     boolean ff_restart;
@@ -1226,7 +1227,7 @@ static void I_WIN_SetMusicVolume(int volume)
 
     volume_factor = sqrtf((float)volume / 120);
 
-    update_volume = true;
+    update_volume = song.registered;
 }
 
 static void I_WIN_StopSong(void)
@@ -1392,6 +1393,7 @@ static void *I_WIN_RegisterSong(void *data, int len)
     {
         song.tracks[i].iter = MIDI_IterateTrack(file, i);
     }
+    song.registered = true;
 
     ResetEvent(hBufferReturnEvent);
     ResetEvent(hExitEvent);
@@ -1419,6 +1421,7 @@ static void I_WIN_UnRegisterSong(void *handle)
     song.elapsed_time = 0;
     song.saved_elapsed_time = 0;
     song.num_tracks = 0;
+    song.registered = false;
     song.looping = false;
     song.ff_loop = false;
     song.ff_restart = false;

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -82,8 +82,8 @@ static char **midi_names;
 static int midi_num_devices;
 static int midi_index;
 char *winmm_midi_device = NULL;
-int winmm_reverb_level = 40;
-int winmm_chorus_level = 0;
+int winmm_reverb_level = -1;
+int winmm_chorus_level = -1;
 #endif
 
 // DOS specific variables: these are unused but should be maintained


### PR DESCRIPTION
**Reverb/chorus:**
These should be left at -1 by default so they're not sent to the MIDI device during a reset unless the user has specified a custom value or if they've set SysEx reset to none. Every message that's sent during the reset process requires time for older devices to respond (e.g. Roland SC-55, Yamaha MU80) so it's best to minimize this whenever possible.

**Volume:**
For the same reason, this should not be sent to each channel twice on startup and there's no reason to send it before a song has been registered.