### PR TITLE
Build x86 version of the MacOS package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,14 @@ jobs:
             pkg-path: pkg/osx/*.dmg
             pkg-dir: pkg/osx
 
+          - name: macOS x86 Clang
+            os: macos-13
+            compiler: clang
+            shell: bash
+            artifacts: true
+            pkg-path: pkg/osx/*.dmg
+            pkg-dir: pkg/osx
+
           - name: MSYS2 UCRT64
             os: windows-latest
             compiler: gcc

--- a/configure.ac
+++ b/configure.ac
@@ -34,9 +34,13 @@ fi
 AC_CANONICAL_TARGET
 TARGET_OS=""
 AS_CASE([$target_cpu],
-        [x86_64|aarch64*],
+        [x86_64],
         [
-            TARGET_OS="64"
+            TARGET_OS="x64"
+        ],
+        [aarch64*|arm*],
+        [
+            TARGET_OS="arm"
         ],
         [i?86|arm*],
         [

--- a/pkg/osx/GNUmakefile
+++ b/pkg/osx/GNUmakefile
@@ -6,8 +6,14 @@ DOC_FILES += README.Strife.md NOT-BUGS.md
 
 export MACOSX_DEPLOYMENT_TARGET=10.7
 
+ifeq ($(TARGET_OS),arm)
+    POSTFIX=arm64
+else
+    POSTFIX=x86
+endif
+
 STAGING_DIR=staging
-DMG=$(PACKAGE_TARNAME)-$(PACKAGE_VERSION).dmg
+DMG=$(PACKAGE_TARNAME)-$(PACKAGE_VERSION)-$(POSTFIX).dmg
 
 TOPLEVEL=../..
 TOPLEVEL_DOCS=$(patsubst %,../../%,$(DOC_FILES))

--- a/pkg/win32/GNUmakefile
+++ b/pkg/win32/GNUmakefile
@@ -3,7 +3,7 @@ include ../config.make
 
 TOPLEVEL=../..
 
-ifeq ($(TARGET_OS),64)
+ifeq ($(TARGET_OS),x64)
     POSTFIX=win64
 else
     POSTFIX=win32


### PR DESCRIPTION
GitHub has switched to ARM64 by default for MacOS builds (see https://github.com/actions/runner-images?tab=readme-ov-file#available-images). So it seems that chocolate-doom-3.1.0.dmg only works on Macs with ARM CPUs. This PR adds the x86 package.