### PR TITLE
Fix new compiler warnings

### DIFF
--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -782,7 +782,7 @@ void R_SortVisSprites (void)
     int			count;
     vissprite_t*	ds;
     vissprite_t*	best;
-    vissprite_t		unsorted;
+    static vissprite_t		unsorted;
     fixed_t		bestscale;
 
     count = vissprite_p - vissprites;

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -782,7 +782,7 @@ void R_SortVisSprites (void)
     int			count;
     vissprite_t*	ds;
     vissprite_t*	best;
-    static vissprite_t		unsorted;
+    static vissprite_t	unsorted;
     fixed_t		bestscale;
 
     count = vissprite_p - vissprites;

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -818,7 +818,7 @@ void R_SortVisSprites(void)
 {
     int i, count;
     vissprite_t *ds, *best;
-    vissprite_t unsorted;
+    static vissprite_t unsorted;
     fixed_t bestscale;
 
     count = vissprite_p - vissprites;

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -845,7 +845,7 @@ void R_SortVisSprites(void)
 {
     int i, count;
     vissprite_t *ds, *best;
-    vissprite_t unsorted;
+    static vissprite_t unsorted;
     fixed_t bestscale;
 
     count = vissprite_p - vissprites;

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -867,7 +867,7 @@ void R_SortVisSprites (void)
     int			count;
     vissprite_t*	ds;
     vissprite_t*	best;
-    vissprite_t		unsorted;
+    static vissprite_t		unsorted;
     fixed_t		bestscale;
 
     count = vissprite_p - vissprites;

--- a/src/strife/r_things.c
+++ b/src/strife/r_things.c
@@ -867,7 +867,7 @@ void R_SortVisSprites (void)
     int			count;
     vissprite_t*	ds;
     vissprite_t*	best;
-    static vissprite_t		unsorted;
+    static vissprite_t	unsorted;
     fixed_t		bestscale;
 
     count = vissprite_p - vissprites;


### PR DESCRIPTION
Starting from yesterday's evening I've got an extra compiler warnings:

<details>

```
[1/3] Building C object src/doom/CMakeFiles/doom.dir/r_things.c.obj
C:/JN/MSYS/home/Julia/chocolate-doom/src/doom/r_things.c: In function 'R_SortVisSprites':
C:/JN/MSYS/home/Julia/chocolate-doom/src/doom/r_things.c:803:27: warning: storing the address of local variable 'unsorted' in '*vissprite_p.130_8 + 18446744073709551536.next' [-Wdangling-pointer=]
  803 |     (vissprite_p-1)->next = &unsorted;
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
C:/JN/MSYS/home/Julia/chocolate-doom/src/doom/r_things.c:785:25: note: 'unsorted' declared here
  785 |     vissprite_t         unsorted;
      |                         ^~~~~~~~
C:/JN/MSYS/home/Julia/chocolate-doom/src/doom/r_things.c:282:17: note: 'vissprite_p' declared here
  282 | vissprite_t*    vissprite_p;
      |                 ^~~~~~~~~~~
C:/JN/MSYS/home/Julia/chocolate-doom/src/doom/r_things.c:801:24: warning: storing the address of local variable 'unsorted' in 'vissprites[0].prev' [-Wdangling-pointer=]
  801 |     vissprites[0].prev = &unsorted;
      |     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
C:/JN/MSYS/home/Julia/chocolate-doom/src/doom/r_things.c:785:25: note: 'unsorted' declared here
  785 |     vissprite_t         unsorted;
      |                         ^~~~~~~~
C:/JN/MSYS/home/Julia/chocolate-doom/src/doom/r_things.c:281:17: note: 'vissprites' declared here
  281 | vissprite_t     vissprites[MAXVISSPRITES];
      |                 ^~~~~~~~~~
[3/3] Linking C executable src\chocolate-doom.exe
```

</details>

Strangely enough, this is happening only in MinGW64, not in MinGW32 or Clang64. 

First idea was to move `vissprite_t unsorted` outside of `R_SortVisSprites`, but @rfomin suggested a static declaration inside of function. Both approaches seems to be working, but we don't know what is better in this case, and is it safe to apply at all. Suggestions and corrections are highly appriciated.