### PR TITLE
Sound cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 
 # Check for FluidSynth.
 find_package(FluidSynth 2.2.0)
-if(FluidSynth_FOUND)
+if(FluidSynth_FOUND AND ENABLE_SDL2_MIXER)
     set(HAVE_FLUIDSYNTH TRUE)
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ AS_HELP_STRING([--without-fluidsynth],
 [
     [with_fluidsynth=check]
 ])
-AS_IF([test "x$with_fluidsynth" != xno], [
+AS_IF([test "x$with_fluidsynth" != xno] && [test "x$enable_sdl2mixer" != xno], [
     PKG_CHECK_MODULES(FLUIDSYNTH, fluidsynth >= 2.2.0, [
         AC_DEFINE([HAVE_FLUIDSYNTH], [1], [fluidsynth installed])
     ], [

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -268,12 +268,12 @@ static boolean I_FL_MusicIsPlaying(void)
     return (fluid_player_get_status(player) == FLUID_PLAYER_PLAYING);
 }
 
-static snddevice_t music_fl_devices[] =
+static const snddevice_t music_fl_devices[] =
 {
     SNDDEVICE_FSYNTH,
 };
 
-music_module_t music_fl_module =
+const music_module_t music_fl_module =
 {
     music_fl_devices,
     arrlen(music_fl_devices),

--- a/src/i_musicpack.c
+++ b/src/i_musicpack.c
@@ -1397,7 +1397,7 @@ static void I_MP_PollMusic(void)
 #endif // !USE_SDL_MIXER_LOOPING
 }
 
-music_module_t music_pack_module =
+const music_module_t music_pack_module =
 {
     NULL,
     0,
@@ -1475,7 +1475,7 @@ static void I_NULL_PollMusic(void)
 {
 }
 
-music_module_t music_pack_module =
+const music_module_t music_pack_module =
 {
     NULL,
     0,

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1771,13 +1771,13 @@ static boolean I_OPL_InitMusic(void)
     return true;
 }
 
-static snddevice_t music_opl_devices[] =
+const static snddevice_t music_opl_devices[] =
 {
     SNDDEVICE_ADLIB,
     SNDDEVICE_SB,
 };
 
-music_module_t music_opl_module =
+const music_module_t music_opl_module =
 {
     music_opl_devices,
     arrlen(music_opl_devices),

--- a/src/i_pcsound.c
+++ b/src/i_pcsound.c
@@ -310,12 +310,12 @@ void I_PCS_UpdateSoundParams(int channel, int vol, int sep)
     // no-op.
 }
 
-static snddevice_t sound_pcsound_devices[] = 
+static const snddevice_t sound_pcsound_devices[] =
 {
     SNDDEVICE_PCSPEAKER,
 };
 
-sound_module_t sound_pcsound_module = 
+const sound_module_t sound_pcsound_module =
 {
     sound_pcsound_devices,
     arrlen(sound_pcsound_devices),

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -430,7 +430,7 @@ static boolean I_SDL_MusicIsPlaying(void)
     return Mix_PlayingMusic();
 }
 
-static snddevice_t music_sdl_devices[] =
+static const snddevice_t music_sdl_devices[] =
 {
     SNDDEVICE_PAS,
     SNDDEVICE_GUS,
@@ -440,7 +440,7 @@ static snddevice_t music_sdl_devices[] =
     SNDDEVICE_AWE32,
 };
 
-music_module_t music_sdl_module =
+const music_module_t music_sdl_module =
 {
     music_sdl_devices,
     arrlen(music_sdl_devices),

--- a/src/i_sdlsound.c
+++ b/src/i_sdlsound.c
@@ -1116,7 +1116,7 @@ static boolean I_SDL_InitSound(boolean _use_sfx_prefix)
     return true;
 }
 
-static snddevice_t sound_sdl_devices[] = 
+static const snddevice_t sound_sdl_devices[] =
 {
     SNDDEVICE_SB,
     SNDDEVICE_PAS,
@@ -1126,7 +1126,7 @@ static snddevice_t sound_sdl_devices[] =
     SNDDEVICE_AWE32,
 };
 
-sound_module_t sound_sdl_module = 
+const sound_module_t sound_sdl_module =
 {
     sound_sdl_devices,
     arrlen(sound_sdl_devices),

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -56,15 +56,15 @@ int snd_musicdevice = SNDDEVICE_SB;
 int snd_sfxdevice = SNDDEVICE_SB;
 
 // Low-level sound and music modules we are using
-static sound_module_t *sound_module;
-static music_module_t *music_module;
+static const sound_module_t *sound_module;
+static const music_module_t *music_module;
 
 // If true, the music pack module was successfully initialized.
 static boolean music_packs_active = false;
 
 // This is either equal to music_module or &music_pack_module,
 // depending on whether the current track is substituted.
-static music_module_t *active_music_module;
+static const music_module_t *active_music_module;
 
 
 // DOS-specific options: These are unused but should be maintained
@@ -78,7 +78,7 @@ static int snd_mport = 0;
 
 // Compiled-in sound modules:
 
-static sound_module_t *sound_modules[] = 
+static const sound_module_t *sound_modules[] =
 {
 #ifndef DISABLE_SDL2MIXER
     &sound_sdl_module,
@@ -89,7 +89,7 @@ static sound_module_t *sound_modules[] =
 
 // Compiled-in music modules:
 
-static music_module_t *music_modules[] =
+static const music_module_t *music_modules[] =
 {
 #ifdef _WIN32
     &music_win_module,
@@ -106,7 +106,7 @@ static music_module_t *music_modules[] =
 
 // Check if a sound device is in the given list of devices
 
-static boolean SndDeviceInList(snddevice_t device, snddevice_t *list,
+static boolean SndDeviceInList(snddevice_t device, const snddevice_t *list,
                                int len)
 {
     int i;

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -109,7 +109,7 @@ typedef struct
 {
     // List of sound devices that this sound module is used for.
 
-    snddevice_t *sound_devices;
+    const snddevice_t *sound_devices;
     int num_sound_devices;
 
     // Initialise sound module
@@ -168,7 +168,7 @@ typedef struct
 {
     // List of sound devices that this music module is used for.
 
-    snddevice_t *sound_devices;
+    const snddevice_t *sound_devices;
     int num_sound_devices;
 
     // Initialise the music subsystem
@@ -254,13 +254,13 @@ void I_OPL_DevMessages(char *, size_t);
 // Sound modules
 
 void I_InitTimidityConfig(void);
-extern sound_module_t sound_sdl_module;
-extern sound_module_t sound_pcsound_module;
-extern music_module_t music_sdl_module;
-extern music_module_t music_opl_module;
-extern music_module_t music_pack_module;
-extern music_module_t music_win_module;
-extern music_module_t music_fl_module;
+extern const sound_module_t sound_sdl_module;
+extern const sound_module_t sound_pcsound_module;
+extern const music_module_t music_sdl_module;
+extern const music_module_t music_opl_module;
+extern const music_module_t music_pack_module;
+extern const music_module_t music_win_module;
+extern const music_module_t music_fl_module;
 
 // For OPL module:
 


### PR DESCRIPTION
1. FluidSynth requires SDL2_Mixer so also disable it when SDL2_Mixer is disabled.
2. Apply `const` to sound and music device definitions.
