### PR TITLE
Don't display any IPs when -privateserver is set.

### DIFF
--- a/src/net_structrw.c
+++ b/src/net_structrw.c
@@ -473,8 +473,15 @@ void NET_WriteWaitData(net_packet_t *packet, net_waitdata_t *data)
     {
         NET_WriteString(packet, data->player_names[i]);
         
-        if (M_CheckParm("-privateserver"))
+        if (M_CheckParm("-privateserver")) 
+        {
+            NET_WriteString(packet, "");
+        } 
+        else 
+        {
             NET_WriteString(packet, data->player_addrs[i]);
+        }
+
     }
 
     NET_WriteSHA1Sum(packet, data->wad_sha1sum);


### PR DESCRIPTION
It has been noticed that when hosting a privateserver (in case of livestreams), IP addresses are publicly displayed.

What was previously done was to only hide the IP of the host but not the client's IP, which is not acceptable. 

This PR just simply does not show IPs only when hosting a privateserver. Fixes what issue #697  really is, on a very specific case.