### PR TITLE
Increase default heap size for 64-bit build

### DIFF
--- a/src/i_system.c
+++ b/src/i_system.c
@@ -134,7 +134,7 @@ byte *I_ZoneBase (int *size)
     // @category obscure
     // @arg <mb>
     //
-    // Specify the heap size, in MiB (default 16).
+    // Specify the heap size, in MiB.
     //
 
     p = M_CheckParmWithArgs("-mb", 1);
@@ -146,7 +146,21 @@ byte *I_ZoneBase (int *size)
     }
     else
     {
-        default_ram = DEFAULT_RAM;
+        // Because of the 8-byte pointer size in a 64-bit build, the default
+        // heap size (16 MiB) is insufficient compared to a 32-bit build. For
+        // example, the Alien Vendetta avm62402.lmp demo completes successfully
+        // on a 32-bit build, but terminates with an out of memory error on a
+        // 64-bit build. Therefore, to maintain consistency with a 32-bit
+        // build, the heap size should be increased.
+
+        if (sizeof(void *) == 8)
+        {
+            default_ram = DEFAULT_RAM * 2;
+        }
+        else
+        {
+            default_ram = DEFAULT_RAM;
+        }
         min_ram = MIN_RAM;
     }
 


### PR DESCRIPTION
Because of the 8-byte pointer size in a 64-bit build, the default heap size (16 Mbytes) is insufficient compared to a 32-bit build. For example, the Alien Vendetta [avm62402.lmp](https://www.dsdarchive.com/files/demos/av/61064/avm62402.zip) demo completes successfully in a 32-bit build but in a 64-bit build it terminates with an out of memory error. Hence increase of the heap size twice for consistency with a 32-bit build.

Fix #1633, thanks to @JNechaevsky for the bug report.