### PR TITLE
Heretic: check if backsector is NULL

### DIFF
--- a/src/heretic/p_map.c
+++ b/src/heretic/p_map.c
@@ -1201,7 +1201,8 @@ boolean PTR_AimTraverse(intercept_t * in)
 
         // Added checks if there is no backsector to prevent crashing.
         // Crashes didn't happen in the DOS version of Heretic
-        // because of reading NULL pointer bytes from memory.
+        // because reading of NULL pointer produces random but 
+        // deterministic values instead of crashing.
         // See https://github.com/chocolate-doom/chocolate-doom/issues/1665
         if (li->backsector == NULL
             || li->frontsector->floorheight != li->backsector->floorheight)

--- a/src/heretic/p_map.c
+++ b/src/heretic/p_map.c
@@ -1199,14 +1199,20 @@ boolean PTR_AimTraverse(intercept_t * in)
 
         dist = FixedMul(attackrange, in->frac);
 
-        if (li->frontsector->floorheight != li->backsector->floorheight)
+        // Added checks if there is no backsector to prevent crashing.
+        // Crashes didn't happen in the DOS version of Heretic, assuming 
+        // that some random bytes were read.
+        // See https://github.com/chocolate-doom/chocolate-doom/issues/1665
+        if (li->backsector == NULL
+            || li->frontsector->floorheight != li->backsector->floorheight)
         {
             slope = FixedDiv(openbottom - shootz, dist);
             if (slope > bottomslope)
                 bottomslope = slope;
         }
 
-        if (li->frontsector->ceilingheight != li->backsector->ceilingheight)
+        if (li->backsector == NULL
+            || li->frontsector->ceilingheight != li->backsector->ceilingheight)
         {
             slope = FixedDiv(opentop - shootz, dist);
             if (slope < topslope)

--- a/src/heretic/p_map.c
+++ b/src/heretic/p_map.c
@@ -1200,8 +1200,8 @@ boolean PTR_AimTraverse(intercept_t * in)
         dist = FixedMul(attackrange, in->frac);
 
         // Added checks if there is no backsector to prevent crashing.
-        // Crashes didn't happen in the DOS version of Heretic, assuming 
-        // that some random bytes were read.
+        // Crashes didn't happen in the DOS version of Heretic
+        // because of reading NULL pointer bytes from memory.
         // See https://github.com/chocolate-doom/chocolate-doom/issues/1665
         if (li->backsector == NULL
             || li->frontsector->floorheight != li->backsector->floorheight)

--- a/src/heretic/p_map.c
+++ b/src/heretic/p_map.c
@@ -1201,7 +1201,7 @@ boolean PTR_AimTraverse(intercept_t * in)
 
         // Added checks if there is no backsector to prevent crashing.
         // Crashes didn't happen in the DOS version of Heretic
-        // because reading of NULL pointer produces random but 
+        // because reading NULL pointer produces unpredictable but
         // deterministic values instead of crashing.
         // See https://github.com/chocolate-doom/chocolate-doom/issues/1665
         if (li->backsector == NULL


### PR DESCRIPTION
Related to https://github.com/chocolate-doom/chocolate-doom/issues/1665. Few remarks:
* First of all - comment. I'm afraid, [original commit](https://github.com/chocolate-doom/chocolate-doom/commit/d610772a0b58e63f665403386f167b3e19a5dcfd) doesn't provide necessary information for this case. It's not about demo desync, it's about crash.
* Do we need it for Hexen? I have added these checks in [Inter-Hexen](https://github.com/JNechaevsky/international-doom/blob/main/src/hexen/p_map.c#L1779-L1787) along with @mikeday0 recent desync fix, and it's fine for demos. But what about Strife? I don't know much about it, and can't suggest anything. Probably worth to leave it for good?
* New line/spacing style should be fine, it is copied from existing code, like [here](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/heretic/p_map.c#L239-L242), [here](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/heretic/p_map.c#L505-L506) and [here](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/heretic/p_map.c#L1539-L1540).
* I have tested, yes, DOS version is working fine with demo from #1665, no crashes.