### PR TITLE
Miscellaneous source edits following merge of PR #1394

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -972,7 +972,7 @@ void PrintDehackedBanners(void)
     }
 }
 
-static struct
+static const struct
 {
     const char *description;
     const char *cmdline;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -972,7 +972,7 @@ void PrintDehackedBanners(void)
     }
 }
 
-static struct 
+static struct
 {
     const char *description;
     const char *cmdline;
@@ -1002,11 +1002,11 @@ static void InitGameVersion(void)
     int i;
     boolean status;
 
-    //! 
+    //!
     // @arg <version>
     // @category compat
     //
-    // Emulate a specific version of Doom.  Valid values are "1.2", 
+    // Emulate a specific version of Doom.  Valid values are "1.2",
     // "1.666", "1.7", "1.8", "1.9", "ultimate", "final", "final2",
     // "hacx" and "chex".
     //
@@ -1023,8 +1023,8 @@ static void InitGameVersion(void)
                 break;
             }
         }
-        
-        if (gameversions[i].description == NULL) 
+
+        if (gameversions[i].description == NULL)
         {
             printf("Supported game versions:\n");
 
@@ -1033,7 +1033,7 @@ static void InitGameVersion(void)
                 printf("\t%s (%s)\n", gameversions[i].cmdline,
                         gameversions[i].description);
             }
-            
+
             I_Error("Unknown game version '%s'", myargv[p+1]);
         }
     }
@@ -1122,7 +1122,7 @@ static void InitGameVersion(void)
     {
         deathmatch = 1;
     }
-    
+
     // The original exe does not support retail - 4th episode not supported
 
     if (gameversion < exe_ultimate && gamemode == retail)

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -369,7 +369,6 @@ static const struct
 static void InitGameVersion(void)
 {
     int p;
-    int i;
 
     //!
     // @arg <version>
@@ -383,6 +382,7 @@ static void InitGameVersion(void)
 
     if (p)
     {
+        int i;
         for (i=0; gameversions[i].description != NULL; ++i)
         {
             if (!strcmp(myargv[p+1], gameversions[i].cmdline))

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -353,7 +353,7 @@ void D_SetGameDescription(void)
     }
 }
 
-static struct
+static const struct
 {
     const char *description;
     const char *cmdline;

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -1009,7 +1009,7 @@ void PrintDehackedBanners(void)
     }
 }
 
-static struct 
+static struct
 {
     const char *description;
     const char *cmdline;
@@ -1027,7 +1027,7 @@ static void InitGameVersion(void)
     int p;
     int i;
 
-    // haleyjd: we support emulating either the 1.2 or the 1.31 versions of 
+    // haleyjd: we support emulating either the 1.2 or the 1.31 versions of
     // Strife, which are the most significant. 1.2 is the most mature version
     // that still has the single saveslot restriction, whereas 1.31 is the
     // final revision. The differences between the two are barely worth
@@ -1053,7 +1053,7 @@ static void InitGameVersion(void)
             }
         }
 
-        if (gameversions[i].description == NULL) 
+        if (gameversions[i].description == NULL)
         {
             printf("Supported game versions:\n");
 

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -1025,7 +1025,6 @@ static const struct
 static void InitGameVersion(void)
 {
     int p;
-    int i;
 
     // haleyjd: we support emulating either the 1.2 or the 1.31 versions of
     // Strife, which are the most significant. 1.2 is the most mature version
@@ -1044,6 +1043,7 @@ static void InitGameVersion(void)
 
     if (p)
     {
+        int i;
         for (i=0; gameversions[i].description != NULL; ++i)
         {
             if (!strcmp(myargv[p+1], gameversions[i].cmdline))

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -1009,7 +1009,7 @@ void PrintDehackedBanners(void)
     }
 }
 
-static struct
+static const struct
 {
     const char *description;
     const char *cmdline;


### PR DESCRIPTION
These are miscellaneous source edits not changing functionality, originally brought up as a consequence of PR #1394 and prepared in a separate branch here.

The first kind of edits, the removal of trailing whitespaces from Doom code (which I repurposed for Hexen's support of two "1.1" versions), was originally added by me in 2021 as a part of PR #1394, before being asked to remove it from that PR. The other two were suggested for the Hexen PR by @turol, and I extended them to also cover the other games, at least where relevant.