### PR TITLE
OPL: set timer2.enabled when checking timer bit 0x20

### DIFF
--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -432,7 +432,7 @@ static void WriteRegister(unsigned int reg_num, unsigned int value)
 
                 if ((value & 0x20) == 0)
                 {
-                    timer1.enabled = (value & 0x02) != 0;
+                    timer2.enabled = (value & 0x02) != 0;
                     OPLTimer_CalculateEndTime(&timer2);
                 }
             }


### PR DESCRIPTION
Was looking for some examples of how to use nuked-opl3 and spotted what I think is a typo where the status bit for timer2 is checked but 'timer1.enabled' is set again instead.

