### PR TITLE
Add -display command line parameter

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1032,6 +1032,24 @@ void I_GraphicsCheckCommandLine(void)
 
     //!
     // @category video
+    // @arg <x>
+    //
+    // Specify the display number on which to show the screen.
+    //
+
+    i = M_CheckParmWithArgs("-display", 1);
+
+    if (i > 0)
+    {
+        int display = atoi(myargv[i + 1]);
+        if (display >= 0)
+        {
+            video_display = display;
+        }
+    }
+
+    //!
+    // @category video
     //
     // Don't scale up the screen. Implies -window.
     //


### PR DESCRIPTION
I added the command line param (-display x) which makes it easier to switch the display the game is show on in the multi-display environment. 
I originally opened PR in the crispy-doom fork, but it was moved upstream: https://github.com/fabiangreffrath/crispy-doom/pull/994

cc: @fabiangreffrath 