### PR TITLE
Implement pause in a different way in Fluidsynth music module

### DIFF
--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -161,7 +161,7 @@ static void I_FL_PauseSong(void)
 {
     if (player)
     {
-        fluid_player_stop(player);
+        Mix_HookMusic(NULL, NULL);
     }
 }
 
@@ -169,7 +169,7 @@ static void I_FL_ResumeSong(void)
 {
     if (player)
     {
-        fluid_player_play(player);
+        Mix_HookMusic(FL_Mix_Callback, NULL);
     }
 }
 


### PR DESCRIPTION
Since the behavior of `fluid_player_stop()` and `fluid_player_play()` has been changed in Fluidsynth 2.3.3, use `Mix_HookMusic()` to pause as it's probably the better way.

Current approach stopped working after this change: https://github.com/FluidSynth/fluidsynth/pull/1236 Thanks to @JNechaevsky for bug report.