### PR TITLE
strife: Support inventory actions common with H/H via gamepad

### DIFF
--- a/src/m_controls.c
+++ b/src/m_controls.c
@@ -355,6 +355,12 @@ void M_BindStrifeControls(void)
     // manner as Hexen!
     M_BindIntVariable("mouseb_jump",        &mousebjump);
     M_BindIntVariable("joyb_jump",          &joybjump);
+
+    // Subset of inventory actions common to Heretic/Hexen and Strife.
+    M_BindIntVariable("joyb_invleft",       &joybinvleft);
+    M_BindIntVariable("joyb_invright",      &joybinvright);
+    // This is technically "invuse" in Strife, but let's reuse the value.
+    M_BindIntVariable("joyb_useartifact",   &joybuseartifact);
 }
 
 void M_BindWeaponControls(void)

--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1192,14 +1192,17 @@ static void MoreControls(TXT_UNCAST_ARG(widget), TXT_UNCAST_ARG(unused))
 
     window = TXT_NewWindow("Additional Gamepad/Joystick buttons");
     TXT_SetTableColumns(window, 6);
-    TXT_SetColumnWidths(window, 18, 10, 1, 18, 10, 0);
+    TXT_SetColumnWidths(window, 20, 10, 1, 20, 10, 0);
 
-    AddJoystickControl(window, "Use artifact", &joybuseartifact);
+    AddJoystickControl(window, "Use inventory item", &joybuseartifact);
     AddJoystickControl(window, "Inventory left", &joybinvleft);
     AddJoystickControl(window, "Inventory right", &joybinvright);
-    AddJoystickControl(window, "Fly up", &joybflyup);
-    AddJoystickControl(window, "Fly down", &joybflydown);
-    AddJoystickControl(window, "Fly center", &joybflycenter);
+    if (gamemission == heretic || gamemission == hexen)
+    {
+        AddJoystickControl(window, "Fly up", &joybflyup);
+        AddJoystickControl(window, "Fly down", &joybflydown);
+        AddJoystickControl(window, "Fly center", &joybflycenter);
+    }
 
     TXT_SetWindowAction(window, TXT_HORIZ_LEFT, NULL);
     TXT_SetWindowAction(window, TXT_HORIZ_CENTER,
@@ -1310,7 +1313,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
 
     AddJoystickControl(window, "Toggle Automap", &joybautomap);
 
-    if (gamemission == heretic || gamemission == hexen)
+    if (gamemission == heretic || gamemission == hexen || gamemission == strife)
     {
         TXT_AddWidget(window,
                        TXT_NewButton2("More controls...", MoreControls, NULL));

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -359,7 +359,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         cmd->buttons2 |= BT2_LOOKDOWN;
 
     // villsa [STRIFE] inventory use key
-    if(gamekeydown[key_invuse])
+    if(gamekeydown[key_invuse] || joybuttons[joybuseartifact])
     {
         player_t* player = &players[consoleplayer];
         if(player->numinventory > 0)
@@ -770,6 +770,7 @@ void G_DoLoadLevel (void)
 static void SetJoyButtons(unsigned int buttons_mask)
 {
     int i;
+    player_t *const player = &players[consoleplayer];
 
     for (i=0; i<MAX_JOY_BUTTONS; ++i)
     {
@@ -788,6 +789,16 @@ static void SetJoyButtons(unsigned int buttons_mask)
             else if (i == joybnextweapon)
             {
                 next_weapon = 1;
+            }
+            else if (i == joybinvleft)
+            {
+                if (player->inventorycursor > 0)
+                    player->inventorycursor--;
+            }
+            else if (i == joybinvright)
+            {
+                if (player->inventorycursor < player->numinventory - 1)
+                    player->inventorycursor++;
             }
         }
 


### PR DESCRIPTION
Support the subset of Strife's inventory actions common with Heretic and Hexen via gamepad.

Whenever the relevant actions were handled in `G_BuildTiccmd()`, this extends the check to account for the gamepad buttons.  For the inventory actions handled in `ST_Responder()`, I've duplicated the code in `SetJoyButtons()`.

For `chocolate-strife-setup`, I have enabled the "More controls" dialog and made the flying actions specific to Heretic/Hexen.
