### PR TITLE
Fix `-1`, `-2` and `-3` command-line options

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -917,10 +917,20 @@ void I_InitWindowIcon(void)
 
 static void SetScaleFactor(int factor)
 {
+    int height;
+
     // Pick 320x200 or 320x240, depending on aspect ratio correct
+    if (aspect_ratio_correct)
+    {
+        height = SCREENHEIGHT_4_3;
+    }
+    else
+    {
+        height = SCREENHEIGHT;
+    }
 
     window_width = factor * SCREENWIDTH;
-    window_height = factor * actualheight;
+    window_height = factor * height;
     fullscreen = false;
 }
 


### PR DESCRIPTION
I noticed that these options were broken. Not sure if anyone uses these? Easy enough to fix though.