### PR TITLE
Add missing `video_display` to setup

### DIFF
--- a/src/setup/display.c
+++ b/src/setup/display.c
@@ -64,6 +64,7 @@ static window_size_t window_sizes_scaled[] =
 
 static char *video_driver = "";
 static char *window_position = "";
+static int video_display = 0;
 static int aspect_ratio_correct = 1;
 static int integer_scaling = 0;
 static int vga_porch_flash = 0;
@@ -250,6 +251,7 @@ void ConfigDisplay(TXT_UNCAST_ARG(widget), void *user_data)
 
 void BindDisplayVariables(void)
 {
+    M_BindIntVariable("video_display",             &video_display);
     M_BindIntVariable("aspect_ratio_correct",      &aspect_ratio_correct);
     M_BindIntVariable("integer_scaling",           &integer_scaling);
     M_BindIntVariable("fullscreen",                &fullscreen);


### PR DESCRIPTION
The `video_display` key was lost every time setup was run.