### PR TITLE
CI: Remove MINGW32 build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,16 +57,6 @@ jobs:
             pkg-path: pkg/win32/*.zip
             pkg-dir: pkg/win32
 
-          - name: MSYS2 MINGW32
-            os: windows-latest
-            compiler: gcc
-            shell: 'msys2 {0}'
-            msystem: mingw32
-            msys-env: mingw-w64-i686
-            artifacts: true
-            pkg-path: pkg/win32/*.zip
-            pkg-dir: pkg/win32
-
     steps:
       - name: Install pandoc
         if: runner.os == 'Windows'
@@ -102,8 +92,8 @@ jobs:
           # matter if we're "breaking" anything:
           pip3 install --break-system-packages pyyaml
 
-      - name: Install dependencies (MSYS2 UCRT64)
-        if: ${{ matrix.config.msystem == 'ucrt64' }}
+      - name: Install dependencies (MSYS2)
+        if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.config.msystem }}
@@ -120,34 +110,6 @@ jobs:
             ${{ matrix.config.msys-env }}-libsamplerate
             ${{ matrix.config.msys-env }}-fluidsynth
             ${{ matrix.config.msys-env }}-python3-yaml
-
-      - name: Install dependencies (MSYS2 MINGW32)
-        if: ${{ matrix.config.msystem == 'mingw32' }}
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: ${{ matrix.config.msystem }}
-          update: true
-          path-type: inherit
-          install: >-
-            autotools
-            zip
-            ${{ matrix.config.msys-env }}-gcc
-            ${{ matrix.config.msys-env }}-SDL2
-            ${{ matrix.config.msys-env }}-SDL2_mixer
-            ${{ matrix.config.msys-env }}-SDL2_net
-            ${{ matrix.config.msys-env }}-libpng
-            ${{ matrix.config.msys-env }}-fluidsynth
-            ${{ matrix.config.msys-env }}-python3-yaml
-
-      - name: Build libsamplerate
-        if: ${{ matrix.config.msystem == 'mingw32' }}
-        run: |
-          git clone "https://github.com/libsndfile/libsamplerate.git"
-          cd "libsamplerate"
-          autoreconf -vif
-          ./configure
-          make
-          make install
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,8 +102,8 @@ jobs:
           # matter if we're "breaking" anything:
           pip3 install --break-system-packages pyyaml
 
-      - name: Install dependencies (MSYS2)
-        if: runner.os == 'Windows'
+      - name: Install dependencies (MSYS2 UCRT64)
+        if: ${{ matrix.config.msystem == 'ucrt64' }}
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.config.msystem }}
@@ -120,6 +120,34 @@ jobs:
             ${{ matrix.config.msys-env }}-libsamplerate
             ${{ matrix.config.msys-env }}-fluidsynth
             ${{ matrix.config.msys-env }}-python3-yaml
+
+      - name: Install dependencies (MSYS2 MINGW32)
+        if: ${{ matrix.config.msystem == 'mingw32' }}
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.config.msystem }}
+          update: true
+          path-type: inherit
+          install: >-
+            autotools
+            zip
+            ${{ matrix.config.msys-env }}-gcc
+            ${{ matrix.config.msys-env }}-SDL2
+            ${{ matrix.config.msys-env }}-SDL2_mixer
+            ${{ matrix.config.msys-env }}-SDL2_net
+            ${{ matrix.config.msys-env }}-libpng
+            ${{ matrix.config.msys-env }}-fluidsynth
+            ${{ matrix.config.msys-env }}-python3-yaml
+
+      - name: Build libsamplerate
+        if: ${{ matrix.config.msystem == 'mingw32' }}
+        run: |
+          git clone "https://github.com/libsndfile/libsamplerate.git"
+          cd "libsamplerate"
+          autoreconf -vif
+          ./configure
+          make
+          make install
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
MSYS2 no longer provides the MINGW32 version of libsamplerate, so we build it ourselves.