### PR TITLE
Introduce gamepad analog control

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -388,7 +388,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
             side += FixedMul(sidemove[speed], joyxmove);
         }
-        else
+        else if (joystick_move_sensitivity)
         {
             if (joyxmove > 0)
                 side += sidemove[speed];
@@ -410,7 +410,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             joyxmove = joyxmove * joystick_turn_sensitivity / 10;
             cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
         }
-        else
+        else if (joystick_turn_sensitivity)
         {
             if (joyxmove > 0)
                 cmd->angleturn -= angleturn[tspeed];
@@ -437,7 +437,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         joyymove = (joyymove < -FRACUNIT) ? -FRACUNIT : joyymove;
         forward -= FixedMul(forwardmove[speed], joyymove);
     }
-    else
+    else if (joystick_move_sensitivity)
     {
         if (joyymove < 0)
             forward += forwardmove[speed];
@@ -466,7 +466,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         joystrafemove = (joystrafemove < -FRACUNIT) ? -FRACUNIT : joystrafemove;
         side += FixedMul(sidemove[speed], joystrafemove);
     }
-    else
+    else if (joystick_move_sensitivity)
     {
         if (joystrafemove < 0)
             side -= sidemove[speed];

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -35,6 +35,7 @@
 #include "m_misc.h"
 #include "m_menu.h"
 #include "m_random.h"
+#include "i_joystick.h"
 #include "i_system.h"
 #include "i_timer.h"
 #include "i_input.h"
@@ -380,11 +381,20 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 	    //	fprintf(stderr, "strafe left\n");
 	    side -= sidemove[speed]; 
 	}
-	if (joyxmove > 0) 
-	    side += sidemove[speed]; 
-	if (joyxmove < 0) 
-	    side -= sidemove[speed]; 
- 
+        if (use_analog && joyxmove)
+        {
+            joyxmove = joyxmove * joystick_move_sensitivity / 10;
+            joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
+            joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
+            side += FixedMul(sidemove[speed], joyxmove);
+        }
+        else
+        {
+            if (joyxmove > 0)
+                side += sidemove[speed];
+            if (joyxmove < 0)
+                side -= sidemove[speed];
+        }
     } 
     else 
     { 
@@ -392,10 +402,21 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 	    cmd->angleturn -= angleturn[tspeed]; 
 	if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
 	    cmd->angleturn += angleturn[tspeed]; 
-	if (joyxmove > 0) 
-	    cmd->angleturn -= angleturn[tspeed]; 
-	if (joyxmove < 0) 
-	    cmd->angleturn += angleturn[tspeed]; 
+        if (use_analog && joyxmove)
+        {
+            // Cubic response curve allows for finer control when stick
+            // deflection is small.
+            joyxmove = FixedMul(FixedMul(joyxmove, joyxmove), joyxmove);
+            joyxmove = joyxmove * joystick_turn_sensitivity / 10;
+            cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
+        }
+        else
+        {
+            if (joyxmove > 0)
+                cmd->angleturn -= angleturn[tspeed];
+            if (joyxmove < 0)
+                cmd->angleturn += angleturn[tspeed];
+        }
     } 
  
     if (gamekeydown[key_up]) 
@@ -409,25 +430,48 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 	forward -= forwardmove[speed]; 
     }
 
-    if (joyymove < 0) 
-        forward += forwardmove[speed]; 
-    if (joyymove > 0) 
-        forward -= forwardmove[speed]; 
+    if (use_analog && joyymove)
+    {
+        joyymove = joyymove * joystick_move_sensitivity / 10;
+        joyymove = (joyymove > FRACUNIT) ? FRACUNIT : joyymove;
+        joyymove = (joyymove < -FRACUNIT) ? -FRACUNIT : joyymove;
+        forward -= FixedMul(forwardmove[speed], joyymove);
+    }
+    else
+    {
+        if (joyymove < 0)
+            forward += forwardmove[speed];
+        if (joyymove > 0)
+            forward -= forwardmove[speed];
+    }
 
     if (gamekeydown[key_strafeleft]
      || joybuttons[joybstrafeleft]
-     || mousebuttons[mousebstrafeleft]
-     || joystrafemove < 0)
+     || mousebuttons[mousebstrafeleft])
     {
         side -= sidemove[speed];
     }
 
     if (gamekeydown[key_straferight]
      || joybuttons[joybstraferight]
-     || mousebuttons[mousebstraferight]
-     || joystrafemove > 0)
+     || mousebuttons[mousebstraferight])
     {
         side += sidemove[speed]; 
+    }
+
+    if (use_analog && joystrafemove)
+    {
+        joystrafemove = joystrafemove * joystick_move_sensitivity / 10;
+        joystrafemove = (joystrafemove > FRACUNIT) ? FRACUNIT : joystrafemove;
+        joystrafemove = (joystrafemove < -FRACUNIT) ? -FRACUNIT : joystrafemove;
+        side += FixedMul(sidemove[speed], joystrafemove);
+    }
+    else
+    {
+        if (joystrafemove < 0)
+            side -= sidemove[speed];
+        if (joystrafemove > 0)
+            side += sidemove[speed];
     }
 
     // buttons

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -359,7 +359,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
             side += FixedMul(sidemove[speed], joyxmove);
         }
-        else
+        else if (joystick_move_sensitivity)
         {
             if (joyxmove > 0)
                 side += sidemove[speed];
@@ -381,7 +381,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             joyxmove = joyxmove * joystick_turn_sensitivity / 10;
             cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
         }
-        else
+        else if (joystick_turn_sensitivity)
         {
             if (joyxmove > 0)
                 cmd->angleturn -= angleturn[tspeed];
@@ -401,7 +401,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         joyymove = (joyymove < -FRACUNIT) ? FRACUNIT : joyymove;
         forward -= FixedMul(forwardmove[speed], joyymove);
     }
-    else
+    else if (joystick_move_sensitivity)
     {
         if (joyymove < 0)
             forward += forwardmove[speed];
@@ -422,7 +422,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         joystrafemove = (joystrafemove < -FRACUNIT) ? -FRACUNIT : joystrafemove;
         side += FixedMul(sidemove[speed], joystrafemove);
     }
-    else
+    else if (joystick_move_sensitivity)
     {
         if (joystrafemove < 0)
             side -= sidemove[speed];
@@ -445,7 +445,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         joylook = (joylook < -FRACUNIT) ? -FRACUNIT : joylook;
         look = -FixedMul(2, joylook);
     }
-    else
+    else if (joystick_look_sensitivity)
     {
         if (joylook < 0)
         {

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -23,6 +23,7 @@
 #include "doomkeys.h"
 #include "deh_str.h"
 #include "i_input.h"
+#include "i_joystick.h"
 #include "i_timer.h"
 #include "i_system.h"
 #include "m_argv.h"
@@ -351,10 +352,20 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             side += sidemove[speed];
         if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
             side -= sidemove[speed];
-        if (joyxmove > 0)
-            side += sidemove[speed];
-        if (joyxmove < 0)
-            side -= sidemove[speed];
+        if (use_analog && joyxmove)
+        {
+            joyxmove = joyxmove * joystick_move_sensitivity / 10;
+            joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
+            joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
+            side += FixedMul(sidemove[speed], joyxmove);
+        }
+        else
+        {
+            if (joyxmove > 0)
+                side += sidemove[speed];
+            if (joyxmove < 0)
+                side -= sidemove[speed];
+        }
     }
     else
     {
@@ -362,35 +373,89 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             cmd->angleturn -= angleturn[tspeed];
         if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
             cmd->angleturn += angleturn[tspeed];
-        if (joyxmove > 0)
-            cmd->angleturn -= angleturn[tspeed];
-        if (joyxmove < 0)
-            cmd->angleturn += angleturn[tspeed];
+        if (use_analog && joyxmove)
+        {
+            // Cubic response curve allows for finer control when stick
+            // deflection is small.
+            joyxmove = FixedMul(FixedMul(joyxmove, joyxmove), joyxmove);
+            joyxmove = joyxmove * joystick_turn_sensitivity / 10;
+            cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
+        }
+        else
+        {
+            if (joyxmove > 0)
+                cmd->angleturn -= angleturn[tspeed];
+            if (joyxmove < 0)
+                cmd->angleturn += angleturn[tspeed];
+        }
     }
 
     if (gamekeydown[key_up])
         forward += forwardmove[speed];
     if (gamekeydown[key_down])
         forward -= forwardmove[speed];
-    if (joyymove < 0)
-        forward += forwardmove[speed];
-    if (joyymove > 0)
-        forward -= forwardmove[speed];
+    if (use_analog && joyymove)
+    {
+        joyymove = joyymove * joystick_move_sensitivity / 10;
+        joyymove = (joyymove > FRACUNIT) ? FRACUNIT : joyymove;
+        joyymove = (joyymove < -FRACUNIT) ? FRACUNIT : joyymove;
+        forward -= FixedMul(forwardmove[speed], joyymove);
+    }
+    else
+    {
+        if (joyymove < 0)
+            forward += forwardmove[speed];
+        if (joyymove > 0)
+            forward -= forwardmove[speed];
+    }
     if (gamekeydown[key_straferight] || mousebuttons[mousebstraferight]
-     || joybuttons[joybstraferight] || joystrafemove > 0)
+     || joybuttons[joybstraferight])
         side += sidemove[speed];
     if (gamekeydown[key_strafeleft] || mousebuttons[mousebstrafeleft]
-     || joybuttons[joybstrafeleft] || joystrafemove < 0)
+     || joybuttons[joybstrafeleft])
         side -= sidemove[speed];
 
+    if (use_analog && joystrafemove)
+    {
+        joystrafemove = joystrafemove * joystick_move_sensitivity / 10;
+        joystrafemove = (joystrafemove > FRACUNIT) ? FRACUNIT : joystrafemove;
+        joystrafemove = (joystrafemove < -FRACUNIT) ? -FRACUNIT : joystrafemove;
+        side += FixedMul(sidemove[speed], joystrafemove);
+    }
+    else
+    {
+        if (joystrafemove < 0)
+            side -= sidemove[speed];
+        if (joystrafemove > 0)
+            side += sidemove[speed];
+    }
     // Look up/down/center keys
-    if (gamekeydown[key_lookup] || joylook < 0)
+    if (gamekeydown[key_lookup])
     {
         look = lspeed;
     }
-    if (gamekeydown[key_lookdown] || joylook > 0)
+    if (gamekeydown[key_lookdown])
     {
         look = -lspeed;
+    }
+    if (use_analog && joylook)
+    {
+        joylook = joylook * joystick_look_sensitivity / 10;
+        joylook = (joylook > FRACUNIT) ? FRACUNIT : joylook;
+        joylook = (joylook < -FRACUNIT) ? -FRACUNIT : joylook;
+        look = -FixedMul(2, joylook);
+    }
+    else
+    {
+        if (joylook < 0)
+        {
+            look = lspeed;
+        }
+
+        if (joylook > 0)
+        {
+            look = -lspeed;
+        }
     }
     // haleyjd: removed externdriver crap
     if (gamekeydown[key_lookcenter])

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -280,7 +280,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
             side += FixedMul(sidemove[pClass][speed], joyxmove);
         }
-        else
+        else if (joystick_move_sensitivity)
         {
             if (joyxmove > 0)
             {
@@ -306,7 +306,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             joyxmove = joyxmove * joystick_turn_sensitivity / 10;
             cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
         }
-        else
+        else if (joystick_turn_sensitivity)
         {
             if (joyxmove > 0)
                 cmd->angleturn -= angleturn[tspeed];
@@ -330,7 +330,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         joyymove = (joyymove < -FRACUNIT) ? FRACUNIT : joyymove;
         forward -= FixedMul(forwardmove[pClass][speed], joyymove);
     }
-    else
+    else if (joystick_move_sensitivity)
     {
         if (joyymove < 0)
         {
@@ -359,7 +359,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         joystrafemove = (joystrafemove < -FRACUNIT) ? -FRACUNIT : joystrafemove;
         side += FixedMul(sidemove[pClass][speed], joystrafemove);
     }
-    else
+    else if (joystick_move_sensitivity)
     {
         if (joystrafemove < 0)
             side -= sidemove[pClass][speed];
@@ -383,7 +383,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         joylook = (joylook < -FRACUNIT) ? -FRACUNIT : joylook;
         look = -FixedMul(2, joylook);
     }
-    else
+    else if (joystick_look_sensitivity)
     {
         if (joylook < 0)
         {

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -21,6 +21,7 @@
 #include "s_sound.h"
 #include "doomkeys.h"
 #include "i_input.h"
+#include "i_joystick.h"
 #include "i_video.h"
 #include "i_system.h"
 #include "i_timer.h"
@@ -272,13 +273,23 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         {
             side -= sidemove[pClass][speed];
         }
-        if (joyxmove > 0)
+        if (use_analog && joyxmove)
         {
-            side += sidemove[pClass][speed];
+            joyxmove = joyxmove * joystick_move_sensitivity / 10;
+            joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
+            joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
+            side += FixedMul(sidemove[pClass][speed], joyxmove);
         }
-        if (joyxmove < 0)
+        else
         {
-            side -= sidemove[pClass][speed];
+            if (joyxmove > 0)
+            {
+                side += sidemove[pClass][speed];
+            }
+            if (joyxmove < 0)
+            {
+                side -= sidemove[pClass][speed];
+            }
         }
     }
     else
@@ -287,10 +298,21 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             cmd->angleturn -= angleturn[tspeed];
         if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
             cmd->angleturn += angleturn[tspeed];
-        if (joyxmove > 0)
-            cmd->angleturn -= angleturn[tspeed];
-        if (joyxmove < 0)
-            cmd->angleturn += angleturn[tspeed];
+        if (use_analog && joyxmove)
+        {
+            // Cubic response curve allows for finer control when stick
+            // deflection is small.
+            joyxmove = FixedMul(FixedMul(joyxmove, joyxmove), joyxmove);
+            joyxmove = joyxmove * joystick_turn_sensitivity / 10;
+            cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
+        }
+        else
+        {
+            if (joyxmove > 0)
+                cmd->angleturn -= angleturn[tspeed];
+            if (joyxmove < 0)
+                cmd->angleturn += angleturn[tspeed];
+        }
     }
 
     if (gamekeydown[key_up])
@@ -301,33 +323,77 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         forward -= forwardmove[pClass][speed];
     }
-    if (joyymove < 0)
+    if (use_analog && joyymove)
     {
-        forward += forwardmove[pClass][speed];
+        joyymove = joyymove * joystick_move_sensitivity / 10;
+        joyymove = (joyymove > FRACUNIT) ? FRACUNIT : joyymove;
+        joyymove = (joyymove < -FRACUNIT) ? FRACUNIT : joyymove;
+        forward -= FixedMul(forwardmove[pClass][speed], joyymove);
     }
-    if (joyymove > 0)
+    else
     {
-        forward -= forwardmove[pClass][speed];
+        if (joyymove < 0)
+        {
+            forward += forwardmove[pClass][speed];
+        }
+        if (joyymove > 0)
+        {
+            forward -= forwardmove[pClass][speed];
+        }
     }
     if (gamekeydown[key_straferight] || mousebuttons[mousebstraferight]
-     || joystrafemove > 0 || joybuttons[joybstraferight])
+     || joybuttons[joybstraferight])
     {
         side += sidemove[pClass][speed];
     }
     if (gamekeydown[key_strafeleft] || mousebuttons[mousebstrafeleft]
-     || joystrafemove < 0 || joybuttons[joybstrafeleft])
+     || joybuttons[joybstrafeleft])
     {
         side -= sidemove[pClass][speed];
     }
 
+    if (use_analog && joystrafemove)
+    {
+        joystrafemove = joystrafemove * joystick_move_sensitivity / 10;
+        joystrafemove = (joystrafemove > FRACUNIT) ? FRACUNIT : joystrafemove;
+        joystrafemove = (joystrafemove < -FRACUNIT) ? -FRACUNIT : joystrafemove;
+        side += FixedMul(sidemove[pClass][speed], joystrafemove);
+    }
+    else
+    {
+        if (joystrafemove < 0)
+            side -= sidemove[pClass][speed];
+        if (joystrafemove > 0)
+            side += sidemove[pClass][speed];
+    }
+
     // Look up/down/center keys
-    if (gamekeydown[key_lookup] || joylook < 0)
+    if (gamekeydown[key_lookup])
     {
         look = lspeed;
     }
-    if (gamekeydown[key_lookdown] || joylook > 0)
+    if (gamekeydown[key_lookdown])
     {
         look = -lspeed;
+    }
+    if (use_analog && joylook)
+    {
+        joylook = joylook * joystick_look_sensitivity / 10;
+        joylook = (joylook > FRACUNIT) ? FRACUNIT : joylook;
+        joylook = (joylook < -FRACUNIT) ? -FRACUNIT : joylook;
+        look = -FixedMul(2, joylook);
+    }
+    else
+    {
+        if (joylook < 0)
+        {
+            look = lspeed;
+        }
+
+        if (joylook > 0)
+        {
+            look = -lspeed;
+        }
     }
     // haleyjd: removed externdriver crap
     if (gamekeydown[key_lookcenter])

--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -30,6 +30,7 @@
 #include "i_system.h"
 
 #include "m_config.h"
+#include "m_fixed.h"
 #include "m_misc.h"
 
 static SDL_GameController *gamepad = NULL;
@@ -79,6 +80,12 @@ static int joystick_x_dead_zone = 33;
 static int joystick_y_dead_zone = 33;
 static int joystick_strafe_dead_zone = 33;
 static int joystick_look_dead_zone = 33;
+
+int use_analog = 0;
+
+int joystick_turn_sensitivity = 10;
+int joystick_move_sensitivity = 10;
+int joystick_look_sensitivity = 10;
 
 // Virtual to physical button joystick button mapping. By default this
 // is a straight mapping.
@@ -294,13 +301,15 @@ static int GetAxisStateGamepad(int axis, int invert, int dead_zone)
 
     if (result < dead_zone && result > -dead_zone)
     {
-        result = 0;
+        return 0;
     }
 
     if (invert)
     {
         result = -result;
     }
+
+    result *= FRACUNIT / 32768; // Want FXP number between -1 and 1
 
     return result;
 }
@@ -667,6 +676,10 @@ void I_BindJoystickVariables(void)
     M_BindIntVariable("joystick_y_dead_zone", &joystick_y_dead_zone);
     M_BindIntVariable("joystick_strafe_dead_zone", &joystick_strafe_dead_zone);
     M_BindIntVariable("joystick_look_dead_zone", &joystick_look_dead_zone);
+    M_BindIntVariable("use_analog", &use_analog);
+    M_BindIntVariable("joystick_turn_sensitivity", &joystick_turn_sensitivity);
+    M_BindIntVariable("joystick_move_sensitivity", &joystick_move_sensitivity);
+    M_BindIntVariable("joystick_look_sensitivity", &joystick_look_sensitivity);
 
     for (i = 0; i < NUM_VIRTUAL_BUTTONS; ++i)
     {

--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -625,6 +625,8 @@ static int GetAxisState(int axis, int invert, int dead_zone)
         result = -result;
     }
 
+    result *= FRACUNIT / 32768; // Want FXP number between -1 and 1
+
     return result;
 }
 

--- a/src/i_joystick.h
+++ b/src/i_joystick.h
@@ -82,6 +82,11 @@ enum
     GAMEPAD_BUTTON_MAX
 };
 
+extern int use_analog;
+extern int joystick_turn_sensitivity;
+extern int joystick_move_sensitivity;
+extern int joystick_look_sensitivity;
+
 void I_InitJoystick(void);
 void I_ShutdownJoystick(void);
 void I_UpdateJoystick(void);

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1243,6 +1243,12 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(joystick_index),
 
     //!
+    // If non-zero, use analog movement when playing with a gamepad.
+    //
+
+    CONFIG_VARIABLE_INT(use_analog),
+
+    //!
     // Joystick axis to use to for horizontal (X) movement.
     //
 
@@ -1253,6 +1259,12 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(joystick_x_invert),
+
+    //!
+    // Joystick turn analog sensitivity, specified as a value between 0 and 20.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_turn_sensitivity),
 
     //!
     // Joystick axis to use to for vertical (Y) movement.
@@ -1280,6 +1292,12 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(joystick_strafe_invert),
 
     //!
+    // Joystick move and strafe analog sensitivity, specified as a value
+    // between 0 and 20.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_move_sensitivity),
+    //!
     // Joystick axis to use to for looking up and down.
     //
 
@@ -1291,6 +1309,12 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(joystick_look_invert),
+
+    //!
+    // Joystick look analog sensitivity, specified as a value between 0 and 20.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_look_sensitivity),
 
     //!
     // The physical joystick button that corresponds to joystick

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1154,7 +1154,7 @@ static void AdjustAnalog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
         TXT_NewLabel("Turn"),
         TXT_NewSpinControl(&joystick_turn_sensitivity, 0, 20),
         NULL);
-    if (gamemission == heretic || gamemission == hexen)
+    if (gamemission == heretic || gamemission == hexen || gamemission == strife)
     {
         TXT_AddWidgets(window,
             TXT_NewLabel("Look"),

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1008,7 +1008,6 @@ static int CalibrationEventCallback(SDL_Event *event, void *user_data)
     // joystick is being configured and which button the user is pressing.
     usejoystick = 1;
     use_gamepad = 0;
-    use_analog = 0;
     gamepad_type = SDL_CONTROLLER_TYPE_UNKNOWN;
     calibrate_button = event->jbutton.button;
 
@@ -1236,8 +1235,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
     TXT_AddWidget(window, TXT_TABLE_EOL);
 
     TXT_AddWidget(window,
-        TXT_NewConditional(&use_gamepad, 1,
-                   TXT_NewButton2("Analog settings", AdjustAnalog, NULL)));
+                   TXT_NewButton2("Analog settings", AdjustAnalog, NULL));
     TXT_AddWidget(window, TXT_TABLE_EOL);
 
     TXT_AddWidget(window, TXT_NewSeparator("Buttons"));

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1155,7 +1155,7 @@ static void AdjustAnalog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
         TXT_NewLabel("Turn"),
         TXT_NewSpinControl(&joystick_turn_sensitivity, 0, 20),
         NULL);
-    if (gamemission == heretic || gamemission == hexen || gamemission == strife)
+    if (gamemission == heretic || gamemission == hexen)
     {
         TXT_AddWidgets(window,
             TXT_NewLabel("Look"),

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -92,6 +92,12 @@ static int joystick_y_dead_zone = 33;
 static int joystick_strafe_dead_zone = 33;
 static int joystick_look_dead_zone = 33;
 
+int use_analog = 0;
+
+int joystick_turn_sensitivity = 10;
+int joystick_move_sensitivity = 10;
+int joystick_look_sensitivity = 10;
+
 // Virtual to physical mapping.
 int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
@@ -1002,6 +1008,7 @@ static int CalibrationEventCallback(SDL_Event *event, void *user_data)
     // joystick is being configured and which button the user is pressing.
     usejoystick = 1;
     use_gamepad = 0;
+    use_analog = 0;
     gamepad_type = SDL_CONTROLLER_TYPE_UNKNOWN;
     calibrate_button = event->jbutton.button;
 
@@ -1133,6 +1140,34 @@ static void SwapLRSticks(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     }
 }
 
+static void AdjustAnalog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
+{
+    txt_window_t *window;
+
+    window = TXT_NewWindow("Analog Settings");
+    TXT_SetTableColumns(window, 2);
+    TXT_SetColumnWidths(window, 10, 6);
+    TXT_AddWidgets(window,
+        TXT_NewCheckBox("Use analog controls", &use_analog),
+        TXT_NewSeparator("Sensitivity"),
+        TXT_NewLabel("Movement"),
+        TXT_NewSpinControl(&joystick_move_sensitivity, 0, 20),
+        TXT_NewLabel("Turn"),
+        TXT_NewSpinControl(&joystick_turn_sensitivity, 0, 20),
+        NULL);
+    if (gamemission == heretic || gamemission == hexen || gamemission == strife)
+    {
+        TXT_AddWidgets(window,
+            TXT_NewLabel("Look"),
+            TXT_NewSpinControl(&joystick_look_sensitivity, 0, 20), NULL);
+    }
+    TXT_SetWindowAction(window, TXT_HORIZ_LEFT, NULL);
+    TXT_SetWindowAction(window, TXT_HORIZ_CENTER,
+        TXT_NewWindowEscapeAction(window));
+    TXT_SetWindowAction(window, TXT_HORIZ_RIGHT, NULL);
+    TXT_SetWidgetAlign(window, TXT_HORIZ_CENTER);
+}
+
 void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
@@ -1197,14 +1232,13 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 
     TXT_AddWidget(window,
         TXT_NewConditional(&use_gamepad, 1,
-            TXT_MakeTable(6,
-                   TXT_NewButton2("Swap L and R sticks", SwapLRSticks, NULL),
-                   TXT_TABLE_OVERFLOW_RIGHT,
-                   TXT_TABLE_OVERFLOW_RIGHT,
-                   TXT_TABLE_EMPTY,
-                   TXT_TABLE_EMPTY,
-                   TXT_TABLE_EMPTY,
-                   NULL)));
+                   TXT_NewButton2("Swap L and R sticks", SwapLRSticks, NULL)));
+    TXT_AddWidget(window, TXT_TABLE_EOL);
+
+    TXT_AddWidget(window,
+        TXT_NewConditional(&use_gamepad, 1,
+                   TXT_NewButton2("Analog settings", AdjustAnalog, NULL)));
+    TXT_AddWidget(window, TXT_TABLE_EOL);
 
     TXT_AddWidget(window, TXT_NewSeparator("Buttons"));
 
@@ -1267,6 +1301,10 @@ void BindJoystickVariables(void)
     M_BindIntVariable("joystick_y_dead_zone", &joystick_y_dead_zone);
     M_BindIntVariable("joystick_strafe_dead_zone", &joystick_strafe_dead_zone);
     M_BindIntVariable("joystick_look_dead_zone", &joystick_look_dead_zone);
+    M_BindIntVariable("use_analog", &use_analog);
+    M_BindIntVariable("joystick_turn_sensitivity", &joystick_turn_sensitivity);
+    M_BindIntVariable("joystick_move_sensitivity", &joystick_move_sensitivity);
+    M_BindIntVariable("joystick_look_sensitivity", &joystick_look_sensitivity);
 
     for (i = 0; i < NUM_VIRTUAL_BUTTONS; ++i)
     {

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -345,11 +345,11 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         consistancy[consoleplayer][maketic%BACKUPTICS]; 
 
     // villsa [STRIFE] look up key
-    if(gamekeydown[key_lookup] || joylook < 0)
+    if(gamekeydown[key_lookup] || (joylook < 0 && joystick_look_sensitivity))
         cmd->buttons2 |= BT2_LOOKUP;
 
     // villsa [STRIFE] look down key
-    if(gamekeydown[key_lookdown] || joylook > 0)
+    if(gamekeydown[key_lookdown] || (joylook > 0 && joystick_look_sensitivity))
         cmd->buttons2 |= BT2_LOOKDOWN;
 
     // villsa [STRIFE] inventory use key
@@ -439,7 +439,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
             side += FixedMul(sidemove[speed], joyxmove);
         }
-        else
+        else if (joystick_move_sensitivity)
         {
             if (joyxmove > 0)
                 side += sidemove[speed];
@@ -462,7 +462,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             joyxmove = joyxmove * joystick_turn_sensitivity / 10;
             cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
         }
-        else
+        else if (joystick_turn_sensitivity)
         {
             if (joyxmove > 0)
                 cmd->angleturn -= angleturn[tspeed];
@@ -489,7 +489,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         joyymove = (joyymove < -FRACUNIT) ? FRACUNIT : joyymove;
         forward -= FixedMul(forwardmove[speed], joyymove);
     }
-    else
+    else if (joystick_move_sensitivity)
     {
         if (joyymove < 0)
             forward += forwardmove[speed];
@@ -518,7 +518,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         joystrafemove = (joystrafemove < -FRACUNIT) ? -FRACUNIT : joystrafemove;
         side += FixedMul(sidemove[speed], joystrafemove);
     }
-    else
+    else if (joystick_move_sensitivity)
     {
         if (joystrafemove < 0)
             side -= sidemove[speed];

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -35,6 +35,7 @@
 #include "m_saves.h" // STRIFE
 #include "m_random.h"
 #include "i_input.h"
+#include "i_joystick.h"
 #include "i_system.h"
 #include "i_timer.h"
 #include "i_video.h"
@@ -431,10 +432,20 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             //	fprintf(stderr, "strafe left\n");
             side -= sidemove[speed]; 
         }
-        if (joyxmove > 0) 
-            side += sidemove[speed]; 
-        if (joyxmove < 0) 
-            side -= sidemove[speed]; 
+        if (use_analog && joyxmove)
+        {
+            joyxmove = joyxmove * joystick_move_sensitivity / 10;
+            joyxmove = (joyxmove > FRACUNIT) ? FRACUNIT : joyxmove;
+            joyxmove = (joyxmove < -FRACUNIT) ? -FRACUNIT : joyxmove;
+            side += FixedMul(sidemove[speed], joyxmove);
+        }
+        else
+        {
+            if (joyxmove > 0)
+                side += sidemove[speed];
+            if (joyxmove < 0)
+                side -= sidemove[speed];
+        }
 
     } 
     else 
@@ -443,10 +454,21 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
             cmd->angleturn -= angleturn[tspeed]; 
         if (gamekeydown[key_left] || mousebuttons[mousebturnleft])
             cmd->angleturn += angleturn[tspeed]; 
-        if (joyxmove > 0) 
-            cmd->angleturn -= angleturn[tspeed]; 
-        if (joyxmove < 0) 
-            cmd->angleturn += angleturn[tspeed]; 
+        if (use_analog && joyxmove)
+        {
+            // Cubic response curve allows for finer control when stick
+            // deflection is small.
+            joyxmove = FixedMul(FixedMul(joyxmove, joyxmove), joyxmove);
+            joyxmove = joyxmove * joystick_turn_sensitivity / 10;
+            cmd->angleturn -= FixedMul(angleturn[1], joyxmove);
+        }
+        else
+        {
+            if (joyxmove > 0)
+                cmd->angleturn -= angleturn[tspeed];
+            if (joyxmove < 0)
+                cmd->angleturn += angleturn[tspeed];
+        }
     } 
 
     if (gamekeydown[key_up]) 
@@ -460,27 +482,49 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         forward -= forwardmove[speed]; 
     }
 
-    if (joyymove < 0) 
-        forward += forwardmove[speed]; 
-    if (joyymove > 0) 
-        forward -= forwardmove[speed]; 
+    if (use_analog && joyymove)
+    {
+        joyymove = joyymove * joystick_move_sensitivity / 10;
+        joyymove = (joyymove > FRACUNIT) ? FRACUNIT : joyymove;
+        joyymove = (joyymove < -FRACUNIT) ? FRACUNIT : joyymove;
+        forward -= FixedMul(forwardmove[speed], joyymove);
+    }
+    else
+    {
+        if (joyymove < 0)
+            forward += forwardmove[speed];
+        if (joyymove > 0)
+            forward -= forwardmove[speed];
+    }
 
     if (gamekeydown[key_strafeleft]
      || joybuttons[joybstrafeleft]
-     || mousebuttons[mousebstrafeleft]
-     || joystrafemove < 0)
+     || mousebuttons[mousebstrafeleft])
     {
         side -= sidemove[speed];
     }
 
     if (gamekeydown[key_straferight]
      || joybuttons[joybstraferight]
-     || mousebuttons[mousebstraferight]
-     || joystrafemove > 0)
+     || mousebuttons[mousebstraferight])
     {
         side += sidemove[speed]; 
     }
 
+    if (use_analog && joystrafemove)
+    {
+        joystrafemove = joystrafemove * joystick_move_sensitivity / 10;
+        joystrafemove = (joystrafemove > FRACUNIT) ? FRACUNIT : joystrafemove;
+        joystrafemove = (joystrafemove < -FRACUNIT) ? -FRACUNIT : joystrafemove;
+        side += FixedMul(sidemove[speed], joystrafemove);
+    }
+    else
+    {
+        if (joystrafemove < 0)
+            side -= sidemove[speed];
+        if (joystrafemove > 0)
+            side += sidemove[speed];
+    }
     // buttons
     cmd->chatchar = HU_dequeueChatChar(); 
 


### PR DESCRIPTION
This PR adds analog gamepad control to all games. A few comments:

* Movement axis values are clamped to prevent automatic SR50, but turning is unconstrained.
* Analog control is off by default.
* User adjustable sensitivity for move, turn and look.
* Analog look speed in the non-Doom games is limited as to not exceed the Vanilla look up/down keypress speed. Frankly this doesn't feel that great but I'm not sure if this can improved without breaking demo compatibility. Ideas are welcome!

![image](https://github.com/chocolate-doom/chocolate-doom/assets/43701387/d6dacdf7-7237-4d01-8a1a-4c0ce8c641f6)
