### PR TITLE
Fixed startup delay caused by incorrect emscripten_sleep() argument

### DIFF
--- a/opl/opl.c
+++ b/opl/opl.c
@@ -467,6 +467,8 @@ static void DelayCallback(void *_delay_data)
     SDL_UnlockMutex(delay_data->mutex);
 }
 
+// Delay for specified number of microseconds after OPL subsystem is initialized
+
 void OPL_Delay(uint64_t us)
 {
     delay_data_t delay_data;
@@ -478,6 +480,10 @@ void OPL_Delay(uint64_t us)
 
     // Create a callback that will signal this thread after the
     // specified time.
+
+    // Note that this is not just a simple time-based delay, it will ensure
+    // that the OPL system is initialized and the queue has begun processing
+    // before releasing the mutex lock
 
     delay_data.finished = 0;
     delay_data.mutex = SDL_CreateMutex();
@@ -496,7 +502,6 @@ void OPL_Delay(uint64_t us)
         // Use async sleep to avoid locking browser main thread
         emscripten_sleep(us / 1000);
 #endif
-
     }
 
     SDL_UnlockMutex(delay_data.mutex);

--- a/opl/opl.c
+++ b/opl/opl.c
@@ -478,7 +478,7 @@ void OPL_Delay(uint64_t us)
 
 #ifdef EMSCRIPTEN
     // Use async sleep when compiled with emscripten
-    emscripten_sleep(us);
+    emscripten_sleep(us / 1000);
 #else
 
     // Create a callback that will signal this thread after the


### PR DESCRIPTION
Removes the startup delay caused by mixing up ms and ns when calling `emscripten_sleep()`, as discussed here https://github.com/chocolate-doom/chocolate-doom/pull/1717#issuecomment-2585347916