### PR TITLE
Fix automake distcheck issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,9 +54,9 @@ DIST_SUBDIRS=pkg $(SUBDIRS)
 if HAVE_DOC
 
 INSTALL : man/INSTALL.template man/simplecpp
-	./man/simplecpp -DDOOM -DHERETIC -DHEXEN -DSTRIFE \
+	$(srcdir)/man/simplecpp -DDOOM -DHERETIC -DHEXEN -DSTRIFE \
             -DLONG_GAME_NAME="@PACKAGE_SHORTNAME@ Doom" \
             -DLONG_EXE_NAME="@PROGRAM_PREFIX@doom" \
-	                < man/INSTALL.template > $@
+	                < $(srcdir)/man/INSTALL.template > $@
 
 endif

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -8,7 +8,9 @@ MANPAGE_GEN_FILES = environ.man           \
                     strife.template       \
                     docgen                \
                     default.cfg.template  \
-                    extra.cfg.template
+                    extra.cfg.template    \
+                    server.template       \
+                    setup.template
 
 doomdocsdir = ${docdir}/../${PROGRAM_PREFIX}doom
 hereticdocsdir = ${docdir}/../${PROGRAM_PREFIX}heretic

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -277,7 +277,7 @@ screensaver_DATA = @PACKAGE_RDNS@.Doom_Screensaver.desktop
 @PACKAGE_RDNS@.Doom_Screensaver.desktop: Doom_Screensaver.desktop
 	cp Doom_Screensaver.desktop $@
 
-CLEANFILES = $(execgames_SCRIPTS) $(app_DATA) $(screensaver_DATA)
+CLEANFILES = $(execgames_SCRIPTS) $(metainfo_DATA) $(app_DATA) $(screensaver_DATA)
 
 .rc.o:
 	$(WINDRES) $< -o $@


### PR DESCRIPTION
There were three issues:
1) `INSTALL` target in the top-level makefile didn't use `srcdir`.
2) `server.template` and `setup.template` weren't included in the tarball.
3) `metainfo.xml` files weren't deleted by `make clean`.