### PR TITLE
GitHub Actions: Update `actions/checkout` to `v6`

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -16,7 +16,7 @@ jobs:
         compiler: [clang]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libfluidsynth-dev libpng-dev libsamplerate0-dev libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev ninja-build
       - name: Run cmake to generate compilation database

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cppcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   cppcheck:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install cppcheck
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run cppcheck
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
             ${{ matrix.config.msys-env }}-libsamplerate
             ${{ matrix.config.msys-env }}-fluidsynth
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 


### PR DESCRIPTION
I attempted to set cppcheck's runner OS to `ubuntu-latest` but this brought out a new set of cppcheck issues to address. Captured that here: https://github.com/chocolate-doom/chocolate-doom/issues/1780. Squash + merge is preferable here.