### PR TITLE
Allow spawn angle of `an=8192` (= 360 deg)

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1254,6 +1254,10 @@ G_CheckSpot
                 xa = finecosine[an];
                 ya = finesine[an];
                 break;
+            case 8192:  // 360 deg:
+                xa = tantoangle[0];        // finecosine[8192]
+                ya = finesine[8192];       // finesine[8192]
+                break;
             default:
                 I_Error("G_CheckSpot: unexpected angle %d\n", an);
                 xa = ya = 0;


### PR DESCRIPTION
The `finesine[]` array has 10240 elements and thus fits, but `finecosine` is actually a pointer pointing 2048 elements into the `finesine[]` array, so its 8192th element will point exactly one element past the `finesine[]` array and end up pointing to the `tantoangle[0]` element.

https://www.doomworld.com/forum/topic/158042-tool-unexpected-angle-error-fixer/