### PR TITLE
Handle DMX format 0 MIDI bug

### DIFF
--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -85,6 +85,7 @@ void S_StartSong(int song, boolean loop)
     {
         I_StopSong();
         I_UnRegisterSong(rs);
+        rs = NULL;
     }
 
     if (song < mus_e1m1 || song > NUMMUSIC)

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -40,6 +40,7 @@ typedef fluid_long_long_t fluid_int_t;
 #include "i_sound.h"
 #include "m_misc.h"
 #include "memio.h"
+#include "midifile.h"
 #include "mus2mid.h"
 
 char *fsynth_sf_path = "";
@@ -222,7 +223,10 @@ static void *I_FL_RegisterSong(void *data, int len)
 
     if (IsMid(data, len))
     {
-        result = fluid_player_add_mem(player, data, len);
+        if (MIDI_CheckFile(data, len))
+        {
+            result = fluid_player_add_mem(player, data, len);
+        }
 
         if (result == FLUID_FAILED)
         {

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1642,6 +1642,7 @@ static void *I_OPL_RegisterSong(void *data, int len)
 {
     midi_file_t *result;
     char *filename;
+    boolean valid = false;
 
     if (!music_initialized)
     {
@@ -1656,15 +1657,16 @@ static void *I_OPL_RegisterSong(void *data, int len)
     if (IsMid(data, len) && len < MAXMIDLENGTH)
     {
         M_WriteFile(filename, data, len);
+        valid = MIDI_CheckFile(data, len);
     }
     else
     {
         // Assume a MUS file and try to convert
 
-        ConvertMus(data, len, filename);
+        valid = (ConvertMus(data, len, filename) == 0);
     }
 
-    result = MIDI_LoadFile(filename);
+    result = valid ? MIDI_LoadFile(filename) : NULL;
 
     if (result == NULL)
     {

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1736,6 +1736,7 @@ static void *I_WIN_RegisterSong(void *data, int len)
     unsigned int i;
     char *filename;
     midi_file_t *file;
+    boolean valid = false;
 
     MIDIPROPTIMEDIV prop_timediv;
     MIDIPROPTEMPO prop_tempo;
@@ -1754,15 +1755,16 @@ static void *I_WIN_RegisterSong(void *data, int len)
     if (IsMid(data, len))
     {
         M_WriteFile(filename, data, len);
+        valid = MIDI_CheckFile(data, len);
     }
     else
     {
         // Assume a MUS file and try to convert
 
-        ConvertMus(data, len, filename);
+        valid = (ConvertMus(data, len, filename) == 0);
     }
 
-    file = MIDI_LoadFile(filename);
+    file = valid ? MIDI_LoadFile(filename) : NULL;
 
     M_remove(filename);
     free(filename);

--- a/src/memio.c
+++ b/src/memio.c
@@ -182,7 +182,7 @@ int mem_fseek(MEMFILE *stream, signed long position, mem_rel_t whence)
 			return -1;
 	}
 
-	if (newpos < stream->buflen)
+	if (newpos <= stream->buflen)
 	{
 		stream->position = newpos;
 		return 0;

--- a/src/midifile.h
+++ b/src/midifile.h
@@ -18,6 +18,8 @@
 #ifndef MIDIFILE_H
 #define MIDIFILE_H
 
+#include "doomtype.h"
+
 typedef struct midi_file_s midi_file_t;
 typedef struct midi_track_iter_s midi_track_iter_t;
 
@@ -183,6 +185,10 @@ typedef struct
         midi_sysex_event_data_t sysex;
     } data;
 } midi_event_t;
+
+// Check if MIDI file is valid.
+
+boolean MIDI_CheckFile(void *data, int len);
 
 // Load a MIDI file.
 


### PR DESCRIPTION
Fixes https://github.com/chocolate-doom/chocolate-doom/issues/1645.

In Vanilla Doom, loading a format 0 MIDI file causes heap corruption unless 3 or more dummy bytes are added to the end of the file (another workaround is converting the file to format 1 which is unaffected). Why 3 bytes? That's the length of an end of track event. Due to a DMX bug, the event is written after the memory block reserved for the MIDI file. This ends up overwriting adjacent portions of the heap. The reserved memory size is based on the file size, not the actual track size reported by the header, which allows the 3-byte trick to work. Why is the event added by DMX in the first place? Unknown, but possibly as a precaution to fix broken MIDI files.

[Doomworld thread](https://www.doomworld.com/forum/post/2541624)
[Additional details](https://github.com/chocolate-doom/chocolate-doom/issues/1645#issuecomment-1831132894)

Test wad: [format0.zip](https://github.com/chocolate-doom/chocolate-doom/files/13501021/format0.zip). Load the first map in any game supported by Chocolate and it will exit with an error, mimicking vanilla behavior.
