### PR TITLE
win midi: Add missing default values

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -40,6 +40,7 @@ int winmm_chorus_level = -1;
 
 enum
 {
+    RESET_TYPE_DEFAULT = -1,
     RESET_TYPE_NONE,
     RESET_TYPE_GS,
     RESET_TYPE_GM,
@@ -47,7 +48,7 @@ enum
     RESET_TYPE_XG,
 };
 
-int winmm_reset_type = RESET_TYPE_GS;
+int winmm_reset_type = RESET_TYPE_DEFAULT;
 int winmm_reset_delay = 0;
 
 static const byte gs_reset[] = {

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -82,6 +82,8 @@ static char **midi_names;
 static int midi_num_devices;
 static int midi_index;
 char *winmm_midi_device = NULL;
+int winmm_reset_type = -1;
+int winmm_reset_delay = 0;
 int winmm_reverb_level = -1;
 int winmm_chorus_level = -1;
 #endif
@@ -339,6 +341,8 @@ void BindSoundVariables(void)
     M_BindStringVariable("fluidsynth_sf_path",    &fluidsynth_sf_path);
 #ifdef _WIN32
     M_BindStringVariable("winmm_midi_device",     &winmm_midi_device);
+    M_BindIntVariable("winmm_reset_type",         &winmm_reset_type);
+    M_BindIntVariable("winmm_reset_delay",        &winmm_reset_delay);
     M_BindIntVariable("winmm_reverb_level",       &winmm_reverb_level);
     M_BindIntVariable("winmm_chorus_level",       &winmm_chorus_level);
 #endif


### PR DESCRIPTION
The values `winmm_reset_type` and `winmm_reset_delay` were lost every time setup was run.