### PR TITLE
Remove unused variables/datatypes/defines in st_stuff.{h,c}

### DIFF
--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -275,9 +275,6 @@ static int		lu_palette;
 // used for making messages go away
 static int		st_msgcounter=0;
 
-// used when in chat 
-static st_chatstateenum_t	st_chatstate;
-
 // whether left-side main status bar is active
 static boolean		st_statusbaron;
 
@@ -1221,8 +1218,6 @@ void ST_initData(void)
 
     st_firsttime = true;
     plyr = &players[consoleplayer];
-
-    st_chatstate = StartChatState;
 
     st_statusbaron = true;
     st_oldchat = st_chat = false;

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -293,9 +293,6 @@ static boolean		st_chat;
 // value of st_chat before message popped up
 static boolean		st_oldchat;
 
-// whether chat window has the cursor on
-static boolean		st_cursoron;
-
 // !deathmatch
 static boolean		st_notdeathmatch; 
 
@@ -1240,7 +1237,6 @@ void ST_initData(void)
 
     st_statusbaron = true;
     st_oldchat = st_chat = false;
-    st_cursoron = false;
 
     st_faceindex = 0;
     st_palette = -1;

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -272,9 +272,6 @@ static boolean		st_firsttime;
 // lump number for PLAYPAL
 static int		lu_palette;
 
-// used for timing
-static unsigned int	st_clock;
-
 // used for making messages go away
 static int		st_msgcounter=0;
 
@@ -947,7 +944,6 @@ void ST_updateWidgets(void)
 void ST_Ticker (void)
 {
 
-    st_clock++;
     st_randomnumber = M_Random();
     ST_updateWidgets();
     st_oldhealth = plyr->health;
@@ -1231,7 +1227,6 @@ void ST_initData(void)
     st_firsttime = true;
     plyr = &players[consoleplayer];
 
-    st_clock = 0;
     st_chatstate = StartChatState;
     st_gamestate = FirstPersonState;
 

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -73,23 +73,12 @@
 // Radiation suit, green shift.
 #define RADIATIONPAL		13
 
-// N/256*100% probability
-//  that the normal face state will change
-#define ST_FACEPROBABILITY		96
-
-// For Responder
-#define ST_TOGGLECHAT		KEY_ENTER
-
 // Location of status bar
 #define ST_X				0
 #define ST_X2				104
 
 #define ST_FX  			143
 #define ST_FY  			169
-
-// Should be set to patch width
-//  for tall numbers later on
-#define ST_TALLNUMWIDTH		(tallnum[0]->width)
 
 // Number of status faces.
 #define ST_NUMPAINFACES		5
@@ -203,62 +192,8 @@
 #define ST_MAXAMMO3X		314
 #define ST_MAXAMMO3Y		185
 
-// pistol
-#define ST_WEAPON0X			110 
-#define ST_WEAPON0Y			172
-
-// shotgun
-#define ST_WEAPON1X			122 
-#define ST_WEAPON1Y			172
-
-// chain gun
-#define ST_WEAPON2X			134 
-#define ST_WEAPON2Y			172
-
-// missile launcher
-#define ST_WEAPON3X			110 
-#define ST_WEAPON3Y			181
-
-// plasma gun
-#define ST_WEAPON4X			122 
-#define ST_WEAPON4Y			181
-
- // bfg
-#define ST_WEAPON5X			134
-#define ST_WEAPON5Y			181
-
-// WPNS title
-#define ST_WPNSX			109 
-#define ST_WPNSY			191
-
- // DETH title
-#define ST_DETHX			109
-#define ST_DETHY			191
-
-//Incoming messages window location
-//UNUSED
-// #define ST_MSGTEXTX	   (viewwindowx)
-// #define ST_MSGTEXTY	   (viewwindowy+viewheight-18)
-#define ST_MSGTEXTX			0
-#define ST_MSGTEXTY			0
 // Dimensions given in characters.
 #define ST_MSGWIDTH			52
-// Or shall I say, in lines?
-#define ST_MSGHEIGHT		1
-
-#define ST_OUTTEXTX			0
-#define ST_OUTTEXTY			6
-
-// Width, in characters again.
-#define ST_OUTWIDTH			52 
- // Height, in lines. 
-#define ST_OUTHEIGHT		1
-
-#define ST_MAPTITLEX \
-    (SCREENWIDTH - ST_MAPWIDTH * ST_CHATFONTWIDTH)
-
-#define ST_MAPTITLEY		0
-#define ST_MAPHEIGHT		1
 
 // graphics are drawn to a backing screen and blitted to the real screen
 pixel_t			*st_backing_screen;

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -278,9 +278,6 @@ static int		st_msgcounter=0;
 // used when in chat 
 static st_chatstateenum_t	st_chatstate;
 
-// whether in automap or first-person
-static st_stateenum_t	st_gamestate;
-
 // whether left-side main status bar is active
 static boolean		st_statusbaron;
 
@@ -449,13 +446,11 @@ ST_Responder (event_t* ev)
     switch(ev->data1)
     {
       case AM_MSGENTERED:
-	st_gamestate = AutomapState;
 	st_firsttime = true;
 	break;
 	
       case AM_MSGEXITED:
 	//	fprintf(stderr, "AM exited\n");
-	st_gamestate = FirstPersonState;
 	break;
     }
   }
@@ -1228,7 +1223,6 @@ void ST_initData(void)
     plyr = &players[consoleplayer];
 
     st_chatstate = StartChatState;
-    st_gamestate = FirstPersonState;
 
     st_statusbaron = true;
     st_oldchat = st_chat = false;

--- a/src/doom/st_stuff.h
+++ b/src/doom/st_stuff.h
@@ -53,15 +53,6 @@ void ST_Init (void);
 
 
 
-// States for status bar code.
-typedef enum
-{
-    AutomapState,
-    FirstPersonState
-    
-} st_stateenum_t;
-
-
 // States for the chat code.
 typedef enum
 {

--- a/src/doom/st_stuff.h
+++ b/src/doom/st_stuff.h
@@ -53,17 +53,6 @@ void ST_Init (void);
 
 
 
-// States for the chat code.
-typedef enum
-{
-    StartChatState,
-    WaitDestState,
-    GetChatState
-    
-} st_chatstateenum_t;
-
-
-
 extern pixel_t *st_backing_screen;
 extern cheatseq_t cheat_mus;
 extern cheatseq_t cheat_god;

--- a/src/strife/st_stuff.c
+++ b/src/strife/st_stuff.c
@@ -148,9 +148,6 @@ static boolean          st_firsttime;
 // lump number for PLAYPAL
 static int              lu_palette;
 
-// whether in automap or first-person
-static st_stateenum_t   st_gamestate;
-
 // whether left-side main status bar is active
 static boolean          st_statusbaron;
 
@@ -307,12 +304,10 @@ boolean ST_Responder(event_t* ev)
             switch(ev->data1)
             {
             case AM_MSGENTERED:
-                st_gamestate = AutomapState;
                 st_firsttime = true;
                 break;
 
             case AM_MSGEXITED:
-                st_gamestate = FirstPersonState;
                 break;
             }
 
@@ -1528,8 +1523,6 @@ void ST_initData(void)
 {
     st_firsttime = true;
     plyr = &players[consoleplayer];
-
-    st_gamestate = FirstPersonState;
 
     st_statusbaron = true;
 

--- a/src/strife/st_stuff.h
+++ b/src/strife/st_stuff.h
@@ -58,15 +58,6 @@ void ST_Init (void);
 
 
 
-// States for status bar code.
-typedef enum
-{
-    AutomapState,
-    FirstPersonState
-    
-} st_stateenum_t;
-
-
 // States for the chat code.
 typedef enum
 {

--- a/src/strife/st_stuff.h
+++ b/src/strife/st_stuff.h
@@ -58,17 +58,6 @@ void ST_Init (void);
 
 
 
-// States for the chat code.
-typedef enum
-{
-    StartChatState,
-    WaitDestState,
-    GetChatState
-    
-} st_chatstateenum_t;
-
-
-
 extern byte *st_backing_screen;
 
 extern cheatseq_t cheat_mus;     // [STRIFE]: idmus -> spin


### PR DESCRIPTION
This PR removes variables, datatypes and #defines from the `st_stuff` module that has never been used.