### PR TITLE
Remove unused `leveljuststarted` globals

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -197,8 +197,6 @@ mline_t thintriangle_guy[] = {
 static int 	cheating = 0;
 static int 	grid = 0;
 
-static int 	leveljuststarted = 1; 	// kluge until AM_LevelInit() is called
-
 boolean    	automapactive = false;
 static int 	finit_width = SCREENWIDTH;
 static int 	finit_height = SCREENHEIGHT - ST_HEIGHT;
@@ -519,8 +517,6 @@ void AM_clearMarks(void)
 //
 void AM_LevelInit(void)
 {
-    leveljuststarted = 0;
-
     f_x = f_y = 0;
     f_w = finit_width;
     f_h = finit_height;

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -94,8 +94,6 @@ const char *LevelNames[] = {
 static int cheating = 0;
 static int grid = 0;
 
-static int leveljuststarted = 1;        // kluge until AM_LevelInit() is called
-
 boolean automapactive = false;
 static int finit_width = SCREENWIDTH;
 static int finit_height = SCREENHEIGHT - 42;
@@ -433,8 +431,6 @@ void AM_clearMarks(void)
 
 void AM_LevelInit(void)
 {
-    leveljuststarted = 0;
-
     f_x = f_y = 0;
     f_w = finit_width;
     f_h = finit_height;

--- a/src/hexen/am_map.c
+++ b/src/hexen/am_map.c
@@ -33,8 +33,6 @@
 int cheating = 0;
 static int grid = 0;
 
-static int leveljuststarted = 1;        // kluge until AM_LevelInit() is called
-
 boolean automapactive = false;
 static int finit_width = SCREENWIDTH;
 static int finit_height = SCREENHEIGHT - SBARHEIGHT - 3;
@@ -346,8 +344,6 @@ void AM_clearMarks(void)
 
 void AM_LevelInit(void)
 {
-    leveljuststarted = 0;
-
     f_x = f_y = 0;
     f_w = finit_width;
     f_h = finit_height;

--- a/src/strife/am_map.c
+++ b/src/strife/am_map.c
@@ -173,8 +173,6 @@ mline_t thintriangle_guy[] = {
 static int 	cheating = 0;
 //static int 	grid = 0;     [STRIFE]: no such variable
 
-static int 	leveljuststarted = 1; 	// kluge until AM_LevelInit() is called
-
 boolean    	automapactive = false;
 static int 	finit_width = SCREENWIDTH;
 static int 	finit_height = SCREENHEIGHT - 32;
@@ -498,8 +496,6 @@ void AM_clearMarks(void)
 //
 void AM_LevelInit(void)
 {
-    leveljuststarted = 0;
-
     f_x = f_y = 0;
     f_w = finit_width;
     f_h = finit_height;


### PR DESCRIPTION
These are only ever set, but never read, so they can just be removed.