### PR TITLE
win_opendir: Remove unused functions, remove `struct __dir` from header

### DIFF
--- a/win32/win_opendir.h
+++ b/win32/win_opendir.h
@@ -99,31 +99,11 @@ struct dirent
     char d_name[NAME_MAX];
 };
 
-struct __dir
-{
-    struct dirent *entries;
-    intptr_t fd;
-    long int count;
-    long int index;
-};
-
 int closedir(DIR *dirp);
 
 DIR *opendir(const char *name);
 
-DIR *_wopendir(const wchar_t *name);
-
-DIR *fdopendir(intptr_t fd);
-
 struct dirent *readdir(DIR *dirp);
-
-void seekdir(DIR *dirp, long int offset);
-
-void rewinddir(DIR *dirp);
-
-long int telldir(DIR *dirp);
-
-intptr_t dirfd(DIR *dirp);
 
 #endif /* WIN_OPENDIR_H */
 


### PR DESCRIPTION
This should fix building with old Windows headers.