### PR TITLE
Add nightly github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,9 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           name: ${{ env.PACKAGE_STRING }}
-          bodyFile: RELEASE_NOTES.md
+          body: |
+            These are development builds, automatically generated from the `master` branch. \
+            Please report any problems you may find.
           allowUpdates: true
           artifacts: ${{ matrix.config.pkg-path }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
           path: ${{ matrix.config.pkg-path }}
 
       - name: Extract Package String [Nightly]
-        if: ${{ contains(github.ref, 'tags') }}
+        if: ${{ !contains(github.ref, 'tags') }}
         run: |
           PACKAGE_NAME=`sed -n '/PACKAGE_NAME/p' ${PWD}/config.h | cut -d '"' -f 2`
           echo "PACKAGE_STRING=\"[Nightly] ${PACKAGE_NAME} ${GITHUB_SHA::7}\"" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,11 +136,34 @@ jobs:
           name: ${{ matrix.config.name }}
           path: ${{ matrix.config.pkg-path }}
 
+      - name: Extract Package String [Nightly]
+        if: ${{ contains(github.ref, 'tags') }}
+        run: |
+          PACKAGE_NAME=`sed -n '/PACKAGE_NAME/p' ${PWD}/config.h | cut -d '"' -f 2`
+          echo "PACKAGE_STRING=\"[Nightly] ${PACKAGE_NAME} ${GITHUB_SHA::7}\"" >> $GITHUB_ENV
+
       - name: Extract Package String
         if: ${{ contains(github.ref, 'tags') }}
         run: |
           PACKAGE_STRING=`sed -n '/PACKAGE_STRING/p' ${PWD}/config.h | cut -d '"' -f 2`
           echo "PACKAGE_STRING=${PACKAGE_STRING}" >> $GITHUB_ENV
+
+      - name: Update Nightly Tag
+        if: ${{ !contains(github.ref, 'tags') && github.ref == 'refs/heads/master' }}
+        run: |
+          git tag -d nightly || true
+          git push origin :refs/tags/nightly || true
+          git tag nightly HEAD
+          git push origin nightly
+
+      - name: Release [Nightly]
+        if: ${{ !contains(github.ref, 'tags') && matrix.config.artifacts }}
+        uses: ncipollo/release-action@v1
+        with:
+          name: ${{ env.PACKAGE_STRING }}
+          bodyFile: RELEASE_NOTES.md
+          allowUpdates: true
+          artifacts: ${{ matrix.config.pkg-path }}
 
       - name: Release
         if: ${{ contains(github.ref, 'tags') && matrix.config.artifacts }}


### PR DESCRIPTION
Getting ahead of the shutting down of shut down of latest.chocolate-doom.org, as per the recent notice on the Chocolate Doom discord server:
https://discord.com/channels/435469554173476866/435471974098010113/1520970872385699841

This PR adds a Github 'pre-release' which gets updated with each untagged commit to the master branch, uploading the dev build artifacts to the relevant releases section. It also force-updates the `nightly` tag to reflect in the GitHub UI that there has been activity.

This particular implementation is quite simple, and does not account for potential quick succession commits, as repo activity is relatively slow either way.

@fragglet, any thoughts? This can still be easily updated afterwards, if anything is to come up.