### PR TITLE
Add more gamepad binds to Heretic and Hexen

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -57,6 +57,9 @@ void G_DoSaveGame(void);
 void D_PageTicker(void);
 void D_AdvanceDemo(void);
 
+static boolean InventoryMoveLeft();
+static boolean InventoryMoveRight();
+
 struct
 {
     int type;   // mobjtype_t
@@ -488,7 +491,8 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     }
 
     // Use artifact key
-    if (gamekeydown[key_useartifact] || mousebuttons[mousebuseartifact])
+    if (gamekeydown[key_useartifact] || mousebuttons[mousebuseartifact]
+        || joybuttons[joybuseartifact])
     {
         if (gamekeydown[key_speed] && !noartiskip)
         {
@@ -820,6 +824,9 @@ void G_DoLoadLevel(void)
 static void SetJoyButtons(unsigned int buttons_mask)
 {
     int i;
+    player_t* plr;
+
+    plr = &players[consoleplayer];
 
     for (i=0; i<MAX_JOY_BUTTONS; ++i)
     {
@@ -838,6 +845,22 @@ static void SetJoyButtons(unsigned int buttons_mask)
             else if (i == joybnextweapon)
             {
                 next_weapon = 1;
+            }
+            else if (i == joybinvleft)
+            {
+                InventoryMoveLeft();
+            }
+            else if (i == joybinvright)
+            {
+                InventoryMoveRight();
+            }
+            else if (i == joybuseartifact)
+            {
+                if (!inventory)
+                {
+                    plr->readyArtifact = plr->inventory[inv_ptr].type;
+                }
+                usearti = true;
             }
         }
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -475,15 +475,15 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     // haleyjd: removed externdriver crap
     
     // Fly up/down/drop keys
-    if (gamekeydown[key_flyup])
+    if (gamekeydown[key_flyup] || joybuttons[joybflyup])
     {
         flyheight = 5;          // note that the actual flyheight will be twice this
     }
-    if (gamekeydown[key_flydown])
+    if (gamekeydown[key_flydown] || joybuttons[joybflydown])
     {
         flyheight = -5;
     }
-    if (gamekeydown[key_flycenter])
+    if (gamekeydown[key_flycenter] || joybuttons[joybflycenter])
     {
         flyheight = TOCENTER;
         // haleyjd: removed externdriver crap

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -407,15 +407,15 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     // haleyjd: removed externdriver crap
 
     // Fly up/down/drop keys
-    if (gamekeydown[key_flyup])
+    if (gamekeydown[key_flyup] || joybuttons[joybflyup])
     {
         flyheight = 5;          // note that the actual flyheight will be twice this
     }
-    if (gamekeydown[key_flydown])
+    if (gamekeydown[key_flydown] || joybuttons[joybflydown])
     {
         flyheight = -5;
     }
-    if (gamekeydown[key_flycenter])
+    if (gamekeydown[key_flycenter] || joybuttons[joybflycenter])
     {
         flyheight = TOCENTER;
         // haleyjd: removed externdriver crap

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -57,6 +57,9 @@ void G_DoSingleReborn(void);
 void H2_PageTicker(void);
 void H2_AdvanceDemo(void);
 
+static boolean InventoryMoveLeft();
+static boolean InventoryMoveRight();
+
 
 gameaction_t gameaction;
 gamestate_t gamestate;
@@ -419,7 +422,8 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         look = TOCENTER;
     }
     // Use artifact key
-    if (gamekeydown[key_useartifact] || mousebuttons[mousebuseartifact])
+    if (gamekeydown[key_useartifact] || mousebuttons[mousebuseartifact]
+        || joybuttons[joybuseartifact])
     {
         if (gamekeydown[key_speed] && artiskip)
         {
@@ -427,6 +431,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
             {                   // Skip an artifact
                 gamekeydown[key_useartifact] = false;
                 mousebuttons[mousebuseartifact] = false;
+                joybuttons[joybuseartifact] = false;
                 P_PlayerNextArtifact(&players[consoleplayer]);
             }
         }
@@ -778,6 +783,9 @@ void G_DoLoadLevel(void)
 static void SetJoyButtons(unsigned int buttons_mask)
 {
     int i;
+    player_t *plr;
+
+    plr = &players[consoleplayer];
 
     for (i=0; i<MAX_JOY_BUTTONS; ++i)
     {
@@ -796,6 +804,22 @@ static void SetJoyButtons(unsigned int buttons_mask)
             else if (i == joybnextweapon)
             {
                 next_weapon = 1;
+            }
+            else if (i == joybinvleft)
+            {
+                InventoryMoveLeft();
+            }
+            else if (i == joybinvright)
+            {
+                InventoryMoveRight();
+            }
+            else if (i == joybuseartifact)
+            {
+                if (!inventory)
+                {
+                    plr->readyArtifact = plr->inventory[inv_ptr].type;
+                }
+                usearti = true;
             }
         }
 

--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -90,7 +90,7 @@ int joystick_look_sensitivity = 10;
 // Virtual to physical button joystick button mapping. By default this
 // is a straight mapping.
 static int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 };
 
 void I_ShutdownGamepad(void)

--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -90,7 +90,7 @@ int joystick_look_sensitivity = 10;
 // Virtual to physical button joystick button mapping. By default this
 // is a straight mapping.
 static int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 };
 
 void I_ShutdownGamepad(void)

--- a/src/i_joystick.h
+++ b/src/i_joystick.h
@@ -24,7 +24,7 @@
 // Number of "virtual" joystick buttons defined in configuration files.
 // This needs to be at least as large as the number of different key
 // bindings supported by the higher-level game code (joyb* variables).
-#define NUM_VIRTUAL_BUTTONS 11
+#define NUM_VIRTUAL_BUTTONS 14
 
 // Max allowed number of virtual mappings. Chosen to be less than joybspeed
 // autorun value.

--- a/src/i_joystick.h
+++ b/src/i_joystick.h
@@ -24,7 +24,7 @@
 // Number of "virtual" joystick buttons defined in configuration files.
 // This needs to be at least as large as the number of different key
 // bindings supported by the higher-level game code (joyb* variables).
-#define NUM_VIRTUAL_BUTTONS 14
+#define NUM_VIRTUAL_BUTTONS 17
 
 // Max allowed number of virtual mappings. Chosen to be less than joybspeed
 // autorun value.

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1422,6 +1422,27 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(joystick_physical_button13),
 
     //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #14.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button14),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #15.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button15),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #16.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button16),
+
+    //!
     // If non-zero, use the SDL_GameController interface instead of the
     // SDL_Joystick interface.
     //
@@ -1518,6 +1539,27 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(joyb_invright),
+
+    //!
+    // @game heretic hexen
+    // Joystick virtual button to fly up.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_flyup),
+
+    //!
+    // @game heretic hexen
+    // Joystick virtual button to fly down.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_flydown),
+
+    //!
+    // @game heretic hexen
+    // Joystick virtual button to center flying.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_flycenter),
 
     //!
     // Key to pause or unpause the game.

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1401,6 +1401,27 @@ static default_t extra_defaults_list[] =
     CONFIG_VARIABLE_INT(joystick_physical_button10),
 
     //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #11.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button11),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #12.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button12),
+
+    //!
+    // The physical joystick button that corresponds to joystick
+    // virtual button #13.
+    //
+
+    CONFIG_VARIABLE_INT(joystick_physical_button13),
+
+    //!
     // If non-zero, use the SDL_GameController interface instead of the
     // SDL_Joystick interface.
     //
@@ -1476,6 +1497,27 @@ static default_t extra_defaults_list[] =
     //
 
     CONFIG_VARIABLE_INT(joyb_nextweapon),
+
+    //!
+    // @game heretic hexen
+    // Joystick virtual button to activate artifact.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_useartifact),
+
+    //!
+    // @game heretic hexen
+    // Joystick virtual button to move left in the inventory.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invleft),
+
+    //!
+    // @game heretic hexen
+    // Joystick virtual button to move right in the inventory.
+    //
+
+    CONFIG_VARIABLE_INT(joyb_invright),
 
     //!
     // Key to pause or unpause the game.

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -210,6 +210,10 @@ int joybnextweapon = -1;
 int joybmenu = -1;
 int joybautomap = -1;
 
+int joybuseartifact = -1;
+int joybinvleft = -1;
+int joybinvright = -1;
+
 // Control whether if a mouse button is double clicked, it acts like 
 // "use" has been pressed
 
@@ -277,6 +281,10 @@ void M_BindHereticControls(void)
     M_BindIntVariable("mouseb_invleft", &mousebinvleft);
     M_BindIntVariable("mouseb_invright", &mousebinvright);
     M_BindIntVariable("mouseb_useartifact", &mousebuseartifact);
+
+    M_BindIntVariable("joyb_invleft", &joybinvleft);
+    M_BindIntVariable("joyb_invright", &joybinvright);
+    M_BindIntVariable("joyb_useartifact", &joybuseartifact);
 
     M_BindIntVariable("key_arti_quartz",        &key_arti_quartz);
     M_BindIntVariable("key_arti_urn",           &key_arti_urn);

--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -214,6 +214,10 @@ int joybuseartifact = -1;
 int joybinvleft = -1;
 int joybinvright = -1;
 
+int joybflyup = -1;
+int joybflydown = -1;
+int joybflycenter = -1;
+
 // Control whether if a mouse button is double clicked, it acts like 
 // "use" has been pressed
 
@@ -285,6 +289,10 @@ void M_BindHereticControls(void)
     M_BindIntVariable("joyb_invleft", &joybinvleft);
     M_BindIntVariable("joyb_invright", &joybinvright);
     M_BindIntVariable("joyb_useartifact", &joybuseartifact);
+
+    M_BindIntVariable("joyb_flyup", &joybflyup);
+    M_BindIntVariable("joyb_flydown", &joybflydown);
+    M_BindIntVariable("joyb_flycenter", &joybflycenter);
 
     M_BindIntVariable("key_arti_quartz",        &key_arti_quartz);
     M_BindIntVariable("key_arti_urn",           &key_arti_urn);

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -169,6 +169,10 @@ extern int joybnextweapon;
 extern int joybmenu;
 extern int joybautomap;
 
+extern int joybuseartifact;
+extern int joybinvleft;
+extern int joybinvright;
+
 extern int dclick_use;
 
 void M_BindBaseControls(void);

--- a/src/m_controls.h
+++ b/src/m_controls.h
@@ -173,6 +173,10 @@ extern int joybuseartifact;
 extern int joybinvleft;
 extern int joybinvright;
 
+extern int joybflyup;
+extern int joybflydown;
+extern int joybflycenter;
+
 extern int dclick_use;
 
 void M_BindBaseControls(void);

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -100,7 +100,7 @@ int joystick_look_sensitivity = 10;
 
 // Virtual to physical mapping.
 int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 };
 
 static txt_button_t *joystick_button;
@@ -167,6 +167,9 @@ static const joystick_config_t empty_defaults[] =
     {"joyb_useartifact",           -1},
     {"joyb_invleft",               -1},
     {"joyb_invright",              -1},
+    {"joyb_flyup",                 -1},
+    {"joyb_flydown",               -1},
+    {"joyb_flycenter",             -1},
     {"joystick_physical_button0",  0},
     {"joystick_physical_button1",  1},
     {"joystick_physical_button2",  2},
@@ -181,6 +184,9 @@ static const joystick_config_t empty_defaults[] =
     {"joystick_physical_button11",  11},
     {"joystick_physical_button12",  12},
     {"joystick_physical_button13",  13},
+    {"joystick_physical_button14",  14},
+    {"joystick_physical_button15",  15},
+    {"joystick_physical_button16",  16},
     {NULL, 0},
 };
 
@@ -640,6 +646,9 @@ static const joystick_config_t modern_gamepad[] =
     {"joyb_useartifact", SDL_CONTROLLER_BUTTON_X},
     {"joyb_invleft", SDL_CONTROLLER_BUTTON_DPAD_LEFT},
     {"joyb_invright", SDL_CONTROLLER_BUTTON_DPAD_RIGHT},
+    {"joyb_flyup", SDL_CONTROLLER_BUTTON_DPAD_UP},
+    {"joyb_flydown", SDL_CONTROLLER_BUTTON_DPAD_DOWN},
+    {"joyb_flycenter", SDL_CONTROLLER_BUTTON_LEFTSTICK},
     {NULL, 0},
 };
 
@@ -1284,6 +1293,9 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
         AddJoystickControl(window, "Use artifact", &joybuseartifact);
         AddJoystickControl(window, "Inventory left", &joybinvleft);
         AddJoystickControl(window, "Inventory right", &joybinvright);
+        AddJoystickControl(window, "Fly up", &joybflyup);
+        AddJoystickControl(window, "Fly down", &joybflydown);
+        AddJoystickControl(window, "Fly center", &joybflycenter);
     }
 
     TXT_SignalConnect(joystick_button, "pressed", CalibrateJoystick, window);

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1186,6 +1186,28 @@ static void AdjustAnalog(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
     TXT_SetWidgetAlign(window, TXT_HORIZ_CENTER);
 }
 
+static void MoreControls(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
+{
+    txt_window_t *window;
+
+    window = TXT_NewWindow("Additional Gamepad/Joystick buttons");
+    TXT_SetTableColumns(window, 6);
+    TXT_SetColumnWidths(window, 18, 10, 1, 18, 10, 0);
+
+    AddJoystickControl(window, "Use artifact", &joybuseartifact);
+    AddJoystickControl(window, "Inventory left", &joybinvleft);
+    AddJoystickControl(window, "Inventory right", &joybinvright);
+    AddJoystickControl(window, "Fly up", &joybflyup);
+    AddJoystickControl(window, "Fly down", &joybflydown);
+    AddJoystickControl(window, "Fly center", &joybflycenter);
+
+    TXT_SetWindowAction(window, TXT_HORIZ_LEFT, NULL);
+    TXT_SetWindowAction(window, TXT_HORIZ_CENTER,
+        TXT_NewWindowEscapeAction(window));
+    TXT_SetWindowAction(window, TXT_HORIZ_RIGHT, NULL);
+    TXT_SetWidgetAlign(window, TXT_HORIZ_CENTER);
+}
+
 void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 {
     txt_window_t *window;
@@ -1290,12 +1312,9 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 
     if (gamemission == heretic || gamemission == hexen)
     {
-        AddJoystickControl(window, "Use artifact", &joybuseartifact);
-        AddJoystickControl(window, "Inventory left", &joybinvleft);
-        AddJoystickControl(window, "Inventory right", &joybinvright);
-        AddJoystickControl(window, "Fly up", &joybflyup);
-        AddJoystickControl(window, "Fly down", &joybflydown);
-        AddJoystickControl(window, "Fly center", &joybflycenter);
+        TXT_AddWidget(window,
+                       TXT_NewButton2("More controls...", MoreControls, NULL));
+        TXT_AddWidget(window, TXT_TABLE_EOL);
     }
 
     TXT_SignalConnect(joystick_button, "pressed", CalibrateJoystick, window);

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -100,7 +100,7 @@ int joystick_look_sensitivity = 10;
 
 // Virtual to physical mapping.
 int joystick_physical_buttons[NUM_VIRTUAL_BUTTONS] = {
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 };
 
 static txt_button_t *joystick_button;
@@ -164,6 +164,9 @@ static const joystick_config_t empty_defaults[] =
     {"joyb_jump",                  -1},
     {"joyb_menu_activate",         -1},
     {"joyb_toggle_automap",        -1},
+    {"joyb_useartifact",           -1},
+    {"joyb_invleft",               -1},
+    {"joyb_invright",              -1},
     {"joystick_physical_button0",  0},
     {"joystick_physical_button1",  1},
     {"joystick_physical_button2",  2},
@@ -174,6 +177,10 @@ static const joystick_config_t empty_defaults[] =
     {"joystick_physical_button7",  7},
     {"joystick_physical_button8",  8},
     {"joystick_physical_button9",  9},
+    {"joystick_physical_button10",  10},
+    {"joystick_physical_button11",  11},
+    {"joystick_physical_button12",  12},
+    {"joystick_physical_button13",  13},
     {NULL, 0},
 };
 
@@ -630,6 +637,9 @@ static const joystick_config_t modern_gamepad[] =
     {"joyb_nextweapon", SDL_CONTROLLER_BUTTON_RIGHTSHOULDER},
     {"joyb_menu_activate", SDL_CONTROLLER_BUTTON_START},
     {"joyb_toggle_automap", SDL_CONTROLLER_BUTTON_Y},
+    {"joyb_useartifact", SDL_CONTROLLER_BUTTON_X},
+    {"joyb_invleft", SDL_CONTROLLER_BUTTON_DPAD_LEFT},
+    {"joyb_invright", SDL_CONTROLLER_BUTTON_DPAD_RIGHT},
     {NULL, 0},
 };
 
@@ -1173,7 +1183,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 
     window = TXT_NewWindow("Gamepad/Joystick configuration");
     TXT_SetTableColumns(window, 6);
-    TXT_SetColumnWidths(window, 18, 10, 1, 15, 10, 0);
+    TXT_SetColumnWidths(window, 18, 10, 1, 18, 10, 0);
     TXT_SetWindowHelpURL(window, WINDOW_HELP_URL);
 
     TXT_AddWidgets(window,
@@ -1268,6 +1278,13 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
     AddJoystickControl(window, "Activate menu", &joybmenu);
 
     AddJoystickControl(window, "Toggle Automap", &joybautomap);
+
+    if (gamemission == heretic || gamemission == hexen)
+    {
+        AddJoystickControl(window, "Use artifact", &joybuseartifact);
+        AddJoystickControl(window, "Inventory left", &joybinvleft);
+        AddJoystickControl(window, "Inventory right", &joybinvright);
+    }
 
     TXT_SignalConnect(joystick_button, "pressed", CalibrateJoystick, window);
     TXT_SetWindowAction(window, TXT_HORIZ_CENTER, TestConfigAction());

--- a/src/setup/txt_joybinput.c
+++ b/src/setup/txt_joybinput.c
@@ -61,6 +61,9 @@ static int *all_joystick_buttons[NUM_VIRTUAL_BUTTONS] =
     &joybuseartifact,
     &joybinvleft,
     &joybinvright,
+    &joybflyup,
+    &joybflydown,
+    &joybflycenter,
 };
 
 // For indirection so that we're not dependent on item ordering in the

--- a/src/setup/txt_joybinput.c
+++ b/src/setup/txt_joybinput.c
@@ -58,6 +58,9 @@ static int *all_joystick_buttons[NUM_VIRTUAL_BUTTONS] =
     &joybjump,
     &joybmenu,
     &joybautomap,
+    &joybuseartifact,
+    &joybinvleft,
+    &joybinvright,
 };
 
 // For indirection so that we're not dependent on item ordering in the


### PR DESCRIPTION
The PR introduces gamepad/joystick binds for flying and artifact use. The defaults are:
* Use artifact - X
* Inventory left - Dpad left
* Inventory right - Dpad right
* Fly up - Dpad up
* Fly down - Dpad down
* Fly center - Left stick button

To support the new binds, I added a "More controls..." child window to the Joystick/Gamepad window in setup.