### PR TITLE
osx: Updates to macOS packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,6 @@ jobs:
         run: |
           brew install \
             automake \
-            dylibbundler \
             sdl2 \
             sdl2_mixer \
             sdl2_net \

--- a/pkg/osx/GNUmakefile
+++ b/pkg/osx/GNUmakefile
@@ -18,12 +18,6 @@ DMG=$(PACKAGE_TARNAME)-$(PACKAGE_VERSION)-$(POSTFIX).dmg
 TOPLEVEL=../..
 TOPLEVEL_DOCS=$(patsubst %,../../%,$(DOC_FILES))
 
-ifeq (, $(shell which dylibbundler))
-	CP=./cp-with-libs
-else
-	CP=cp
-endif
-
 # DMG file containing package:
 
 $(DMG) : tmp.dmg
@@ -75,25 +69,16 @@ $(STAGING_DIR): launcher $(TOPLEVEL_DOCS) app.icns wadfile.icns
 	cp launcher "$(APP_BIN_DIR)"
 	$(STRIP) "$(APP_BIN_DIR)/launcher"
 
-	$(CP) $(TOPLEVEL)/src/$(PROGRAM_PREFIX)doom "$(APP_BIN_DIR)"
+	./cp-with-libs $(TOPLEVEL)/src/$(PROGRAM_PREFIX)doom "$(APP_BIN_DIR)"
 	$(STRIP) "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)doom"
-	$(CP) $(TOPLEVEL)/src/$(PROGRAM_PREFIX)heretic "$(APP_BIN_DIR)"
+	./cp-with-libs $(TOPLEVEL)/src/$(PROGRAM_PREFIX)heretic "$(APP_BIN_DIR)"
 	$(STRIP) "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)heretic"
-	$(CP) $(TOPLEVEL)/src/$(PROGRAM_PREFIX)hexen "$(APP_BIN_DIR)"
+	./cp-with-libs $(TOPLEVEL)/src/$(PROGRAM_PREFIX)hexen "$(APP_BIN_DIR)"
 	$(STRIP) "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)hexen"
-	$(CP) $(TOPLEVEL)/src/$(PROGRAM_PREFIX)strife "$(APP_BIN_DIR)"
+	./cp-with-libs $(TOPLEVEL)/src/$(PROGRAM_PREFIX)strife "$(APP_BIN_DIR)"
 	$(STRIP) "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)strife"
-	$(CP) $(TOPLEVEL)/src/$(PROGRAM_PREFIX)setup "$(APP_BIN_DIR)"
+	./cp-with-libs $(TOPLEVEL)/src/$(PROGRAM_PREFIX)setup "$(APP_BIN_DIR)"
 	$(STRIP) "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)setup"
-
-	-dylibbundler --bundle-deps --overwrite-files                      \
-		      --install-path "@executable_path/"                   \
-		      --dest-dir "$(APP_BIN_DIR)"                          \
-		      --fix-file "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)doom"    \
-		      --fix-file "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)heretic" \
-		      --fix-file "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)hexen"   \
-		      --fix-file "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)strife"  \
-		      --fix-file "$(APP_BIN_DIR)/$(PROGRAM_PREFIX)setup"
 
 	$(TOPLEVEL)/man/simplecpp -DPRECOMPILED -D__MACOSX__  \
 	                -DDOOM -DHERETIC -DHEXEN -DSTRIFE     \

--- a/pkg/osx/cp-with-libs
+++ b/pkg/osx/cp-with-libs
@@ -27,6 +27,9 @@ is_sys_lib() {
 		/System/*)
 			true
 			;;
+		/usr/local/*)  # homebrew/manual install
+			false
+			;;
 		/usr/*)
 			true
 			;;
@@ -54,7 +57,7 @@ install_with_deps() {
 
 	if [ -e "$dest_file" ]; then
 		return
-	fi	
+	fi
 
 	echo "Installing $bin_name..."
 

--- a/pkg/osx/cp-with-libs
+++ b/pkg/osx/cp-with-libs
@@ -68,7 +68,6 @@ install_with_deps() {
 	# Copy libraries that this file depends on:
 
 	otool -L "$src_file" | tail -n +2 | sed 's/^.//; s/ (.*//' | while read; do
-		
 		# Don't copy system libraries
 
 		if is_sys_lib "$REPLY"; then
@@ -95,6 +94,11 @@ install_with_deps() {
 	if is_dylib "$dest_file"; then
 		install_name_tool -id "@executable_path/$bin_name" "$dest_file"
 	fi
+
+	# The install_name_tool calls above break signatures. Recent versions
+	# of macOS make signatures mandatory, even if just ad-hoc ones.
+	codesign --remove-signature "$dest_file"
+	codesign --force -s - "$dest_file"  # ad-hoc signature
 }
 
 # Install the file, and recursively install any libraries:


### PR DESCRIPTION
This has actually already been fixed in commit 28472387c230df24eb7fa461d3dd9cf9409e20e0, but I'm using the same `cp-with-libs` script in some of my other projects such as SDL Sopwith and WadGadget, so I'd like to keep them in sync. This also eliminates a build dependency on dylibbundler, which simplifies the Makefile as we no longer need two ways of doing the same thing.