### PR TITLE
strife: Mirror the `mouse_fire_countdown` in joystick logic as well

### DIFF
--- a/src/strife/doomstat.h
+++ b/src/strife/doomstat.h
@@ -182,6 +182,7 @@ extern  boolean	usergame;
 extern  boolean	demoplayback;
 extern  boolean	demorecording;
 extern  int     mouse_fire_countdown;   // villsa [STRIFE]
+extern  int     joystick_fire_countdown;
 
 extern fixed_t forwardmove[2];
 extern fixed_t sidemove[2];

--- a/src/strife/g_game.c
+++ b/src/strife/g_game.c
@@ -157,6 +157,7 @@ fixed_t         sidemove[2] = {0x18, 0x28};
 fixed_t         angleturn[3] = {640, 1280, 320};    // + slow turn 
 
 int mouse_fire_countdown = 0;    // villsa [STRIFE]
+int joystick_fire_countdown = 0;
 
 static int *weapon_keys[] = {
     &key_weapon1,
@@ -540,7 +541,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
         cmd->buttons2 |= BT2_JUMP;
  
     // villsa [STRIFE]: Moved mousebuttons[mousebfire] to below
-    if (gamekeydown[key_fire] || joybuttons[joybfire]) 
+    if (gamekeydown[key_fire])
         cmd->buttons |= BT_ATTACK;
 
     // villsa [STRIFE]
@@ -550,6 +551,13 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
              cmd->buttons |= BT_ATTACK;
          else
              --mouse_fire_countdown;
+    }
+    if(joybuttons[joybfire])
+    {
+         if(joystick_fire_countdown <= 0)
+             cmd->buttons |= BT_ATTACK;
+         else
+             --joystick_fire_countdown;
     }
  
     if (gamekeydown[key_use]

--- a/src/strife/m_menu.c
+++ b/src/strife/m_menu.c
@@ -1791,6 +1791,7 @@ boolean M_Responder (event_t* ev)
                 key = key_menu_forward;
             }
             joywait = I_GetTime() + 5;
+            joystick_fire_countdown = 5;
         }
         if (JOY_BUTTON_PRESSED(joybuse))
         {


### PR DESCRIPTION
Mirror the `mouse_fire_countdown` logic to `joystick_fire_countdown`. This resolves the same problem, that is the joystick fire button used to select a response triggering an attack when the dialog closes.

Originally reported to fabiangreffrath/crispy-doom#1390.