### PR TITLE
add a fsynth_gain config key to fine tune the FluidSynth output level

### DIFF
--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -55,6 +55,7 @@ float fsynth_reverb_damp = 0.4f;
 float fsynth_reverb_level = 0.15f;
 float fsynth_reverb_roomsize = 0.6f;
 float fsynth_reverb_width = 4.0f;
+float fsynth_gain = 1.0f;
 
 static fluid_synth_t *synth = NULL;
 static fluid_settings_t *settings = NULL;
@@ -119,6 +120,15 @@ static boolean I_FL_InitMusic(void)
                               fsynth_chorus_speed);
     }
 
+    if (fsynth_gain < 0.1f)
+    {
+        fsynth_gain = 0.1f;
+    }
+    if (fsynth_gain > 10.0f)
+    {
+        fsynth_gain = 10.0f;
+    }
+
     synth = new_fluid_synth(settings);
 
     if (synth == NULL)
@@ -154,7 +164,7 @@ static void I_FL_SetMusicVolume(int volume)
     }
     // FluidSynth's default is 0.2. Make 1.0 the maximum.
     // 0 -- 0.2 -- 10.0
-    fluid_synth_set_gain(synth, (float) volume / 127);
+    fluid_synth_set_gain(synth, ((float) volume / 127) * fsynth_gain);
 }
 
 static void I_FL_PauseSong(void)

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -120,9 +120,9 @@ static boolean I_FL_InitMusic(void)
                               fsynth_chorus_speed);
     }
 
-    if (fsynth_gain < 0.1f)
+    if (fsynth_gain < 0.0f)
     {
-        fsynth_gain = 0.1f;
+        fsynth_gain = 0.0f;
     }
     if (fsynth_gain > 10.0f)
     {

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -525,6 +525,7 @@ void I_BindSoundVariables(void)
     M_BindFloatVariable("fsynth_reverb_level",      &fsynth_reverb_level);
     M_BindFloatVariable("fsynth_reverb_roomsize",   &fsynth_reverb_roomsize);
     M_BindFloatVariable("fsynth_reverb_width",      &fsynth_reverb_width);
+    M_BindFloatVariable("fsynth_gain",              &fsynth_gain);
     M_BindStringVariable("fsynth_sf_path",          &fsynth_sf_path);
 #endif // HAVE_FLUIDSYNTH
 

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -293,6 +293,7 @@ extern float fsynth_reverb_damp;
 extern float fsynth_reverb_level;
 extern float fsynth_reverb_roomsize;
 extern float fsynth_reverb_width;
+extern float fsynth_gain;
 #endif // HAVE_FLUIDSYNTH
 
 #endif

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1022,6 +1022,13 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_FLOAT(fsynth_reverb_width),
 
     //!
+    // Fine tune the FluidSynth output level. Default is 1.0,
+    // range is 0.1 - 10.0.
+    //
+
+    CONFIG_VARIABLE_FLOAT(fsynth_gain),
+
+    //!
     // Full path to a soundfont file to use with FluidSynth MIDI playback.
     //
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1023,7 +1023,7 @@ static default_t extra_defaults_list[] =
 
     //!
     // Fine tune the FluidSynth output level. Default is 1.0,
-    // range is 0.1 - 10.0.
+    // range is 0.0 - 10.0.
     //
 
     CONFIG_VARIABLE_FLOAT(fsynth_gain),

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -103,6 +103,7 @@ float fsynth_reverb_damp = 0.4f;
 float fsynth_reverb_level = 0.15f;
 float fsynth_reverb_roomsize = 0.6f;
 float fsynth_reverb_width = 4.0f;
+float fsynth_gain = 1.0f;
 #endif // HAVE_FLUIDSYNTH
 
 // DOS specific variables: these are unused but should be maintained
@@ -376,6 +377,7 @@ void BindSoundVariables(void)
     M_BindFloatVariable("fsynth_reverb_level",    &fsynth_reverb_level);
     M_BindFloatVariable("fsynth_reverb_roomsize", &fsynth_reverb_roomsize);
     M_BindFloatVariable("fsynth_reverb_width",    &fsynth_reverb_width);
+    M_BindFloatVariable("fsynth_gain",            &fsynth_gain);
     M_BindStringVariable("fsynth_sf_path",        &fsynth_sf_path);
 #endif // HAVE_FLUIDSYNTH
 


### PR DESCRIPTION
Fixes #https://github.com/fabiangreffrath/crispy-doom/issues/1087