### PR TITLE
Add clangd gitignore entires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ GTAGS
 # VSCode settings
 
 /.vscode/
+
+# clangd settings
+/.cache/clangd
+compile_commands.json


### PR DESCRIPTION
as per Fabian's suggestion in [DenisBelmondo:gitignore-clangd](https://github.com/fabiangreffrath/crispy-doom/pull/1257#issuecomment-2584549370), i am opening this PR here in the chocolate repo instead so downstreams can have this too.

this just adds clangd-specific gitignore entries (.cache/clangd, compile_commands.json) for those whose development environments leverage such tools (vscodium, nvim/lsp)