### PR TITLE
Hexen: Make user message strings uppercase

### DIFF
--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -71,7 +71,7 @@ void P_SetMessage(player_t * player, const char *message, boolean ultmsg)
     }
 
     M_StringCopy(player->message, message, sizeof(player->message));
-//    strupr(player->message);
+    M_ForceUppercase(player->message);
     player->messageTics = MESSAGETICS;
     player->yellowMessage = false;
     if (ultmsg)


### PR DESCRIPTION
This corrects a regression from vanilla. In the vanilla source release, the `strupr` function is *not* commented out. Thanks to waXx from the Discord for the report.