### PR TITLE
cpp-linter: Disable several checks

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -39,6 +39,9 @@ jobs:
             ,clang-analyzer-*
             ,cppcoreguidelines-*
             ,-cppcoreguidelines-avoid-magic-numbers
+            ,-cppcoreguidelines-init-variables
+            ,-readability-identifier-length
+            ,-readability-isolate-declaration
             ,-readability-magic-numbers
 
       - name: Fail fast?!


### PR DESCRIPTION
This commit disables several cpp-linter checks that I believe are not useful:

* cppcoreguidelines-init-variables: Flags when a variable is not initialized at declaration, even if it is never used uninitialized. It is my belief that this is an explicitly harmful practice to
  encourage: <https://fragglet.livejournal.com/19966.html>
* readability-identifier-length: Flags when variables have short names. The Doom codebase is already full of variables named 'i' or 'j' for loop counters, and I don't think this is really a problem. Naming it something like "count" doesn't do anything particularly useful.
* readability-isolate-declaration: Flags when multiple variables are initialized in a single statement. Again, the Doom codebase is full of examples of this, and I'm not convinced there's much benefit in avoiding it.