### PR TITLE
win midi: Prevent hanging notes when pausing game

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1271,8 +1271,7 @@ static void FillBuffer(void)
             StreamOut();
             return;
 
-        default:
-            // Stopped or unknown state.
+        case STATE_STOPPED:
             return;
     }
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -80,6 +80,7 @@ typedef enum
 {
     STATE_STOPPED,
     STATE_PLAYING,
+    STATE_PAUSE,
     STATE_PAUSED
 } win_midi_state_t;
 
@@ -1252,7 +1253,7 @@ static void FillBuffer(void)
         return;
     }
 
-    if (win_midi_state == STATE_STOPPED)
+    if (win_midi_state == STATE_PAUSE)
     {
         StopSound();
         StreamOut();
@@ -1432,6 +1433,8 @@ static boolean I_WIN_InitMusic(void)
                                                     : AddToBuffer_Standard;
     MIDI_InitFallback();
 
+    win_midi_state = STATE_STOPPED;
+
     return true;
 }
 
@@ -1461,6 +1464,7 @@ static void I_WIN_StopSong(void)
         return;
     }
 
+    win_midi_state = STATE_STOPPED;
     SetEvent(hExitEvent);
     WaitForSingleObject(hPlayerThread, PLAYER_THREAD_WAIT_TIME);
     CloseHandle(hPlayerThread);
@@ -1512,7 +1516,7 @@ static void I_WIN_PauseSong(void)
         return;
     }
 
-    win_midi_state = STATE_STOPPED;
+    win_midi_state = STATE_PAUSE;
 }
 
 static void I_WIN_ResumeSong(void)

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1253,20 +1253,27 @@ static void FillBuffer(void)
         return;
     }
 
-    if (win_midi_state == STATE_PAUSE)
+    switch ((int) win_midi_state)
     {
-        StopSound();
-        StreamOut();
-        win_midi_state = STATE_PAUSED;
-        return;
-    }
+        case STATE_PLAYING:
+            break;
 
-    if (win_midi_state == STATE_PAUSED)
-    {
-        // Send a NOP every 100 ms while paused.
-        SendDelayMsg(100);
-        StreamOut();
-        return;
+        case STATE_PAUSE:
+            // Stop sound to prevent hanging notes.
+            StopSound();
+            StreamOut();
+            win_midi_state = STATE_PAUSED;
+            return;
+
+        case STATE_PAUSED:
+            // Send a NOP every 100 ms while paused.
+            SendDelayMsg(100);
+            StreamOut();
+            return;
+
+        default:
+            // Stopped or unknown state.
+            return;
     }
 
     for (num_events = 0; num_events < STREAM_MAX_EVENTS; )

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -78,8 +78,8 @@ static boolean update_volume = false;
 
 typedef enum
 {
-    STATE_PLAYING,
     STATE_STOPPED,
+    STATE_PLAYING,
     STATE_PAUSED
 } player_state_t;
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -81,9 +81,9 @@ typedef enum
     STATE_STOPPED,
     STATE_PLAYING,
     STATE_PAUSED
-} player_state_t;
+} win_midi_state_t;
 
-static player_state_t player_state;
+static win_midi_state_t win_midi_state;
 
 static DWORD timediv;
 static DWORD tempo;
@@ -1252,15 +1252,15 @@ static void FillBuffer(void)
         return;
     }
 
-    if (player_state == STATE_STOPPED)
+    if (win_midi_state == STATE_STOPPED)
     {
         StopSound();
         StreamOut();
-        player_state = STATE_PAUSED;
+        win_midi_state = STATE_PAUSED;
         return;
     }
 
-    if (player_state == STATE_PAUSED)
+    if (win_midi_state == STATE_PAUSED)
     {
         // Send a NOP every 100 ms while paused.
         SendDelayMsg(100);
@@ -1494,7 +1494,7 @@ static void I_WIN_PlaySong(void *handle, boolean looping)
     SetThreadPriority(hPlayerThread, THREAD_PRIORITY_TIME_CRITICAL);
 
     initial_playback = true;
-    player_state = STATE_PLAYING;
+    win_midi_state = STATE_PLAYING;
 
     SetEvent(hBufferReturnEvent);
 
@@ -1512,7 +1512,7 @@ static void I_WIN_PauseSong(void)
         return;
     }
 
-    player_state = STATE_STOPPED;
+    win_midi_state = STATE_STOPPED;
 }
 
 static void I_WIN_ResumeSong(void)
@@ -1522,7 +1522,7 @@ static void I_WIN_ResumeSong(void)
         return;
     }
 
-    player_state = STATE_PLAYING;
+    win_midi_state = STATE_PLAYING;
 }
 
 // Determine whether memory block is a .mid file 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1253,7 +1253,7 @@ static void FillBuffer(void)
         return;
     }
 
-    switch ((int) win_midi_state)
+    switch (win_midi_state)
     {
         case STATE_PLAYING:
             break;

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -367,7 +367,7 @@ static void ResetVolume(void)
     }
 }
 
-static void StopSound(void)
+static void SendNotesSoundOff(void)
 {
     int i;
 
@@ -417,8 +417,8 @@ static void ResetPitchBendSensitivity(void)
 
 static void ResetDevice(void)
 {
-    // Stop sound prior to reset to prevent volume spikes.
-    StopSound();
+    // Send notes/sound off prior to reset to prevent volume spikes.
+    SendNotesSoundOff();
 
     MIDI_ResetFallback();
     use_fallback = false;
@@ -1259,8 +1259,8 @@ static void FillBuffer(void)
             break;
 
         case STATE_PAUSE:
-            // Stop sound to prevent hanging notes.
-            StopSound();
+            // Send notes/sound off to prevent hanging notes.
+            SendNotesSoundOff();
             StreamOut();
             win_midi_state = STATE_PAUSED;
             return;

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -80,7 +80,7 @@ typedef enum
 {
     STATE_STOPPED,
     STATE_PLAYING,
-    STATE_PAUSE,
+    STATE_PAUSING,
     STATE_PAUSED
 } win_midi_state_t;
 
@@ -1258,7 +1258,7 @@ static void FillBuffer(void)
         case STATE_PLAYING:
             break;
 
-        case STATE_PAUSE:
+        case STATE_PAUSING:
             // Send notes/sound off to prevent hanging notes.
             SendNotesSoundOff();
             StreamOut();
@@ -1523,7 +1523,7 @@ static void I_WIN_PauseSong(void)
         return;
     }
 
-    win_midi_state = STATE_PAUSE;
+    win_midi_state = STATE_PAUSING;
 }
 
 static void I_WIN_ResumeSong(void)

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1471,11 +1471,11 @@ static void I_WIN_StopSong(void)
         return;
     }
 
-    win_midi_state = STATE_STOPPED;
     SetEvent(hExitEvent);
     WaitForSingleObject(hPlayerThread, PLAYER_THREAD_WAIT_TIME);
     CloseHandle(hPlayerThread);
     hPlayerThread = NULL;
+    win_midi_state = STATE_STOPPED;
 
     if (!hMidiStream)
     {


### PR DESCRIPTION
`midiStreamPause()` sends a custom notes off event and releases "hold 1 pedal" but doesn't handle other events that can cause hanging notes. More details and a test wad [here](https://github.com/fabiangreffrath/woof/pull/1069).