### PR TITLE
Add missing includes

### DIFF
--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -42,6 +42,8 @@ typedef fluid_long_long_t fluid_int_t;
 #include "memio.h"
 #include "mus2mid.h"
 
+#include <string.h>
+
 char *fsynth_sf_path = "";
 int fsynth_chorus_active = 1;
 float fsynth_chorus_depth = 5.0f;

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -17,6 +17,7 @@
 // Use to convert a MUS file into a single track, type 0 MIDI file.
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "doomtype.h"
 #include "i_swap.h"

--- a/src/net_gui.c
+++ b/src/net_gui.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 
 #include "config.h"

--- a/src/v_diskicon.c
+++ b/src/v_diskicon.c
@@ -27,6 +27,8 @@
 
 #include "v_diskicon.h"
 
+#include <string.h>
+
 // Only display the disk icon if more then this much bytes have been read
 // during the previous tic.
 


### PR DESCRIPTION
- `src/i_flmusic.c` requires `<string.h>` for `strlen()` and `memcmp()`
- `src/mus2mid.c` requires `<stdlib.h>` for `exit()`
- `src/net_gui.c` requires `<string.h>` for `memcmp()`
- `src/v_diskicon.c` requires `<string.h>` for `memcpy()` and `memset()`