### PR TITLE
Hexen: Do not read `player` field from `struct degenmobj_t`

### DIFF
--- a/src/hexen/p_local.h
+++ b/src/hexen/p_local.h
@@ -152,6 +152,7 @@ void P_ThrustMobj(mobj_t * mo, angle_t angle, fixed_t move);
 int P_FaceMobj(mobj_t * source, mobj_t * target, angle_t * delta);
 boolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax);
 void P_MobjThinker(thinker_t *thinker);
+void P_DegenMobjThinker(thinker_t *thinker);
 void P_BlasterMobjThinker(thinker_t *thinker);
 void P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z);
 void P_SpawnBlood(fixed_t x, fixed_t y, fixed_t z, int damage);

--- a/src/hexen/p_setup.c
+++ b/src/hexen/p_setup.c
@@ -576,6 +576,12 @@ void P_LoadBlockMap(int lump)
 =================
 */
 
+void P_DegenMobjThinker(thinker_t *thinker)
+{
+  (void) thinker;
+  // no-op
+}
+
 void P_GroupLines(void)
 {
     line_t **linebuffer;
@@ -632,6 +638,7 @@ void P_GroupLines(void)
         // set the degenmobj_t to the middle of the bounding box
         sector->soundorg.x = (bbox[BOXRIGHT] + bbox[BOXLEFT]) / 2;
         sector->soundorg.y = (bbox[BOXTOP] + bbox[BOXBOTTOM]) / 2;
+        sector->soundorg.thinker.function = (think_t) P_DegenMobjThinker;
 
         // adjust bounding box to map blocks
         block = (bbox[BOXTOP] - bmaporgy + MAXRADIUS) >> MAPBLOCKSHIFT;

--- a/src/hexen/po_man.c
+++ b/src/hexen/po_man.c
@@ -1449,6 +1449,7 @@ void PO_Init(int lump)
         {                       // Polyobj StartSpot Pt.
             polyobjs[polyIndex].startSpot.x = spawnthing.x << FRACBITS;
             polyobjs[polyIndex].startSpot.y = spawnthing.y << FRACBITS;
+            polyobjs[polyIndex].startSpot.thinker.function = (think_t) P_DegenMobjThinker;
             SpawnPolyobj(polyIndex, spawnthing.angle,
                          (spawnthing.type == PO_SPAWNCRUSH_TYPE));
             polyIndex++;

--- a/src/hexen/s_sound.c
+++ b/src/hexen/s_sound.c
@@ -416,7 +416,7 @@ void S_StartSoundAtVolume(mobj_t * origin, int sound_id, int volume)
     #endif
     for (i = 0; i < snd_Channels; i++)
     {
-        if (origin->player)
+        if (origin->thinker.function != P_DegenMobjThinker && origin->player)
         {
             i = snd_Channels;
             break;              // let the player have more than one sound.


### PR DESCRIPTION
Fixes #1756