### PR TITLE
Add macOS workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: brew install automake libpng sdl2 sdl2_mixer sdl2_net
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure
         run: ./autogen.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,27 @@
+name: macos
+
+on:
+  push:
+    branches:
+      - "master"
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Install dependencies
+        run: brew install automake sdl2 sdl2_image sdl2_mixer sdl2_net
+
+      - uses: actions/checkout@v2
+
+      - name: Configure
+        run: ./autogen.sh
+
+      - name: Build
+        run: make -j4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: brew install automake sdl2 sdl2_image sdl2_mixer sdl2_net
+        run: brew install automake libpng sdl2 sdl2_mixer sdl2_net
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
I have a Mac now so I thought I'd take a moment to add this to Chocolate Doom's growing CI/CD:
- Installs a minimal set of dependencies via `brew`.
- Ignores using `./.travis.sh` in favour of invoking `./autogen.sh` and `make -j4`, modeled after the `msys2` workflow.
- Doesn't use `gcc` because macOS seems to prefer `clang` and even makes `gcc` essentially an alias of `clang`.

Future To-Do:
- Sunset `.travis.sh`.
- Complete the "CD" in CI/CD by adding artifact publishing similar to the `msys2` workflow.

Resolves #1427.