### PR TITLE
Various v1.2 emulation improvements

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1277,6 +1277,42 @@ static void LoadIwadDeh(void)
                     "doom2.exe.");
         }
     }
+
+    // Doom 1.2 needs a separate Dehacked patch which must be downloaded and
+    // installed next to the IWAD.
+    if (gameversion == exe_doom_1_2)
+    {
+        char *doom12_deh = NULL;
+        char *dirname;
+
+        // Look for doom12.deh in the same directory as the IWAD file.
+        dirname = M_DirName(iwadfile);
+        doom12_deh = M_StringJoin(dirname, DIR_SEPARATOR_S, "doom12.deh", NULL);
+        free(dirname);
+
+        // If the dehacked patch isn't found, try searching the WAD
+        // search path instead.  We might find it...
+        if (!M_FileExists(doom12_deh))
+        {
+            free(doom12_deh);
+            doom12_deh = D_FindWADByName("doom12.deh");
+        }
+
+        // Still not found?
+        if (doom12_deh == NULL)
+        {
+            I_Error("Unable to find Doom 1.2 dehacked file (doom12.deh).\n"
+                    "The dehacked file is required in order to emulate\n"
+                    "Doom 1.2 correctly.  It can be found in your nearest\n"
+                    "/idgames repository mirror at:\n\n"
+                    "   <url placeholder>");
+        }
+
+        if (!DEH_LoadFile(doom12_deh))
+        {
+            I_Error("Failed to load doom12.deh needed for emulating v1.2.");
+        }
+    }
 }
 
 static void G_CheckDemoStatusAtExit (void)

--- a/src/doom/p_floor.c
+++ b/src/doom/p_floor.c
@@ -410,7 +410,8 @@ EV_DoFloor
 		    {
 			sec = getSector(secnum,i,1);
 
-			if (sec->floorheight == floor->floordestheight)
+			if (gameversion < exe_doom_1_5 ||
+			    sec->floorheight == floor->floordestheight)
 			{
 			    floor->texture = sec->floorpic;
 			    floor->newspecial = sec->special;
@@ -421,7 +422,8 @@ EV_DoFloor
 		    {
 			sec = getSector(secnum,i,0);
 
-			if (sec->floorheight == floor->floordestheight)
+			if (gameversion < exe_doom_1_5 ||
+			    sec->floorheight == floor->floordestheight)
 			{
 			    floor->texture = sec->floorpic;
 			    floor->newspecial = sec->special;

--- a/src/doom/p_floor.c
+++ b/src/doom/p_floor.c
@@ -241,7 +241,12 @@ void T_MoveFloor(floormove_t* floor)
 	}
 	P_RemoveThinker(&floor->thinker);
 
-	S_StartSound(&floor->sector->soundorg, sfx_pstop);
+	// Moving floors (but not plats) in versions <= v1.2 did not make a
+	// stop sound.
+	if (gameversion > exe_doom_1_2)
+	{
+	    S_StartSound(&floor->sector->soundorg, sfx_pstop);
+	}
     }
 
 }

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -382,7 +382,7 @@ P_TouchSpecialThing
 	
       case SPR_BON2:
 	player->armorpoints++;		// can go over 100%
-	if (player->armorpoints > deh_max_armor && gameversion > exe_doom_1_2)
+	if (player->armorpoints > deh_max_armor)
 	    player->armorpoints = deh_max_armor;
         // deh_green_armor_class only applies to the green armor shirt;
         // for the armor helmets, armortype 1 is always used.

--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -179,6 +179,7 @@ boolean P_BlockThingsIterator (int x, int y, boolean(*func)(mobj_t*) );
 #define PT_ADDLINES		1
 #define PT_ADDTHINGS	2
 #define PT_EARLYOUT		4
+#define PT_COMPATADDLINES	8
 
 extern divline_t	trace;
 

--- a/src/doom/p_maputl.c
+++ b/src/doom/p_maputl.c
@@ -608,7 +608,55 @@ PIT_AddLineIntercepts (line_t* ld)
     return true;	// continue
 }
 
+//
+// PIT_CompatAddLineIntercepts.
+// Old line intercept code for Doom v1.0/v1.1/v1.2 compatibility.  Derived from
+// code in P_SightBlockLinesIterator() in prboom-plus/src/p_sight.c:133-151.
+// Adjusted to more closely resemble PIT_AddLineIntercepts().
+//
+boolean
+PIT_CompatAddLineIntercepts(line_t *ld)
+{
+    int s1;
+    int s2;
+    fixed_t frac;
+    divline_t dl;
 
+    s1 = P_PointOnDivlineSide(ld->v1->x, ld->v1->y, &trace);
+    s2 = P_PointOnDivlineSide(ld->v2->x, ld->v2->y, &trace);
+
+    if (s1 == s2)
+    {
+        return true; // line isn't crossed
+    }
+
+    // hit the line
+    P_MakeDivline(ld, &dl);
+
+    s1 = P_PointOnDivlineSide(trace.x, trace.y, &dl);
+    s2 = P_PointOnDivlineSide(trace.x + trace.dx, trace.y + trace.dy, &dl);
+
+    if (s1 == s2)
+    {
+        return true; // line isn't crossed
+    }
+
+    frac = P_InterceptVector(&trace, &dl);
+
+    // try to early out the check
+    if (!ld->backsector)
+    {
+        return false; // stop checking
+    }
+
+    intercept_p->frac = frac;
+    intercept_p->isaline = true;
+    intercept_p->d.line = ld;
+    InterceptsOverrun(intercept_p - intercepts, intercept_p);
+    intercept_p++;
+
+    return true; // continue
+}
 
 //
 // PIT_AddThingIntercepts
@@ -976,6 +1024,12 @@ P_PathTraverse
 		return false;	// early out
 	}
 		
+	if (flags & PT_COMPATADDLINES)
+	{
+	    if (!P_BlockLinesIterator (mapx, mapy,PIT_CompatAddLineIntercepts))
+		return false;	// early out
+	}
+
 	if (mapx == xt2
 	    && mapy == yt2)
 	{

--- a/src/doom/p_plats.c
+++ b/src/doom/p_plats.c
@@ -84,8 +84,16 @@ void T_PlatRaise(plat_t* plat)
 		    break;
 		    
 		  case raiseAndChange:
-		  case raiseToNearestAndChange:
 		    P_RemoveActivePlat(plat);
+		    break;
+
+		  case raiseToNearestAndChange:
+		    // In versions < v1.2 (at least), this platform type always
+		    // remains active.
+		    if (gameversion > exe_doom_1_2)
+		    {
+		        P_RemoveActivePlat(plat);
+		    }
 		    break;
 		    
 		  default:

--- a/src/doom/p_sight.c
+++ b/src/doom/p_sight.c
@@ -377,7 +377,7 @@ P_CheckSight
     if (gameversion <= exe_doom_1_2)
     {
         return P_PathTraverse(t1->x, t1->y, t2->x, t2->y,
-                              PT_EARLYOUT | PT_ADDLINES, PTR_SightTraverse);
+                              PT_EARLYOUT | PT_COMPATADDLINES, PTR_SightTraverse);
     }
 
     strace.x = t1->x;

--- a/src/doom/p_spec.c
+++ b/src/doom/p_spec.c
@@ -336,6 +336,7 @@ P_FindNextHighestFloor
     sector_t*   other;
     fixed_t     height = currentheight;
     fixed_t     heightlist[MAX_ADJOINING_SECTORS + 2];
+    fixed_t     last_height_0 = 0;
 
     for (i=0, h=0; i < sec->linecount; i++)
     {
@@ -366,10 +367,23 @@ P_FindNextHighestFloor
     // Find lowest height in list
     if (!h)
     {
-        return currentheight;
+        // Taken from prboom-plus p_spec.c:
+        //
+        // cph - my guess at doom v1.2 - 1.4beta compatibility here.  If there
+        // are no higher neighbouring sectors, Heretic just returned
+        // heightlist[0] (local variable), i.e. noise off the stack. 0 is right
+        // for RETURN01 E1M2, so let's take that.
+        //
+        // SmileTheory's response: It's not *quite* random stack noise. If this
+        // function is called as part of a loop, heightlist will be at the same
+        // location as in the previous call. Doing it this way fixes
+        // 1_ON_1.WAD.
+
+        return (gameversion < exe_doom_1_5 ? last_height_0 : currentheight);
     }
         
     min = heightlist[0];
+    last_height_0 = heightlist[0];
     
     // Range checking? 
     for (i = 1; i < h; i++)

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -213,7 +213,7 @@ void R_InitSpriteDefs(const char **namelist)
 		frame = lumpinfo[l]->name[4] - 'A';
 		rotation = lumpinfo[l]->name[5] - '0';
 
-		if (modifiedgame)
+		if (gameversion > exe_doom_1_2 && modifiedgame)
 		    patched = W_GetNumForName (lumpinfo[l]->name);
 		else
 		    patched = l;

--- a/src/doom/st_lib.c
+++ b/src/doom/st_lib.c
@@ -22,6 +22,7 @@
 
 #include "deh_main.h"
 #include "doomdef.h"
+#include "doomstat.h"
 
 #include "z_zone.h"
 #include "v_video.h"
@@ -114,8 +115,17 @@ STlib_drawNum
 
     V_CopyRect(x, n->y - ST_Y, st_backing_screen, w*numdigits, h, x, n->y);
 
+    // Early versions did not draw if number was negative, nor did they have
+    // the "1994" special case
+    if (gameversion < exe_doom_1_5)
+    {
+        if (neg)
+        {
+            return;
+        }
+    }
     // if non-number, do not draw it
-    if (num == 1994)
+    else if (num == 1994)
 	return;
 
     x = n->x;


### PR DESCRIPTION
This PR gathers a number of v1.2 emulation improvements. Some of these are based on the work of @SmileTheory in #1207. Many thanks to SmileTheory! Co-author credit has been given where appropriate.

I've elected to leverage an external deh file to emulate some v1.2 behaviors. This approach mirrors that of the French IWAD and Chex Quest support. I've attached my proposed `doom12.deh` to this PR for testing and review. If this change and deh file are deemed acceptable I will proceed to upload to idgames and will update the placeholder URL in the user message code accordingly.

[doom12deh.zip](https://github.com/user-attachments/files/23689982/doom12deh.zip)

**Add1.2 lowerAndChange behavior** 572d11bdff55a770e1b2c1c5df5961e7b51609dd
Taken from Heretic source release. Notably, this restores the proper v1.2 behavior of this bridge in E3M1:

v1.2
<img width="320" height="240" alt="DOOM00" src="https://github.com/user-attachments/assets/019fdabb-e70e-435d-8883-915edbe318f1" /><br/>
v1.9
<img width="320" height="240" alt="DOOM01" src="https://github.com/user-attachments/assets/ab538dec-f874-4d07-99d2-fe587fb0db7c" />

**Disable buggy sprite loading** e9f177dce224b5bb02917211bd7c603c0c57d157
Unlike later versions, Doom 1.2 won't even try to load replacement sprites that aren't located in between `S_START` and `S_END` markers. If you have "vestigial" sprite replacements in your pwad, Doom 1.2 will simply silently fail to replace the sprite. An example is egypt.wad; it works fine on 1.2 but fails in later versions with a "R_DrawSpriteRange: bad texturecolumn" when encountering a key.

**Add 1.2 P_FindNextHighestFloor emulation** 74efd007666568782bb8fa178c3fae1f6512228e
Taken from DSDA-Doom. This fixes the well-known broken lift in E1M2 in return01.wad.

**Fix inaccurate 1.2 sight calculations** a4b56327e6f7fa6b01c64930cb3ad2d4ffffc6fa
**Moving floors don't make stop sound in 1.2** e7dbd8a399e325ecb990e1075eb0978026425344
**Emulate 1.2 always active plats** 8ed210fdc2bd6413bda7ff81e0ce0d9d5606d503
These originate from #1207. Mostly to address various demo de-syncs.

**Require dehacked file for v1.2 emulation** 2d6daee6685836dd9ed00e2eac1b92b6d417e263
**Rely on deh file for v1.2 armor "limit"** 0ad9403500a015630be0d5649ebd59ea9cbdf3ee
I leverage dehacked for the following behaviors:
* Lost Souls count as kills
* Max health is 199
* No cap on armor (set limit to INT_MAX)
* Lots of animation frames that are fullbright in later versions are *not* fullbright in v1.2 (found by exhaustive comparison of 1.2 and 1.9 state tables)

**Add v1.2 HUD number drawing** f2db085d3c67ffa3663a0d3816480db4233654a8
Found when testing the v1.2 armor overflow bug. Unlike later versions, Doom v1.2 does not draw negative numbers. I recognize that this is pretty obscure and unlikely to ever be encountered in the wild but it was a difference that popped up.
