### PR TITLE
Move cppcheck into its own workflow

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,23 @@
+name: cppcheck
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - master
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install cppcheck
+
+      - uses: actions/checkout@v2
+
+      - name: Run cppcheck
+        env:
+          ANALYZE: true
+        run: $GITHUB_WORKSPACE/.travis.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,19 +37,3 @@ jobs:
         env:
           CC: ${{ matrix.compiler }}
         run: $GITHUB_WORKSPACE/.travis.sh
-
-  cppcheck:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install cppcheck
-
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Run cppcheck
-        env:
-          ANALYZE: true
-        run: $GITHUB_WORKSPACE/.travis.sh


### PR DESCRIPTION
- Moved cppcheck from main.yml into its own cppcheck.yml workflow so it can run sooner and give back results quicker (i.e. not wait on project compilation).
- Removed `with.submodules: true` from `actions/checkout@v2`.
- Purposely kept the runner at `ubuntu-20.04` instead of `ubuntu-latest` for as long as #1522 is still open. The desire would be to flip it to `ubuntu-latest` after that issue is resolved.