### PR TITLE
Use $TMPDIR environment variable on Unix systems

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -509,9 +509,15 @@ char *M_TempFile(const char *s)
         tempdir = ".";
     }
 #else
-    // In Unix, just use /tmp.
+	
+    // Check the $TMPDIR environment variable to find the location.
 
-    tempdir = "/tmp";
+    tempdir = getenv("TMPDIR");
+
+	if (tempdir == NULL)
+	{
+		tempdir = "/tmp";
+	}
 #endif
 
     return M_StringJoin(tempdir, DIR_SEPARATOR_S, s, NULL);

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -512,12 +512,12 @@ char *M_TempFile(const char *s)
 	
     // Check the $TMPDIR environment variable to find the location.
 
-    tempdir = getenv("TMPDIR");
+    tempdir = M_getenv("TMPDIR");
 
-	if (tempdir == NULL)
-	{
-		tempdir = "/tmp";
-	}
+    if (tempdir == NULL)
+    {
+        tempdir = "/tmp";
+    }
 #endif
 
     return M_StringJoin(tempdir, DIR_SEPARATOR_S, s, NULL);

--- a/src/setup/execute.c
+++ b/src/setup/execute.c
@@ -68,9 +68,15 @@ static char *TempFile(const char *s)
         tempdir = ".";
     }
 #else
-    // In Unix, just use /tmp.
+    
+    // Check the TEMP environment variable to find the location.
 
-    tempdir = "/tmp";
+    tempdir = getenv("TMPDIR");
+
+    if (tempdir == NULL)
+    {
+        tempdir = "/tmp";
+    }
 #endif
 
     return M_StringJoin(tempdir, DIR_SEPARATOR_S, s, NULL);

--- a/src/setup/execute.c
+++ b/src/setup/execute.c
@@ -71,7 +71,7 @@ static char *TempFile(const char *s)
     
     // Check the TEMP environment variable to find the location.
 
-    tempdir = getenv("TMPDIR");
+    tempdir = M_getenv("TMPDIR");
 
     if (tempdir == NULL)
     {


### PR DESCRIPTION
Use $TMPDIR instead of /tmp by default in src/m_misc.c and src/setup/execute.c