### PR TITLE
Haiku-specific paths for Chocolate Doom

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -639,6 +639,10 @@ static void AddXdgDirs(void)
     const char *env;
     char *tmp_env;
 
+#ifdef __HAIKU__
+    const char *haikuhome;
+#endif
+
     // Quote:
     // > $XDG_DATA_HOME defines the base directory relative to which
     // > user specific data files should be stored. If $XDG_DATA_HOME
@@ -663,6 +667,14 @@ static void AddXdgDirs(void)
     // ~/.local/share/games/doom) as a user-writeable extension to
     // the usual /usr/share/games/doom location.
     AddIWADDir(M_StringJoin(env, "/games/doom", NULL));
+#ifdef __HAIKU__
+    AddIWADDir(M_StringJoin(env, "/doom", NULL));
+    AddIWADDir(M_StringJoin(env, "/doomdata", NULL));
+    AddIWADDir(M_StringJoin(env, "/chocolate-doom", NULL));
+    haikuhome = getenv("HOME");
+    AddIWADDir(M_StringJoin(haikuhome, "/doom", NULL));
+    AddIWADDir(M_StringJoin(haikuhome, "/config/data/doomdata", NULL));
+#endif
     free(tmp_env);
 
     // Quote:


### PR DESCRIPTION
This patch gives Chocolate Doom a bunch of additional search paths (7) for wads when it's built for [Haiku OS](https://www.haiku-os.org/).

The paths are all created using standard environment variables (XDG_DATA_HOME, HOME, XDG_DATA_DIRS), most of these paths are meant to be shared with other source-ports but there's also one that's specific to Chocolate Doom if that's needed by the user.

This is part of an effort to standardize paths for Doom source ports on the platform, the PrBoom+ and GZDoom ports (the other available source ports atm) will also include similar paths.

Shouldn't affect other OSes. Let me know if everything's alright, I haven't touched indentation, maybe you guys want it different there.