### PR TITLE
Fix boolean typedef for C23

### DIFF
--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -100,9 +100,9 @@
 
 #include <inttypes.h>
 
-#if defined(__cplusplus) || defined(__bool_true_false_are_defined)
+#if defined(__cplusplus) || defined(__bool_true_false_are_defined) || (__STDC_VERSION__ >= 202311L)
 
-// Use builtin bool type with C++.
+// Use builtin bool type with C++ and C23.
 
 typedef bool boolean;
 


### PR DESCRIPTION
The C23 standard elevates "false" and "true" to keywords, making it illegal to use them as enum variant names. This commit makes the code use the built-in "bool" type when building with C23 or later.