### PR TITLE
Remove #ifdef SDL_HINT_NO_SIGNAL_HANDLERS check

### DIFF
--- a/src/i_main.c
+++ b/src/i_main.c
@@ -68,9 +68,7 @@ int main(int argc, char **argv)
     M_FindResponseFile();
     M_SetExeDir();
 
-    #ifdef SDL_HINT_NO_SIGNAL_HANDLERS
     SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
-    #endif
 
     // start doom
 


### PR DESCRIPTION
This hint has been in SDL2 since 2.0.4 and the minimum SDL2 version is now 2.0.14.