### PR TITLE
Add windows msys2 build to CI

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,0 +1,72 @@
+name: msys2
+
+on:
+  push:
+    branches:
+      - "master"
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+
+    steps:
+      - name: Install pandoc
+        shell: cmd
+        run: choco install pandoc
+
+      - name: Extract Version Number
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF##*-}" >> $GITHUB_ENV
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: ${{ matrix.sys }}
+          path-type: inherit
+          install: >-
+            autotools
+            zip
+            mingw-w64-${{matrix.env}}-gcc
+            mingw-w64-${{matrix.env}}-SDL2
+            mingw-w64-${{matrix.env}}-SDL2_mixer
+            mingw-w64-${{matrix.env}}-SDL2_net
+            mingw-w64-${{matrix.env}}-libpng
+            mingw-w64-${{matrix.env}}-libsamplerate
+            mingw-w64-${{matrix.env}}-fluidsynth
+
+      - uses: actions/checkout@v3
+
+      - name: Configure
+        run: |
+          ./autogen.sh
+
+      - name: Build
+        run: make -j4
+
+      - name: Package
+        run: |
+          cd pkg/win32
+          make
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Win-${{ matrix.env }}
+          path: pkg/win32/*.zip


### PR DESCRIPTION
Mostly copied from Crispy Doom. This should fail for now because of mismatching `const` in sound code.
