### PR TITLE
Introduce SDL_GameController support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -83,7 +83,7 @@ IncludeCategories:
     SortPriority:    0
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
-IndentCaseLabels: false
+IndentCaseLabels: true
 IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: None

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(CMAKE_FIND_PACKAGE_PREFER_CONFIG
 option(ENABLE_SDL2_NET "Enable SDL2_net" On)
 option(ENABLE_SDL2_MIXER "Enable SDL2_mixer" On)
 
-find_package(SDL2 2.0.7)
+find_package(SDL2 2.0.14)
 if(ENABLE_SDL2_MIXER)
     find_package(SDL2_mixer 2.0.2)
 else()

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,10 @@
   * Add native support for the FluidSynth midi synthesizer.
   * It's now possible to play back a demo file by drag-and-dropping it
     on the executable (Fabian).
+  * Add improved gamepad support via the SDL\_GameController interface. This
+    includes support for analog triggers, modern dual-stick default bindings
+    (based on Unity Doom), descriptive button names for common controller types
+    and configurable dead zones for stick axes. (Michael Day)
 
 ### Refactorings
   * CMake project files have been added, replacing the Microsoft Visual

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ then
         CFLAGS="-O$OPT_LEVEL -g $WARNINGS $orig_CFLAGS"
 fi
 
-PKG_CHECK_MODULES(SDL, [sdl2 >= 2.0.7])
+PKG_CHECK_MODULES(SDL, [sdl2 >= 2.0.14])
 # Check for SDL2_mixer
 AC_ARG_ENABLE([sdl2mixer],
 AS_HELP_STRING([--disable-sdl2mixer], [Disable SDL2_mixer support])

--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -18,6 +18,7 @@
 
 #include "SDL.h"
 #include "SDL_joystick.h"
+#include "SDL_gamecontroller.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -36,6 +37,7 @@
 
 #define DEAD_ZONE (32768 / 3)
 
+static SDL_GameController *gamepad = NULL;
 static SDL_Joystick *joystick = NULL;
 
 // Configuration variables:
@@ -43,6 +45,9 @@ static SDL_Joystick *joystick = NULL;
 // Standard default.cfg Joystick enable/disable
 
 static int usejoystick = 0;
+
+// Use SDL_gamecontroller interface for the selected device
+static int use_gamepad = 0;
 
 // SDL GUID and index of the joystick to use.
 static char *joystick_guid = "";
@@ -75,6 +80,240 @@ static int joystick_look_invert = 0;
 static int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 };
+
+void I_ShutdownGamepad(void)
+{
+    if (gamepad != NULL)
+    {
+        SDL_GameControllerClose(gamepad);
+        gamepad = NULL;
+        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+    }
+}
+
+static int FindFirstGamepad(void)
+{
+    int i;
+    int gamepadindex = -1;
+
+    for (i = 0; i < SDL_NumJoysticks(); ++i)
+    {
+        if (SDL_IsGameController(i))
+        {
+            gamepadindex = i;
+            break;
+        }
+    }
+
+    return gamepadindex;
+}
+
+static int FindSpecificGamepad(SDL_JoystickGUID guid)
+{
+    SDL_JoystickGUID dev_guid;
+    int i;
+    int gamepadindex = -1;
+
+    for (i = 0; i < SDL_NumJoysticks(); ++i)
+    {
+        dev_guid = SDL_JoystickGetDeviceGUID(i);
+        if (!memcmp(&guid, &dev_guid, sizeof(SDL_JoystickGUID)))
+        {
+            gamepadindex = i;
+            break;
+        }
+    }
+
+    return gamepadindex;
+}
+
+static int DeviceIndexGamepad(void)
+{
+    SDL_JoystickGUID guid, dev_guid;
+    int index = -1;
+
+    if (strcmp(joystick_guid, ""))
+    {
+        guid = SDL_JoystickGetGUIDFromString(joystick_guid);
+
+        // First, look for the gamepad at the previously-used index.
+        if (joystick_index >= 0 && joystick_index < SDL_NumJoysticks())
+        {
+            dev_guid = SDL_JoystickGetDeviceGUID(joystick_index);
+            if (!memcmp(&guid, &dev_guid, sizeof(SDL_JoystickGUID)))
+            {
+                return joystick_index;
+            }
+        }
+
+        // Maybe the index has moved?
+        index = FindSpecificGamepad(guid);
+    }
+
+    // If the previous gamepad isn't present, see if a different one is
+    // available.
+    if (index < 0)
+    {
+        index = FindFirstGamepad();
+    }
+
+    return index;
+}
+
+void I_InitGamepad(void)
+{
+    SDL_JoystickGUID guid;
+    int index;
+
+    if (!use_gamepad)
+    {
+        return;
+    }
+
+    if (SDL_Init(SDL_INIT_GAMECONTROLLER) < 0)
+    {
+        return;
+    }
+
+    index = DeviceIndexGamepad();
+
+    if (index < 0)
+    {
+        printf("I_InitGamepad: No gamepad found.\n");
+        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        return;
+    }
+
+    gamepad = SDL_GameControllerOpen(index);
+
+    if (gamepad == NULL)
+    {
+        printf("I_InitGamepad: Failed to open gamepad: %s\n", SDL_GetError());
+        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        return;
+    }
+
+    joystick_index = index;
+
+    if (strcmp(joystick_guid, ""))
+    {
+        joystick_guid = malloc(GUID_STRING_BUF_SIZE);
+    }
+
+    guid = SDL_JoystickGetDeviceGUID(joystick_index);
+    SDL_JoystickGetGUIDString(guid, joystick_guid, GUID_STRING_BUF_SIZE);
+
+    // GameController events do not fire if Joystick events are disabled.
+    SDL_JoystickEventState(SDL_ENABLE);
+    SDL_GameControllerEventState(SDL_ENABLE);
+
+    printf("I_InitGamepad: %s\n", SDL_GameControllerName(gamepad));
+    I_AtExit(I_ShutdownGamepad, true);
+}
+
+static int GetTriggerStateGamepad(SDL_GameControllerAxis trigger)
+{
+    return (SDL_GameControllerGetAxis(gamepad, trigger) > TRIGGER_THRESHOLD);
+}
+
+// Get the state of the given virtual button.
+
+static int ReadButtonStateGamepad(int vbutton)
+{
+    int physbutton, state;
+
+    // Map from virtual button to physical (SDL) button.
+    if (vbutton < NUM_VIRTUAL_BUTTONS)
+    {
+        physbutton = joystick_physical_buttons[vbutton];
+    }
+    else
+    {
+        physbutton = vbutton;
+    }
+
+    switch (physbutton)
+    {
+        case GAMEPAD_BUTTON_TRIGGERLEFT:
+            state = GetTriggerStateGamepad(SDL_CONTROLLER_AXIS_TRIGGERLEFT);
+            break;
+
+        case GAMEPAD_BUTTON_TRIGGERRIGHT:
+            state = GetTriggerStateGamepad(SDL_CONTROLLER_AXIS_TRIGGERRIGHT);
+            break;
+
+        default:
+            state = SDL_GameControllerGetButton(gamepad, physbutton);
+            break;
+    }
+
+    return state;
+}
+
+// Get a bitmask of all currently-pressed buttons
+
+static int GetButtonsStateGamepad(void)
+{
+    int i;
+    int result = 0;
+
+    for (i = 0; i < MAX_VIRTUAL_BUTTONS; ++i)
+    {
+        if (ReadButtonStateGamepad(i))
+        {
+            result |= 1u << i;
+        }
+    }
+
+    return result;
+}
+
+// Read the state of an axis, inverting if necessary.
+
+static int GetAxisStateGamepad(int axis, int invert)
+{
+    int result;
+
+    // Axis -1 means disabled.
+
+    if (axis < 0)
+    {
+        return 0;
+    }
+
+    result = SDL_GameControllerGetAxis(gamepad, axis);
+
+    if (result < DEAD_ZONE && result > -DEAD_ZONE)
+    {
+        result = 0;
+    }
+
+    if (invert)
+    {
+        result = -result;
+    }
+
+    return result;
+}
+
+void I_UpdateGamepad(void)
+{
+    if (gamepad != NULL)
+    {
+        event_t ev;
+
+        ev.type = ev_joystick;
+        ev.data1 = GetButtonsStateGamepad();
+        ev.data2 = GetAxisStateGamepad(joystick_x_axis, joystick_x_invert);
+        ev.data3 = GetAxisStateGamepad(joystick_y_axis, joystick_y_invert);
+        ev.data4 =
+            GetAxisStateGamepad(joystick_strafe_axis, joystick_strafe_invert);
+        ev.data5 =
+            GetAxisStateGamepad(joystick_look_axis, joystick_look_invert);
+
+        D_PostEvent(&ev);
+    }
+}
 
 void I_ShutdownJoystick(void)
 {
@@ -153,6 +392,12 @@ void I_InitJoystick(void)
         return;
     }
 
+    if (use_gamepad)
+    {
+        I_InitGamepad();
+        return;
+    }
+
     if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
     {
         return;
@@ -175,7 +420,8 @@ void I_InitJoystick(void)
 
     if (joystick == NULL)
     {
-        printf("I_InitJoystick: Failed to open joystick #%i\n", index);
+        printf("I_InitJoystick: Failed to open joystick #%i: %s\n", index,
+               SDL_GetError());
         SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
         return;
     }
@@ -270,11 +516,9 @@ static int ReadButtonState(int vbutton)
 static int GetButtonsState(void)
 {
     int i;
-    int result;
+    int result = 0;
 
-    result = 0;
-
-    for (i = 0; i < 20; ++i)
+    for (i = 0; i < MAX_VIRTUAL_BUTTONS; ++i)
     {
         if (ReadButtonState(i))
         {
@@ -362,6 +606,12 @@ static int GetAxisState(int axis, int invert)
 
 void I_UpdateJoystick(void)
 {
+    if (use_gamepad)
+    {
+        I_UpdateGamepad();
+        return;
+    }
+
     if (joystick != NULL)
     {
         event_t ev;
@@ -382,6 +632,7 @@ void I_BindJoystickVariables(void)
     int i;
 
     M_BindIntVariable("use_joystick",          &usejoystick);
+    M_BindIntVariable("use_gamepad",           &use_gamepad);
     M_BindStringVariable("joystick_guid",      &joystick_guid);
     M_BindIntVariable("joystick_index",        &joystick_index);
     M_BindIntVariable("joystick_x_axis",       &joystick_x_axis);

--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -49,6 +49,9 @@ static int usejoystick = 0;
 // Use SDL_gamecontroller interface for the selected device
 static int use_gamepad = 0;
 
+// SDL_GameControllerType of gamepad
+static int gamepad_type = 0;
+
 // SDL GUID and index of the joystick to use.
 static char *joystick_guid = "";
 static int joystick_index = -1;
@@ -194,6 +197,7 @@ void I_InitGamepad(void)
     }
 
     joystick_index = index;
+    gamepad_type = SDL_GameControllerTypeForIndex(index);
 
     if (strcmp(joystick_guid, ""))
     {
@@ -633,6 +637,7 @@ void I_BindJoystickVariables(void)
 
     M_BindIntVariable("use_joystick",          &usejoystick);
     M_BindIntVariable("use_gamepad",           &use_gamepad);
+    M_BindIntVariable("gamepad_type",          &gamepad_type);
     M_BindStringVariable("joystick_guid",      &joystick_guid);
     M_BindIntVariable("joystick_index",        &joystick_index);
     M_BindIntVariable("joystick_x_axis",       &joystick_x_axis);

--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -175,7 +175,7 @@ void I_InitGamepad(void)
         return;
     }
 
-    if (SDL_Init(SDL_INIT_GAMECONTROLLER) < 0)
+    if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) < 0)
     {
         return;
     }
@@ -410,7 +410,7 @@ void I_InitJoystick(void)
         return;
     }
 
-    if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
+    if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
     {
         return;
     }

--- a/src/i_joystick.h
+++ b/src/i_joystick.h
@@ -19,10 +19,16 @@
 #ifndef __I_JOYSTICK__
 #define __I_JOYSTICK__
 
+#include "SDL_gamecontroller.h"
+
 // Number of "virtual" joystick buttons defined in configuration files.
 // This needs to be at least as large as the number of different key
 // bindings supported by the higher-level game code (joyb* variables).
 #define NUM_VIRTUAL_BUTTONS 11
+
+// Max allowed number of virtual mappings. Chosen to be less than joybspeed
+// autorun value.
+#define MAX_VIRTUAL_BUTTONS 20
 
 // If this bit is set in a configuration file axis value, the axis is
 // not actually a joystick axis, but instead is a "button axis". This
@@ -59,6 +65,22 @@
 
 #define HAT_AXIS_HORIZONTAL 1
 #define HAT_AXIS_VERTICAL   2
+
+// When a trigger reads greater than this, consider it to be pressed.  30 comes
+// from XINPUT_GAMEPAD_TRIGGER_THRESHOLD in xinput.h, and is scaled here for
+// the SDL_GameController trigger max value.
+#define TRIGGER_THRESHOLD (30 * 32767 / 255)
+
+// To be used with SDL_JoystickGetGUIDString; see SDL_joystick.h
+#define GUID_STRING_BUF_SIZE 33
+
+// Extend the SDL_GameControllerButton enum to include the triggers.
+enum
+{
+    GAMEPAD_BUTTON_TRIGGERLEFT = SDL_CONTROLLER_BUTTON_MAX,
+    GAMEPAD_BUTTON_TRIGGERRIGHT,
+    GAMEPAD_BUTTON_MAX
+};
 
 void I_InitJoystick(void);
 void I_ShutdownJoystick(void);

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1377,6 +1377,12 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(use_gamepad),
 
     //!
+    // Stores the SDL_GameControllerType of the last configured gamepad.
+    //
+
+    CONFIG_VARIABLE_INT(gamepad_type),
+
+    //!
     // Joystick virtual button to make the player strafe left.
     //
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1383,6 +1383,34 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(gamepad_type),
 
     //!
+    // Joystick x axis dead zone, specified as a percentage of the axis max
+    // value.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_x_dead_zone),
+
+    //!
+    // Joystick y axis dead zone, specified as a percentage of the axis max
+    // value.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_y_dead_zone),
+
+    //!
+    // Joystick strafe axis dead zone, specified as a percentage of the axis
+    // max value.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_strafe_dead_zone),
+
+    //!
+    // Joystick look axis dead zone, specified as a percentage of the axis max
+    // value.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_look_dead_zone),
+
+    //!
     // Joystick virtual button to make the player strafe left.
     //
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1370,6 +1370,13 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(joystick_physical_button10),
 
     //!
+    // If non-zero, use the SDL_GameController interface instead of the
+    // SDL_Joystick interface.
+    //
+
+    CONFIG_VARIABLE_INT(use_gamepad),
+
+    //!
     // Joystick virtual button to make the player strafe left.
     //
 

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1025,15 +1025,30 @@ static void NoJoystick(void)
     SetJoystickButtonLabel();
 }
 
-static void CalibrateWindowClosed(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
+static void RefreshJoystickWindow(TXT_UNCAST_ARG(widget),
+                                  TXT_UNCAST_ARG(unused))
 {
+    ConfigJoystick(NULL, NULL);
+}
+
+static void CalibrateWindowClosed(TXT_UNCAST_ARG(widget),
+                                  TXT_UNCAST_ARG(joystick_window))
+{
+    TXT_CAST_ARG(txt_window_t, joystick_window);
     TXT_SDL_SetEventCallback(NULL, NULL);
     SetJoystickButtonLabel();
     CloseAllJoysticks();
+
+    // Refresh Joystick window to update button and axis widgets.
+    TXT_SignalConnect(joystick_window, "closed", RefreshJoystickWindow, NULL);
+    TXT_CloseWindow(joystick_window);
 }
 
-static void CalibrateJoystick(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
+static void CalibrateJoystick(TXT_UNCAST_ARG(widget),
+                              TXT_UNCAST_ARG(joystick_window))
 {
+    TXT_CAST_ARG(txt_window_t, joystick_window);
+
     // Try to open all available joysticks.  If none are opened successfully,
     // bomb out with an error.
 
@@ -1059,7 +1074,8 @@ static void CalibrateJoystick(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
 
     TXT_SDL_SetEventCallback(CalibrationEventCallback, NULL);
 
-    TXT_SignalConnect(calibration_window, "closed", CalibrateWindowClosed, NULL);
+    TXT_SignalConnect(calibration_window, "closed", CalibrateWindowClosed,
+                      joystick_window);
 
     // Start calibration
     usejoystick = 0;
@@ -1174,7 +1190,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 
     AddJoystickControl(window, "Toggle Automap", &joybautomap);
 
-    TXT_SignalConnect(joystick_button, "pressed", CalibrateJoystick, NULL);
+    TXT_SignalConnect(joystick_button, "pressed", CalibrateJoystick, window);
     TXT_SetWindowAction(window, TXT_HORIZ_CENTER, TestConfigAction());
 
     InitJoystick();

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -599,6 +599,9 @@ static const known_joystick_t known_joysticks[] =
 // Use SDL_GameController interface
 int use_gamepad = 0;
 
+// SDL_GameControllerType of gamepad
+int gamepad_type = 0;
+
 // Based on Unity Doom mapping
 static const joystick_config_t modern_gamepad[] =
 {
@@ -980,6 +983,7 @@ static int CalibrationEventCallback(SDL_Event *event, void *user_data)
     {
         usejoystick = 1;
         use_gamepad = 1;
+        gamepad_type = SDL_GameControllerTypeForIndex(joystick_index);
         LoadConfigurationSet(empty_defaults);
         GetGamepadDefaultConfig();
         TXT_CloseWindow(calibration_window);
@@ -990,6 +994,7 @@ static int CalibrationEventCallback(SDL_Event *event, void *user_data)
     // In the first "center" stage, we're just trying to work out which
     // joystick is being configured and which button the user is pressing.
     usejoystick = 1;
+    gamepad_type = SDL_CONTROLLER_TYPE_UNKNOWN;
     calibrate_button = event->jbutton.button;
 
     // If the joystick is a known one, auto-load default
@@ -1205,6 +1210,7 @@ void BindJoystickVariables(void)
 
     M_BindIntVariable("use_joystick",           &usejoystick);
     M_BindIntVariable("use_gamepad",            &use_gamepad);
+    M_BindIntVariable("gamepad_type",           &gamepad_type);
     M_BindStringVariable("joystick_guid",       &joystick_guid);
     M_BindIntVariable("joystick_index",         &joystick_index);
     M_BindIntVariable("joystick_x_axis",        &joystick_x_axis);

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -85,6 +85,13 @@ static int joystick_strafe_invert = 0;
 static int joystick_look_axis = -1;
 static int joystick_look_invert = 0;
 
+// Configurable dead zone for each axis, specified as a percentage of the axis
+// max value.
+static int joystick_x_dead_zone = 33;
+static int joystick_y_dead_zone = 33;
+static int joystick_strafe_dead_zone = 33;
+static int joystick_look_dead_zone = 33;
+
 // Virtual to physical mapping.
 int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
@@ -1146,6 +1153,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
                    TXT_NewLabel("Forward/backward"),
                    y_axis_widget = TXT_NewJoystickAxis(&joystick_y_axis,
                                                        &joystick_y_invert,
+                                                       &joystick_y_dead_zone,
                                                        JOYSTICK_AXIS_VERTICAL),
                    TXT_TABLE_OVERFLOW_RIGHT,
                    TXT_TABLE_OVERFLOW_RIGHT,
@@ -1156,6 +1164,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
                    x_axis_widget =
                         TXT_NewJoystickAxis(&joystick_x_axis,
                                             &joystick_x_invert,
+                                            &joystick_x_dead_zone,
                                             JOYSTICK_AXIS_HORIZONTAL),
                    TXT_TABLE_OVERFLOW_RIGHT,
                    TXT_TABLE_OVERFLOW_RIGHT,
@@ -1165,6 +1174,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
                    TXT_NewLabel("Strafe left/right"),
                    TXT_NewJoystickAxis(&joystick_strafe_axis,
                                        &joystick_strafe_invert,
+                                       &joystick_strafe_dead_zone,
                                         JOYSTICK_AXIS_HORIZONTAL),
                    TXT_TABLE_OVERFLOW_RIGHT,
                    TXT_TABLE_OVERFLOW_RIGHT,
@@ -1178,6 +1188,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
                    TXT_NewLabel("Look up/down"),
                    TXT_NewJoystickAxis(&joystick_look_axis,
                                        &joystick_look_invert,
+                                       &joystick_look_dead_zone,
                                         JOYSTICK_AXIS_VERTICAL),
                    TXT_TABLE_OVERFLOW_RIGHT,
                    TXT_TABLE_OVERFLOW_RIGHT,
@@ -1254,6 +1265,10 @@ void BindJoystickVariables(void)
     M_BindIntVariable("joystick_strafe_invert", &joystick_strafe_invert);
     M_BindIntVariable("joystick_look_axis",   &joystick_look_axis);
     M_BindIntVariable("joystick_look_invert", &joystick_look_invert);
+    M_BindIntVariable("joystick_x_dead_zone", &joystick_x_dead_zone);
+    M_BindIntVariable("joystick_y_dead_zone", &joystick_y_dead_zone);
+    M_BindIntVariable("joystick_strafe_dead_zone", &joystick_strafe_dead_zone);
+    M_BindIntVariable("joystick_look_dead_zone", &joystick_look_dead_zone);
 
     for (i = 0; i < NUM_VIRTUAL_BUTTONS; ++i)
     {

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1106,6 +1106,28 @@ static void AddJoystickControl(TXT_UNCAST_ARG(table), const char *label, int *va
                    NULL);
 }
 
+static void SwapLRSticks(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
+{
+    // Single pad/stick controllers don't get a joystick_strafe_axis value
+    if (joystick_strafe_axis >= 0)
+    {
+        if (joystick_x_axis == SDL_CONTROLLER_AXIS_LEFTX)
+        {
+            joystick_x_axis = SDL_CONTROLLER_AXIS_RIGHTX;
+            joystick_y_axis = SDL_CONTROLLER_AXIS_LEFTY;
+            joystick_strafe_axis = SDL_CONTROLLER_AXIS_LEFTX;
+            joystick_look_axis = SDL_CONTROLLER_AXIS_RIGHTY;
+        }
+        else
+        {
+            joystick_x_axis = SDL_CONTROLLER_AXIS_LEFTX;
+            joystick_y_axis = SDL_CONTROLLER_AXIS_RIGHTY;
+            joystick_strafe_axis = SDL_CONTROLLER_AXIS_RIGHTX;
+            joystick_look_axis = SDL_CONTROLLER_AXIS_LEFTY;
+        }
+    }
+}
+
 void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
@@ -1163,6 +1185,17 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
                    TXT_TABLE_EMPTY,
                    NULL);
     }
+
+    TXT_AddWidget(window,
+        TXT_NewConditional(&use_gamepad, 1,
+            TXT_MakeTable(6,
+                   TXT_NewButton2("Swap L and R sticks", SwapLRSticks, NULL),
+                   TXT_TABLE_OVERFLOW_RIGHT,
+                   TXT_TABLE_OVERFLOW_RIGHT,
+                   TXT_TABLE_EMPTY,
+                   TXT_TABLE_EMPTY,
+                   TXT_TABLE_EMPTY,
+                   NULL)));
 
     TXT_AddWidget(window, TXT_NewSeparator("Buttons"));
 

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1001,6 +1001,7 @@ static int CalibrationEventCallback(SDL_Event *event, void *user_data)
     // In the first "center" stage, we're just trying to work out which
     // joystick is being configured and which button the user is pressing.
     usejoystick = 1;
+    use_gamepad = 0;
     gamepad_type = SDL_CONTROLLER_TYPE_UNKNOWN;
     calibrate_button = event->jbutton.button;
 
@@ -1090,9 +1091,6 @@ static void CalibrateJoystick(TXT_UNCAST_ARG(widget),
                       joystick_window);
 
     // Start calibration
-    usejoystick = 0;
-    use_gamepad = 0;
-    joystick_index = -1;
 }
 
 //

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -770,7 +770,7 @@ static void InitJoystick(void)
 {
     if (!joystick_initted)
     {
-        joystick_initted = SDL_Init(SDL_INIT_JOYSTICK) >= 0;
+        joystick_initted = SDL_InitSubSystem(SDL_INIT_JOYSTICK) >= 0;
     }
 }
 

--- a/src/setup/joystick.h
+++ b/src/setup/joystick.h
@@ -22,6 +22,7 @@
 extern int joystick_index;
 extern int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS];
 extern int use_gamepad;
+extern int gamepad_type;
 
 
 void ConfigJoystick(void *widget, void *user_data);

--- a/src/setup/joystick.h
+++ b/src/setup/joystick.h
@@ -21,6 +21,7 @@
 
 extern int joystick_index;
 extern int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS];
+extern int use_gamepad;
 
 
 void ConfigJoystick(void *widget, void *user_data);

--- a/src/setup/txt_joyaxis.c
+++ b/src/setup/txt_joyaxis.c
@@ -359,7 +359,7 @@ void TXT_ConfigureJoystickAxis(txt_joystick_axis_t *joystick_axis,
                                txt_joystick_axis_callback_t callback)
 {
     // Open the joystick first.
-    if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
+    if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
     {
         return;
     }

--- a/src/setup/txt_joyaxis.c
+++ b/src/setup/txt_joyaxis.c
@@ -486,20 +486,43 @@ static void TXT_JoystickAxisDrawer(TXT_UNCAST_ARG(joystick_axis))
     }
 }
 
+static void GetAxisDescription(int axis, char *buf, size_t buf_len)
+{
+    switch (axis)
+    {
+        case SDL_CONTROLLER_AXIS_INVALID:
+            M_StringCopy(buf, "(none)", sizeof(buf));
+            break;
+
+        case SDL_CONTROLLER_AXIS_LEFTX:
+            M_StringCopy(buf, "Left X", sizeof(buf));
+            break;
+
+        case SDL_CONTROLLER_AXIS_LEFTY:
+            M_StringCopy(buf, "Left Y", sizeof(buf));
+            break;
+
+        case SDL_CONTROLLER_AXIS_RIGHTX:
+            M_StringCopy(buf, "Right X", sizeof(buf));
+            break;
+
+        case SDL_CONTROLLER_AXIS_RIGHTY:
+            M_StringCopy(buf, "Right Y", sizeof(buf));
+            break;
+
+        default:
+            M_StringCopy(buf, "(unknown)", sizeof(buf));
+            break;
+    }
+}
+
 static void TXT_GamepadAxisDrawer(TXT_UNCAST_ARG(joystick_axis))
 {
     TXT_CAST_ARG(txt_joystick_axis_t, joystick_axis);
     char buf[JOYSTICK_AXIS_WIDTH + 1];
     int i;
 
-    if (*joystick_axis->axis < 0)
-    {
-        M_StringCopy(buf, "(none)", sizeof(buf));
-    }
-    else
-    {
-        M_snprintf(buf, sizeof(buf), "AXIS #%i", *joystick_axis->axis);
-    }
+    GetAxisDescription(*joystick_axis->axis, buf, sizeof(buf));
 
     TXT_SetWidgetBG(joystick_axis);
     TXT_FGColor(TXT_COLOR_BRIGHT_WHITE);

--- a/src/setup/txt_joyaxis.c
+++ b/src/setup/txt_joyaxis.c
@@ -420,14 +420,19 @@ void TXT_ConfigureGamepadAxis(txt_joystick_axis_t *joystick_axis,
     // Build the prompt window.
 
     joystick_axis->config_window = TXT_NewWindow("Configure axis");
-    TXT_SetColumnWidths(joystick_axis->config_window, 14);
-    TXT_AddWidgets(joystick_axis->config_window, TXT_NewStrut(0, 1),
+    TXT_SetTableColumns(joystick_axis->config_window, 2);
+    TXT_SetColumnWidths(joystick_axis->config_window, 10, 5);
+    TXT_AddWidgets(joystick_axis->config_window,
                    TXT_NewCheckBox("Invert", joystick_axis->invert),
-                   TXT_NewStrut(0, 1), NULL);
+                   TXT_TABLE_EMPTY,
+                   TXT_NewLabel("Dead zone"),
+                   TXT_NewSpinControl(joystick_axis->dead_zone, 10, 90),
+                   NULL);
 
     TXT_SetWindowAction(joystick_axis->config_window, TXT_HORIZ_LEFT, NULL);
-    TXT_SetWindowAction(joystick_axis->config_window, TXT_HORIZ_CENTER,
-                        TXT_NewWindowAbortAction(joystick_axis->config_window));
+    TXT_SetWindowAction(
+        joystick_axis->config_window, TXT_HORIZ_CENTER,
+        TXT_NewWindowEscapeAction(joystick_axis->config_window));
     TXT_SetWindowAction(joystick_axis->config_window, TXT_HORIZ_RIGHT, NULL);
     TXT_SetWidgetAlign(joystick_axis->config_window, TXT_HORIZ_CENTER);
 }
@@ -623,7 +628,7 @@ txt_widget_class_t txt_gamepad_axis_class =
     NULL,
 };
 
-txt_joystick_axis_t *TXT_NewJoystickAxis(int *axis, int *invert,
+txt_joystick_axis_t *TXT_NewJoystickAxis(int *axis, int *invert, int *dead_zone,
                                          txt_joystick_axis_direction_t dir)
 {
     txt_joystick_axis_t *joystick_axis;
@@ -640,6 +645,7 @@ txt_joystick_axis_t *TXT_NewJoystickAxis(int *axis, int *invert,
     }
     joystick_axis->axis = axis;
     joystick_axis->invert = invert;
+    joystick_axis->dead_zone = dead_zone;
     joystick_axis->dir = dir;
     joystick_axis->bad_axis = NULL;
 

--- a/src/setup/txt_joyaxis.h
+++ b/src/setup/txt_joyaxis.h
@@ -45,7 +45,7 @@ typedef void (*txt_joystick_axis_callback_t)(void);
 struct txt_joystick_axis_s
 {
     txt_widget_t widget;
-    int *axis, *invert;
+    int *axis, *invert, *dead_zone;
     txt_joystick_axis_direction_t dir;
 
     // Only used when configuring:
@@ -75,7 +75,7 @@ struct txt_joystick_axis_s
     txt_joystick_axis_callback_t callback;
 };
 
-txt_joystick_axis_t *TXT_NewJoystickAxis(int *axis, int *invert,
+txt_joystick_axis_t *TXT_NewJoystickAxis(int *axis, int *invert, int *dead_zone,
                                          txt_joystick_axis_direction_t dir);
 
 // Configure a joystick axis widget.

--- a/src/setup/txt_joybinput.c
+++ b/src/setup/txt_joybinput.c
@@ -467,7 +467,7 @@ static void OpenPromptWindow(txt_joystick_input_t *joystick_input)
 
     joystick_input->check_conflicts = !TXT_GetModifierState(TXT_MOD_SHIFT);
 
-    if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
+    if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
     {
         return;
     }
@@ -502,7 +502,7 @@ static void OpenPromptWindowGamepad(txt_joystick_input_t *joystick_input)
 
     joystick_input->check_conflicts = !TXT_GetModifierState(TXT_MOD_SHIFT);
 
-    if (SDL_Init(SDL_INIT_GAMECONTROLLER) < 0)
+    if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) < 0)
     {
         return;
     }

--- a/src/setup/txt_joybinput.c
+++ b/src/setup/txt_joybinput.c
@@ -60,6 +60,199 @@ static int *all_joystick_buttons[NUM_VIRTUAL_BUTTONS] =
     &joybautomap,
 };
 
+// For indirection so that we're not dependent on item ordering in the
+// SDL_GameControllerButton enum.
+static const int gamepad_buttons[GAMEPAD_BUTTON_MAX] =
+{
+   SDL_CONTROLLER_BUTTON_A,
+   SDL_CONTROLLER_BUTTON_B,
+   SDL_CONTROLLER_BUTTON_X,
+   SDL_CONTROLLER_BUTTON_Y,
+   SDL_CONTROLLER_BUTTON_BACK,
+   SDL_CONTROLLER_BUTTON_GUIDE,
+   SDL_CONTROLLER_BUTTON_START,
+   SDL_CONTROLLER_BUTTON_LEFTSTICK,
+   SDL_CONTROLLER_BUTTON_RIGHTSTICK,
+   SDL_CONTROLLER_BUTTON_LEFTSHOULDER,
+   SDL_CONTROLLER_BUTTON_RIGHTSHOULDER,
+   SDL_CONTROLLER_BUTTON_DPAD_UP,
+   SDL_CONTROLLER_BUTTON_DPAD_DOWN,
+   SDL_CONTROLLER_BUTTON_DPAD_LEFT,
+   SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
+   SDL_CONTROLLER_BUTTON_MISC1,
+   SDL_CONTROLLER_BUTTON_PADDLE1,
+   SDL_CONTROLLER_BUTTON_PADDLE2,
+   SDL_CONTROLLER_BUTTON_PADDLE3,
+   SDL_CONTROLLER_BUTTON_PADDLE4,
+   SDL_CONTROLLER_BUTTON_TOUCHPAD,
+   GAMEPAD_BUTTON_TRIGGERLEFT,
+   GAMEPAD_BUTTON_TRIGGERRIGHT,
+};
+
+// Items in the following button lists are ordered according to gamepad_buttons
+// above.
+static const char *xbox360_buttons[GAMEPAD_BUTTON_MAX] =
+{
+    "A",
+    "B",
+    "X",
+    "Y",
+    "BACK",
+    "GUIDE",
+    "START",
+    "LSB",
+    "RSB",
+    "LB",
+    "RB",
+    "DPAD U",
+    "DPAD D",
+    "DPAD L",
+    "DPAD R",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "LT",
+    "RT",
+};
+
+static const char *xboxone_buttons[GAMEPAD_BUTTON_MAX] =
+{
+    "A",
+    "B",
+    "X",
+    "Y",
+    "VIEW",
+    "XBOX",
+    "MENU",
+    "LSB",
+    "RSB",
+    "LB",
+    "RB",
+    "DPAD U",
+    "DPAD D",
+    "DPAD L",
+    "DPAD R",
+    "PROFILE",
+    "P1",
+    "P2",
+    "P3",
+    "P4",
+    "",
+    "LT",
+    "RT",
+};
+
+static const char *ps3_buttons[GAMEPAD_BUTTON_MAX] =
+{
+    "X",
+    "CIRCLE",
+    "SQUARE",
+    "TRIANGLE",
+    "SELECT",
+    "PS",
+    "START",
+    "L3",
+    "R3",
+    "L1",
+    "R1",
+    "DPAD U",
+    "DPAD D",
+    "DPAD L",
+    "DPAD R",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "L2",
+    "R2",
+};
+
+static const char *ps4_buttons[GAMEPAD_BUTTON_MAX] =
+{
+    "X",
+    "CIRCLE",
+    "SQUARE",
+    "TRIANGLE",
+    "SHARE",
+    "PS",
+    "OPTIONS",
+    "L3",
+    "R3",
+    "L1",
+    "R1",
+    "DPAD U",
+    "DPAD D",
+    "DPAD L",
+    "DPAD R",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "TOUCH",
+    "L2",
+    "R2",
+};
+
+static const char *ps5_buttons[GAMEPAD_BUTTON_MAX] =
+{
+    "X",
+    "CIRCLE",
+    "SQUARE",
+    "TRIANGLE",
+    "SHARE",
+    "PS",
+    "OPTIONS",
+    "L3",
+    "R3",
+    "L1",
+    "R1",
+    "DPAD U",
+    "DPAD D",
+    "DPAD L",
+    "DPAD R",
+    "MUTE",
+    "",
+    "",
+    "",
+    "",
+    "TOUCH",
+    "L2",
+    "R2",
+};
+
+static const char *switchpro_buttons[GAMEPAD_BUTTON_MAX] =
+{
+    "B",
+    "A",
+    "Y",
+    "X",
+    "MINUS",
+    "HOME",
+    "PLUS",
+    "LSB",
+    "RSB",
+    "L",
+    "R",
+    "DPAD U",
+    "DPAD D",
+    "DPAD L",
+    "DPAD R",
+    "CAPTURE",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "ZL",
+    "ZR",
+};
+
 static int PhysicalForVirtualButton(int vbutton)
 {
     if (vbutton < NUM_VIRTUAL_BUTTONS)
@@ -381,6 +574,93 @@ static void TXT_JoystickInputDrawer(TXT_UNCAST_ARG(joystick_input))
     }
 }
 
+static int GetGamepadButtonIndex(int button)
+{
+    int i;
+
+    for (i = 0; i < arrlen(gamepad_buttons); ++i)
+    {
+        if (button == gamepad_buttons[i])
+        {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static void GetGamepadButtonDescription(int vbutton, char *buf, size_t buf_len)
+{
+    int index;
+
+    index = GetGamepadButtonIndex(PhysicalForVirtualButton(vbutton));
+
+    if (index < 0)
+    {
+        M_StringCopy(buf, "(unknown)", buf_len);
+        return;
+    }
+
+    switch (gamepad_type)
+    {
+        case SDL_CONTROLLER_TYPE_XBOX360:
+            M_snprintf(buf, buf_len, "%s", xbox360_buttons[index]);
+            break;
+
+        case SDL_CONTROLLER_TYPE_XBOXONE:
+            M_snprintf(buf, buf_len, "%s", xboxone_buttons[index]);
+            break;
+
+        case SDL_CONTROLLER_TYPE_PS3:
+            M_snprintf(buf, buf_len, "%s", ps3_buttons[index]);
+            break;
+
+        case SDL_CONTROLLER_TYPE_PS4:
+            M_snprintf(buf, buf_len, "%s", ps4_buttons[index]);
+            break;
+
+        case SDL_CONTROLLER_TYPE_PS5:
+            M_snprintf(buf, buf_len, "%s", ps5_buttons[index]);
+            break;
+
+        case SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO:
+            M_snprintf(buf, buf_len, "%s", switchpro_buttons[index]);
+            break;
+
+        default:
+            M_snprintf(buf, buf_len, "BUTTON #%i",
+                       PhysicalForVirtualButton(vbutton) + 1);
+            break;
+    }
+}
+
+static void TXT_GamepadInputDrawer(TXT_UNCAST_ARG(joystick_input))
+{
+    TXT_CAST_ARG(txt_joystick_input_t, joystick_input);
+    char buf[20]; // Need to fit "BUTTON #XX"
+    int i;
+
+    if (*joystick_input->variable < 0)
+    {
+        M_StringCopy(buf, "(none)", sizeof(buf));
+    }
+    else
+    {
+        GetGamepadButtonDescription(*joystick_input->variable, buf,
+                                    sizeof(buf));
+    }
+
+    TXT_SetWidgetBG(joystick_input);
+    TXT_FGColor(TXT_COLOR_BRIGHT_WHITE);
+
+    TXT_DrawString(buf);
+
+    for (i = TXT_UTF8_Strlen(buf); i < JOYSTICK_INPUT_WIDTH; ++i)
+    {
+        TXT_DrawString(" ");
+    }
+}
+
 static void TXT_JoystickInputDestructor(TXT_UNCAST_ARG(joystick_input))
 {
 }
@@ -466,7 +746,7 @@ txt_widget_class_t txt_gamepad_input_class =
 {
     TXT_AlwaysSelectable,
     TXT_JoystickInputSizeCalc,
-    TXT_JoystickInputDrawer,
+    TXT_GamepadInputDrawer,
     TXT_GamepadInputKeyPress,
     TXT_JoystickInputDestructor,
     TXT_GamepadInputMousePress,

--- a/src/setup/txt_joybinput.c
+++ b/src/setup/txt_joybinput.c
@@ -104,8 +104,9 @@ static void CanonicalizeButtons(void)
 
         // Don't remap the speed key if it's bound to "always run".
         // Also preserve "unbound" variables.
-        if ((all_joystick_buttons[i] == &joybspeed && vbutton >= 20)
-         || vbutton < 0)
+        if ((all_joystick_buttons[i] == &joybspeed &&
+             vbutton >= MAX_VIRTUAL_BUTTONS) ||
+            vbutton < 0)
         {
             new_mapping[i] = i;
         }


### PR DESCRIPTION
This PR brings to the table support for the SDL_GameController interface. Some highlights:

* Support for trigger buttons (i.e. R2/L2, LT/RT, etc)
* Descriptive button names for PS3, PS4, PS5, Xbox 360, Xbox One and Switch Pro Controllers.
* No longer necessary to manually calibrate axes. The only configuration options for the axes are inversion, and swapping the two sticks ("Southpaw" scheme).
* New modern default mapping for twin stick controllers based on Unity Doom.
* Classic/retro-ish controllers get default mapping based on SNES Doom.
* Possible to switch between controllers without having to go back into the setup utility. For example, you can do the initial configuration with a XBox 360 controller in setup, but later plug in a PS4 controller and it will work just the same.

![image](https://github.com/chocolate-doom/chocolate-doom/assets/43701387/5d82b7ad-0ac5-45d7-84e0-9cad1b8acdfa)
![image](https://github.com/chocolate-doom/chocolate-doom/assets/43701387/bc9e694d-3095-4dc3-a278-4587f15a3819)

I implemented the gamepad interface without removing any of the existing SDL_Joystick code. Controllers that aren't supported by SDL_GameController should work the same as before. There is opportunity to delete some code here but I have intentionally preserved everything. (With maintainer approval I'll gladly have a go at ripping out stuff that I think might now be deprecated.)

So far tested with PS3, PS4, Xbox 360 and SNES (via USB adapter) controllers.

Fixes #736 and #1367.