### PR TITLE
Fix ASAN report about use after free

### DIFF
--- a/src/net_query.c
+++ b/src/net_query.c
@@ -323,6 +323,7 @@ static void NET_Query_ParseResponse(net_addr_t *addr, net_packet_t *packet,
         // Create new target.
 
         target = GetTargetForAddr(addr, true);
+        broadcast_target = GetTargetForAddr(NULL, false);
         target->state = QUERY_TARGET_QUERIED;
         target->query_time = broadcast_target->query_time;
     }


### PR DESCRIPTION
`GetTargetForAddr` can invalidate pointers because of the use of `realloc`. Get element from the `targets` array again.