### PR TITLE
evaluate `numiwadlumps` after `DoMerge()` has been called

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1294,7 +1294,6 @@ void D_DoomMain (void)
     int p;
     char file[256];
     char demolumpname[9];
-    int numiwadlumps;
 
     I_AtExit(D_Endoom, false);
 
@@ -1504,7 +1503,6 @@ void D_DoomMain (void)
 
     DEH_printf("W_Init: Init WADfiles.\n");
     D_AddFile(iwadfile);
-    numiwadlumps = numlumps;
 
     W_CheckCorrectIWAD(doom);
 
@@ -1706,6 +1704,12 @@ void D_DoomMain (void)
     if (M_ParmExists("-dehlump"))
     {
         int i, loaded = 0;
+        int numiwadlumps = numlumps;
+
+        while (!W_IsIWADLump(lumpinfo[numiwadlumps - 1]))
+        {
+            numiwadlumps--;
+        }
 
         for (i = numiwadlumps; i < numlumps; ++i)
         {


### PR DESCRIPTION
If a merged PWAD contains sprites, these get mangled into the IWAD sprites, changing the value of `numlumps` and thus invalidating the value of `numiwadlumps` determined earlier. Also, this variable is only used in one occasion, so only evaluate it as needed.

This approach makes sure `numiwadlumps` points past the index of the last IWAD lump in the linear `lumpinfo[]` array.

Fixes https://github.com/fabiangreffrath/crispy-doom/issues/1101