### PR TITLE
doom: Fix mouse event causing unwanted key press

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1478,7 +1478,7 @@ boolean M_Responder (event_t* ev)
     }
     else
     {
-	if (ev->type == ev_mouse && mousewait < I_GetTime())
+	if (ev->type == ev_mouse && mousewait < I_GetTime() && menuactive)
 	{
 	    mousey += ev->data3;
 	    if (mousey < lasty-30)


### PR DESCRIPTION
If a particular in-game action and an in-menu action share a common keybind, then the mouse event which also causes that in-menu action will trigger the in-game action when outside of the menus. Add check to prevent this from happening.

Fixes #1569.