### PR TITLE
win midi: Fall back to default midi device

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1388,7 +1388,7 @@ static boolean I_WIN_InitMusic(void)
         MIDIOUTCAPS caps;
 
         if (midiOutGetDevCaps(i, &caps, sizeof(caps)) == MMSYSERR_NOERROR &&
-            !strcasecmp(winmm_midi_device, caps.szPname))
+            !strncasecmp(winmm_midi_device, caps.szPname, MAXPNAMELEN))
         {
             MidiDevice = i;
             break;

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1379,11 +1379,9 @@ static DWORD WINAPI PlayerProc(void)
 
 static boolean I_WIN_InitMusic(void)
 {
-    int all_devices;
+    const int all_devices = midiOutGetNumDevs();
     int i;
     MMRESULT mmr;
-
-    all_devices = midiOutGetNumDevs(); // Does not include MIDI_MAPPER.
 
     for (i = 0; i < all_devices; i++)
     {

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -190,7 +190,8 @@ static txt_dropdown_list_t *MidiDeviceSelector(void)
             free(midi_names[num_devices]);
             midi_names[num_devices] = M_StringDuplicate(caps.szPname);
 
-            if (!strcasecmp(winmm_midi_device, midi_names[num_devices]))
+            if (!strncasecmp(winmm_midi_device, midi_names[num_devices],
+                             MAXPNAMELEN))
             {
                 // Set the dropdown list index to the saved device.
                 midi_index = num_devices;

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -80,7 +80,7 @@ static char *gus_patch_path = NULL;
 static int gus_ram_kb = 1024;
 #ifdef _WIN32
 #define MAX_MIDI_DEVICES 20
-static char *midi_names[MAX_MIDI_DEVICES] = {"Microsoft MIDI Mapper"};
+static char *midi_names[MAX_MIDI_DEVICES];
 static int midi_index;
 char *winmm_midi_device = NULL;
 int winmm_complevel = 0;
@@ -168,13 +168,13 @@ static void UpdateMidiDevice(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(data))
 static txt_dropdown_list_t *MidiDeviceSelector(void)
 {
     txt_dropdown_list_t *result;
-    int num_devices;
-    int all_devices;
+    int num_devices = 1;
+    int all_devices = midiOutGetNumDevs();
     int i;
 
     midi_index = 0;
-    num_devices = 1; // Always show MIDI_MAPPER.
-    all_devices = midiOutGetNumDevs(); // Does not include MIDI_MAPPER.
+    free(midi_names[0]);
+    midi_names[0] = M_StringDuplicate("Microsoft MIDI Mapper");
 
     if (all_devices > MAX_MIDI_DEVICES - num_devices)
     {

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -204,7 +204,7 @@ static txt_dropdown_list_t *MidiDeviceSelector(void)
     free(winmm_midi_device);
     winmm_midi_device = M_StringDuplicate(midi_names[midi_index]);
 
-    result = TXT_NewDropdownList(&midi_index, (const char **)midi_names,
+    result = TXT_NewDropdownList(&midi_index, (const char **) midi_names,
                                  num_devices);
     TXT_SignalConnect(result, "changed", UpdateMidiDevice, NULL);
 


### PR DESCRIPTION
Fall back to the system's default midi device, as determined by MIDI_MAPPER, when no devices are found. This handles cases where the system doesn't report midi devices correctly but still has a functional default midi device (MS GS Synth). This required some refactoring of the midi device selection parts of sound.c and i_winmusic.c.