### PR TITLE
Stop building macOS .dmg packages in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
             shell: bash
 
           - name: macOS x86 Clang
-            os: macos-13
+            os: macos-15-intel
             compiler: clang
             shell: bash
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,17 +35,11 @@ jobs:
             os: macos-latest
             compiler: clang
             shell: bash
-            artifacts: true
-            pkg-path: pkg/osx/*.dmg
-            pkg-dir: pkg/osx
 
           - name: macOS x86 Clang
             os: macos-13
             compiler: clang
             shell: bash
-            artifacts: true
-            pkg-path: pkg/osx/*.dmg
-            pkg-dir: pkg/osx
 
           - name: MSYS2 UCRT64
             os: windows-latest


### PR DESCRIPTION
See my comment in #1698 for rationale. The macOS releases have been broken to varying degrees for some time now as Apple have made the OS impossible to develop for unless the tax is paid. I don't intend to pay the tax.

This just stops building the .dmg with every commit; what this commit does not do:

* We do still build on macOS to check that it isn't entirely broken. The Homebrew project distribute a `chocolate-doom` package and if possible we want this to continue working.
* This does not delete the code that builds the launcher and the .dmg package; it only stops invoking them regularly. This will likely happen in the future; for the time being I want to leave open the possibility of doing one final release of the macOS package that is properly signed.