### PR TITLE
OPL Music: Undo locks in TrackTimerCallback from commit fe3c10a

### DIFF
--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1388,13 +1388,10 @@ static void TrackTimerCallback(void *arg)
     opl_track_data_t *track = arg;
     midi_event_t *event;
 
-    OPL_Lock();
-
     // Get the next event and process it.
 
     if (!MIDI_GetNextEvent(track->iter, &event))
     {
-        OPL_Unlock();
         return;
     }
 
@@ -1419,15 +1416,12 @@ static void TrackTimerCallback(void *arg)
             OPL_SetCallback(5000, RestartSong, NULL);
         }
 
-        OPL_Unlock();
         return;
     }
 
     // Reschedule the callback for the next event in the track.
 
     ScheduleTrack(track);
-
-    OPL_Unlock();
 }
 
 static void ScheduleTrack(opl_track_data_t *track)


### PR DESCRIPTION
Related Commit:
fe3c10a

**Changes Summary**
This is a small correction to my previous commit fe3c10a. I just realized that OPL lock / unlocks in `TrackTimerCallback` are not really needed, as the function call itself is already protected by it in `AdvanceTime`:

````C
        SDL_LockMutex(callback_mutex);
        callback(callback_data);
        SDL_UnlockMutex(callback_mutex);
````

.. with `SDL_LockMutex(callback_mutex)` being the exact same Mutex used as in`OPL_Lock` which is calling `OPL_SDL_Lock`. So only the ones for the Un-/Registering of the songs are required. Sorry for this mishap!