### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/man/docgen
+++ b/man/docgen
@@ -433,7 +433,7 @@ def process_file(filename):
                 else:
                     # More documentation text
 
-                    munged_line = re.sub(r'\s*\/\/\s*', '', line, 1)
+                    munged_line = re.sub(r'\s*\/\/\s*', '', line, count=1)
                     munged_line = re.sub(r'\s*$', '', munged_line)
                     param.add_text(munged_line)
 


### PR DESCRIPTION
# PR Summary
This small PR resolves deprecation warnings of regex library in Python3.13+ which you can see in the [CI logs](https://github.com/chocolate-doom/chocolate-doom/actions/runs/14572967802/job/40873420350#step:8:410):
```python
/Users/runner/work/chocolate-doom/chocolate-doom/man/bash-completion/../../man/docgen:436: DeprecationWarning: 'count' is passed as positional argument
```