### PR TITLE
Hexen: Partial fix for Segfault in P_BounceWall

### DIFF
--- a/src/hexen/p_local.h
+++ b/src/hexen/p_local.h
@@ -292,6 +292,7 @@ boolean P_CheckSight(mobj_t * t1, mobj_t * t2);
 void P_UseLines(player_t * player);
 boolean P_UsePuzzleItem(player_t * player, int itemType);
 void PIT_ThrustSpike(mobj_t * actor);
+void P_InitSlideLine(void);
 
 boolean P_ChangeSector(sector_t * sector, int crunch);
 

--- a/src/hexen/p_map.c
+++ b/src/hexen/p_map.c
@@ -1482,7 +1482,6 @@ boolean PTR_BounceTraverse(intercept_t * in)
         I_Error("PTR_BounceTraverse: not a line?");
 
     li = in->d.line;
-
     if (!(li->flags & ML_TWOSIDED))
     {
         if (P_PointOnLineSide(slidemo->x, slidemo->y, li))

--- a/src/hexen/p_map.c
+++ b/src/hexen/p_map.c
@@ -1483,9 +1483,6 @@ boolean PTR_BounceTraverse(intercept_t * in)
 
     li = in->d.line;
 
-    // if (bestslideline == NULL)
-    //     bestslideline = li;
-
     if (!(li->flags & ML_TWOSIDED))
     {
         if (P_PointOnLineSide(slidemo->x, slidemo->y, li))

--- a/src/hexen/p_map.c
+++ b/src/hexen/p_map.c
@@ -1464,6 +1464,10 @@ boolean PTR_BounceTraverse(intercept_t * in)
         I_Error("PTR_BounceTraverse: not a line?");
 
     li = in->d.line;
+
+    // if (bestslideline == NULL)
+    //     bestslideline = li;
+
     if (!(li->flags & ML_TWOSIDED))
     {
         if (P_PointOnLineSide(slidemo->x, slidemo->y, li))

--- a/src/hexen/p_map.c
+++ b/src/hexen/p_map.c
@@ -1459,14 +1459,15 @@ void P_SlideMove(mobj_t * mo)
 void P_InitSlideLine(void)
 {
     // use relevant parts from first bestslideline in demo1 (hexen.wad)
-    static vertex_t initvertex1 = {-77594624,37748736};
-    static line_t initslideline = {&initvertex1, NULL, 0, 6291456, 0, 0, 0, 0, 0, 0, 0, 
-                                                {0,0}, {0,0,0,0}, 0, NULL, NULL, 0, NULL};  
+    static vertex_t initvertex1 = {-77594624, 37748736};
+    static line_t initslideline = {&initvertex1, NULL, 0, 6291456, 0, 0, 0, 0,
+                    0, 0, 0, { 0, 0 }, { 0, 0, 0, 0 }, 0, NULL, NULL, 0, NULL};
     
     if (bestslideline == NULL)
+    {
         bestslideline = &initslideline;
+    }
 }
-
 
 //============================================================================
 //
@@ -1553,7 +1554,9 @@ void P_BounceWall(mobj_t * mo)
     // https://github.com/chocolate-doom/chocolate-doom/issues/1732
     // https://github.com/chocolate-doom/chocolate-doom/issues/1160
     if (bestslideline == NULL)
+    {
         I_Error("P_BounceWall: No bestslideline was set. Try bumping walls.");
+    }
     
     side = P_PointOnLineSide(mo->x, mo->y, bestslideline);
     lineangle = R_PointToAngle2(0, 0, bestslideline->dx, bestslideline->dy);

--- a/src/hexen/p_map.c
+++ b/src/hexen/p_map.c
@@ -1547,6 +1547,12 @@ void P_BounceWall(mobj_t * mo)
     P_PathTraverse(leadx, leady, leadx + mo->momx, leady + mo->momy,
                    PT_ADDLINES, PTR_BounceTraverse);
 
+    // P_BounceWall call on a tall sector after fresh game start
+    // without the player sliding along any walls before.
+    // For more details check:
+    // https://github.com/chocolate-doom/chocolate-doom/issues/1732
+    // https://github.com/chocolate-doom/chocolate-doom/issues/1160
+
     if (bestslideline == NULL)
         I_Error("P_BounceWall: No bestslideline was set. Try bumping walls.");
     

--- a/src/hexen/p_map.c
+++ b/src/hexen/p_map.c
@@ -1552,7 +1552,6 @@ void P_BounceWall(mobj_t * mo)
     // For more details check:
     // https://github.com/chocolate-doom/chocolate-doom/issues/1732
     // https://github.com/chocolate-doom/chocolate-doom/issues/1160
-
     if (bestslideline == NULL)
         I_Error("P_BounceWall: No bestslideline was set. Try bumping walls.");
     

--- a/src/hexen/p_map.c
+++ b/src/hexen/p_map.c
@@ -1452,6 +1452,24 @@ void P_SlideMove(mobj_t * mo)
 
 //============================================================================
 //
+// P_InitSlideLine
+//
+//============================================================================
+
+void P_InitSlideLine(void)
+{
+    // use relevant parts from first bestslideline in demo1 (hexen.wad)
+    static vertex_t initvertex1 = {-77594624,37748736};
+    static line_t initslideline = {&initvertex1, NULL, 0, 6291456, 0, 0, 0, 0, 0, 0, 0, 
+                                                {0,0}, {0,0,0,0}, 0, NULL, NULL, 0, NULL};  
+    
+    if (bestslideline == NULL)
+        bestslideline = &initslideline;
+}
+
+
+//============================================================================
+//
 // PTR_BounceTraverse
 //
 //============================================================================
@@ -1533,6 +1551,9 @@ void P_BounceWall(mobj_t * mo)
     P_PathTraverse(leadx, leady, leadx + mo->momx, leady + mo->momy,
                    PT_ADDLINES, PTR_BounceTraverse);
 
+    if (bestslideline == NULL)
+        I_Error("P_BounceWall: No bestslideline was set. Try bumping walls.");
+    
     side = P_PointOnLineSide(mo->x, mo->y, bestslideline);
     lineangle = R_PointToAngle2(0, 0, bestslideline->dx, bestslideline->dy);
     if (side == 1)

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -2151,6 +2151,9 @@ void SV_LoadGame(int slot)
             players[i].readyArtifact = players[i].inventory[inv_ptr].type;
         }
     }
+
+    // Set Bestslideline after loading
+    P_InitSlideLine();
 }
 
 //==========================================================================


### PR DESCRIPTION
Related Issues:
#1732
#1160

**Changes Summary**

- Initialize the bestslideline when loading a game to ensure crashing no longer occurs in that scenario. 
- Give an error message when running into the crash starting from a fresh (new) game. 