### PR TITLE
Remove unused global char arrays `wadfile` and `mapdir`

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -120,9 +120,6 @@ boolean         storedemo;
 // If true, the main game loop has started.
 boolean         main_loop_started = false;
 
-char		wadfile[1024];		// primary wad file
-char		mapdir[1024];           // directory of development maps
-
 int             show_endoom = 1;
 int             show_diskicon = 1;
 

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -137,9 +137,6 @@ boolean         isdemoversion;
 //boolean         storedemo;
 
 
-char		wadfile[1024];          // primary wad file
-char		mapdir[1024];           // directory of development maps
-
 int             show_endoom = 1;
 int             show_diskicon = 1;
 int             graphical_startup = 1;


### PR DESCRIPTION
Both of these has been first introduced with the initial revision commit (66a2cc66d7504c9b64e1c461e62ad2a9d964fa95), but it seems they were never used.