### PR TITLE
OPL Music: adding further OPL locks in critical areas

### DIFF
--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1394,6 +1394,7 @@ static void TrackTimerCallback(void *arg)
 
     if (!MIDI_GetNextEvent(track->iter, &event))
     {
+        OPL_Unlock();
         return;
     }
 
@@ -1418,6 +1419,7 @@ static void TrackTimerCallback(void *arg)
             OPL_SetCallback(5000, RestartSong, NULL);
         }
 
+        OPL_Unlock();
         return;
     }
 
@@ -1598,12 +1600,12 @@ static void I_OPL_StopSong(void)
 
 static void I_OPL_UnRegisterSong(void *handle)
 {
-    OPL_Lock();
-
     if (!music_initialized)
     {
         return;
     }
+
+    OPL_Lock();
 
     if (handle != NULL)
     {

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1388,6 +1388,8 @@ static void TrackTimerCallback(void *arg)
     opl_track_data_t *track = arg;
     midi_event_t *event;
 
+    OPL_Lock();
+
     // Get the next event and process it.
 
     if (!MIDI_GetNextEvent(track->iter, &event))
@@ -1422,6 +1424,8 @@ static void TrackTimerCallback(void *arg)
     // Reschedule the callback for the next event in the track.
 
     ScheduleTrack(track);
+
+    OPL_Unlock();
 }
 
 static void ScheduleTrack(opl_track_data_t *track)
@@ -1594,6 +1598,8 @@ static void I_OPL_StopSong(void)
 
 static void I_OPL_UnRegisterSong(void *handle)
 {
+    OPL_Lock();
+
     if (!music_initialized)
     {
         return;
@@ -1603,6 +1609,8 @@ static void I_OPL_UnRegisterSong(void *handle)
     {
         MIDI_FreeFile(handle);
     }
+
+    OPL_Unlock();
 }
 
 // Determine whether memory block is a .mid file
@@ -1648,6 +1656,8 @@ static void *I_OPL_RegisterSong(void *data, int len)
         return NULL;
     }
 
+    OPL_Lock();
+
     // MUS files begin with "MUS"
     // Reject anything which doesnt have this signature
 
@@ -1675,6 +1685,8 @@ static void *I_OPL_RegisterSong(void *data, int len)
 
     M_remove(filename);
     free(filename);
+
+    OPL_Unlock();
 
     return result;
 }


### PR DESCRIPTION
Related PR:
https://github.com/fabiangreffrath/crispy-doom/pull/1402

**Changes Summary**
In the above linked PR for Crispy it was found, that rare crashes in the processing of OPL midi events can take place upon level switches. This specifically happens when trying to access event information (like event type) from the SDL Audio thread callback (`TrackTimerCallback`) while Registering / Unregistering music in the "game thread".

To avoid this, I systematically added further OPL locks where the crashes occurred in order to resolve them.