### PR TITLE
Add support for DOS IWAD locations of H+H

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -233,19 +233,29 @@ static registry_value_t root_path_keys[] =
         SOFTWARE_KEY "\\GOG.com\\Games\\1983497091",
         "PATH",
     },
+
+    // Heretic + Hexen Rerelease
+
+    {
+        HKEY_LOCAL_MACHINE,
+        SOFTWARE_KEY "\\GOG.com\\Games\\1776058590",
+        "PATH"
+    },
 };
 
 // Subdirectories of the above install path, where IWADs are installed.
 
 static char *root_path_subdirs[] =
 {
-    ".",
     "Doom2",
     "Final Doom",
     "Ultimate Doom",
     "Plutonia",
     "TNT",
     "base\\wads",
+    "dos\\base\\heretic",
+    "dos\\base\\hexen",
+    ".",
 };
 
 // Location where Steam is installed


### PR DESCRIPTION
Please note that support has only been added for the Steam version. In the GOG version the `dos` subfolders are also present, however, the auto-search there will primarily load the unsupported IWAD from the root folder (according to [this logic](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/d_iwad.c#L242)).

A bit more information has been left in the Pull Request for Crispy: https://github.com/fabiangreffrath/crispy-doom/pull/1322