### PR TITLE
heretic: fix array bounds errors in R_ScaleFromGlobalAngle and R_RenderSegLoop

### DIFF
--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -318,7 +318,8 @@ void R_InitPointToAngle(void)
 fixed_t R_ScaleFromGlobalAngle(angle_t visangle)
 {
     fixed_t scale;
-    int anglea, angleb;
+    int anglea;
+    angle_t angleb;
     int sinea, sineb;
     fixed_t num, den;
 

--- a/src/heretic/r_segs.c
+++ b/src/heretic/r_segs.c
@@ -230,6 +230,7 @@ void R_RenderSegLoop(void)
         {
             // calculate texture offset
             angle = (rw_centerangle + xtoviewangle[rw_x]) >> ANGLETOFINESHIFT;
+            angle &= (FINEMASK >> 1);
             texturecolumn =
                 rw_offset - FixedMul(finetangent[angle], rw_distance);
             texturecolumn >>= FRACBITS;


### PR DESCRIPTION
## Summary
- Fixed two array bounds errors in chocolate-heretic detected by CHERI RISC-V hardware array bounds checking
- Changed `angleb` from `int` to `angle_t` in `R_ScaleFromGlobalAngle()` to prevent negative array indexing via arithmetic right shift
- Added `angle &= (FINEMASK >> 1)` in `R_RenderSegLoop()` to bound `finetangent[]` array access to its 4096-element range

## Changes
| File | Change |
|------|--------|
| `src/heretic/r_main.c` | `int anglea, angleb` → `int anglea; angle_t angleb` |
| `src/heretic/r_segs.c` | Added `angle &= (FINEMASK >> 1)` before `finetangent[angle]` access |

## Test Plan
- Build on CHERI RISC-V hardware and run chocolate-heretic with the shareware .wad and built-in demo (as described in the issue)
- Alternatively, run cppcheck static analysis on the modified files
- No behavior change on non-CHERI platforms since the original code happened to work on 2's complement systems

Fixes chocolate-doom/chocolate-doom#1790
